### PR TITLE
Refactor 3.5 runtime Dockerfiles

### DIFF
--- a/3.5-windowsservercore-1709/runtime/Dockerfile
+++ b/3.5-windowsservercore-1709/runtime/Dockerfile
@@ -2,10 +2,34 @@
 
 FROM microsoft/windowsservercore:1709
 
-ADD install /build
-RUN DISM /Online /Add-Package /PackagePath:C:\build\microsoft-windows-netfx3-ondemand-package.cab & `
-    DISM /Online /Add-Package /PackagePath:C:\build\patch\Windows10.0-KB3213986-x64.cab  & `
-    rd /s /q C:\build
+# Install .NET Fx 3.5
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1709.zip" `
+            -OutFile microsoft-windows-netfx3.zip; `
+        Expand-Archive microsoft-windows-netfx3.zip; `
+        Remove-Item -Force microsoft-windows-netfx3.zip; `
+        Add-WindowsPackage -Online -PackagePath .\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package.cab; `
+        Remove-Item -Force -Recurse microsoft-windows-netfx3
+
+# Apply latest patch
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/11/windows10.0-kb4048955-x64_f214597fd57cd8284a363ada825a3d8ca16bf632.msu" `
+            -OutFile patch.msu; `
+        New-Item -Type Directory patch; `
+        Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
+        Remove-Item -Force patch.msu; `
+        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-KB4048955-x64.cab; `
+        Remove-Item -Force -Recurse \patch
+
+# ngen .NET Fx
 RUN set COMPLUS_NGenProtectedProcess_FeatureEnabled=0 & `
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
     \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update & `

--- a/3.5-windowsservercore-1709/runtime/Dockerfile
+++ b/3.5-windowsservercore-1709/runtime/Dockerfile
@@ -21,12 +21,12 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
-            -Uri "http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/11/windows10.0-kb4048955-x64_f214597fd57cd8284a363ada825a3d8ca16bf632.msu" `
+            -Uri "http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/12/windows10.0-kb4054517-x64_f1c0e8eae96b357bc13e5668c5874904502106df.msu" `
             -OutFile patch.msu; `
         New-Item -Type Directory patch; `
         Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
         Remove-Item -Force patch.msu; `
-        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-KB4048955-x64.cab; `
+        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-KB4054517-x64.cab; `
         Remove-Item -Force -Recurse \patch
 
 # ngen .NET Fx

--- a/3.5-windowsservercore-ltsc2016/runtime/Dockerfile
+++ b/3.5-windowsservercore-ltsc2016/runtime/Dockerfile
@@ -2,10 +2,34 @@
 
 FROM microsoft/windowsservercore:ltsc2016
 
-ADD install /build
-RUN DISM /Online /Add-Package /PackagePath:C:\build\microsoft-windows-netfx3-ondemand-package.cab & `
-    DISM /Online /Add-Package /PackagePath:C:\build\patch\Windows10.0-KB3213986-x64.cab  & `
-    rd /s /q C:\build
+# Install .NET Fx 3.5
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-ltsc2016.zip" `
+            -OutFile microsoft-windows-netfx3.zip; `
+        Expand-Archive microsoft-windows-netfx3.zip; `
+        Remove-Item -Force microsoft-windows-netfx3.zip; `
+        Add-WindowsPackage -Online -PackagePath .\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package.cab; `
+        Remove-Item -Force -Recurse microsoft-windows-netfx3
+
+# Apply latest patch
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/11/windows10.0-kb4048953-x64_6fccbf0ed11c9dfbc8d13e50d81ccfe97d1e2b82.msu" `
+            -OutFile patch.msu; `
+        New-Item -Type Directory patch; `
+        Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
+        Remove-Item -Force patch.msu; `
+        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-KB4048953-x64.cab; `
+        Remove-Item -Force -Recurse \patch
+
+# ngen .NET Fx
 RUN set COMPLUS_NGenProtectedProcess_FeatureEnabled=0 & `
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
     \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update & `

--- a/3.5-windowsservercore-ltsc2016/runtime/Dockerfile
+++ b/3.5-windowsservercore-ltsc2016/runtime/Dockerfile
@@ -21,12 +21,12 @@ RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
-            -Uri "http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/11/windows10.0-kb4048953-x64_6fccbf0ed11c9dfbc8d13e50d81ccfe97d1e2b82.msu" `
+            -Uri "http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/12/windows10.0-kb4053579-x64_c8f23cbaf60b5093a6902ce64520c354cfe360c7.msu" `
             -OutFile patch.msu; `
         New-Item -Type Directory patch; `
         Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
         Remove-Item -Force patch.msu; `
-        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-KB4048953-x64.cab; `
+        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-KB4053579-x64.cab; `
         Remove-Item -Force -Recurse \patch
 
 # ngen .NET Fx


### PR DESCRIPTION
These changes address the following:
1.  Remove the unnecessary installer files that are currently included in the 3.5 runtime docker images.  These files are significant in size (464MB for 1709 and 1.32 GB for ltsc2016)
1.  Contents of the 3.5 Dockerfiles are transparent to users.  The LCU being installed in the Dockerfile was not reflective of what was contained in the image.
1.  Dockerfile is now buildable by anyone.  This will allow users to create their own 3.5 image in the case they can't use these 3.5 images.


Fixes #58 
Fixes #45 