### PR TITLE
build tweaks to prevent timeouts and preserve base os images.

### DIFF
--- a/build-pipeline/dotnet-framework-docker-post-image-build.json
+++ b/build-pipeline/dotnet-framework-docker-post-image-build.json
@@ -186,7 +186,7 @@
     }
   ],
   "jobAuthorizationScope": "projectCollection",
-  "jobTimeoutInMinutes": 60,
+  "jobTimeoutInMinutes": 120,
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {

--- a/build-pipeline/dotnet-framework-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-framework-docker-windows-1709-amd64-images.json
@@ -223,7 +223,7 @@
     }
   ],
   "jobAuthorizationScope": "projectCollection",
-  "jobTimeoutInMinutes": 60,
+  "jobTimeoutInMinutes": 120,
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {

--- a/build-pipeline/dotnet-framework-docker-windows-ltsc2016-amd64-images.json
+++ b/build-pipeline/dotnet-framework-docker-windows-ltsc2016-amd64-images.json
@@ -17,7 +17,7 @@
         "scriptName": "",
         "arguments": "",
         "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
         "failOnStandardError": "true"
       }
     },
@@ -133,7 +133,7 @@
         "scriptName": "",
         "arguments": "",
         "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
+        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
         "failOnStandardError": "true"
       }
     }
@@ -223,7 +223,7 @@
     }
   ],
   "jobAuthorizationScope": "projectCollection",
-  "jobTimeoutInMinutes": 60,
+  "jobTimeoutInMinutes": 120,
   "jobCancelTimeoutInMinutes": 5,
   "repository": {
     "properties": {


### PR DESCRIPTION
1. Increase build timeouts.  When new base os images have to be pulled and the network is slow, the builds would timeout periodically.
2. Modified cleanup logic to preserve base os images.