### PR TITLE
Remove hard coded repo owner from tests

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -42,7 +42,7 @@ function ExecuteWithRetry {
 }
 
 function Get-ImageBuilder() {
-    $imageBuilderImageName = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180105103709'
+    $imageBuilderImageName = 'microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180111160403'
     $imageBuilderContainerName = "ImageBuilder-$(Get-Date -Format yyyyMMddhhmmss)"
     New-Item -Path "$imageBuilderFolder" -ItemType Directory -Force | Out-Null
     ExecuteWithRetry -Command "docker pull $imageBuilderImageName"
@@ -58,7 +58,7 @@ if (-not (Test-Path -Path "$imageBuilderExe" -PathType Leaf)) {
     Get-ImageBuilder
 }
 
-$imageBuilderArgs = "build --path $buildFilter --test-var VersionFilter=$VersionFilter --test-var OSFilter=$OSFilter"
+$imageBuilderArgs = "build --path $buildFilter --var VersionFilter=$VersionFilter --var OSFilter=$OSFilter"
 if (-not [string]::IsNullOrWhiteSpace($ImageBuilderCustomArgs)) {
     $imageBuilderArgs += " $ImageBuilderCustomArgs"
 }

--- a/build-pipeline/dotnet-framework-docker-post-image-build.json
+++ b/build-pipeline/dotnet-framework-docker-post-image-build.json
@@ -141,7 +141,7 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20180105103711"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20180111155528"
     },
     "image-builder.common.args": {
       "value": "--manifest manifest.json --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_customCommonArgs)",

--- a/build-pipeline/dotnet-framework-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-framework-docker-windows-1709-amd64-images.json
@@ -183,10 +183,10 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180105103709"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180111160403"
     },
     "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_testVars) $(PB_image-builder_customCommonArgs)",
+      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_vars) $(PB_image-builder_customCommonArgs)",
       "allowOverride": true
     },
     "image-builder.containerName": {
@@ -202,7 +202,7 @@
     "PB_image-builder_path": {
       "value": ""
     },
-    "PB_image-builder_testVars": {
+    "PB_image-builder_vars": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-framework-docker-windows-ltsc2016-amd64-images.json
+++ b/build-pipeline/dotnet-framework-docker-windows-ltsc2016-amd64-images.json
@@ -183,10 +183,10 @@
       "allowOverride": true
     },
     "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180105103709"
+      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180111160403"
     },
     "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_testVars) $(PB_image-builder_customCommonArgs)",
+      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_vars) $(PB_image-builder_customCommonArgs)",
       "allowOverride": true
     },
     "image-builder.containerName": {
@@ -202,7 +202,7 @@
     "PB_image-builder_path": {
       "value": ""
     },
-    "PB_image-builder_testVars": {
+    "PB_image-builder_vars": {
       "value": ""
     }
   },

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -17,14 +17,14 @@
           "Name": "dotnet-framework-docker-windows-ltsc2016-amd64-images",
           "Parameters": {
             "PB_image-builder_path": "3.5-windowsservercore-ltsc2016/*",
-            "PB_image-builder_testVars": "--test-var VersionFilter=3.5 --test-var OSFilter=windowsservercore-ltsc2016"
+            "PB_image-builder_vars": "--var VersionFilter=3.5 --var OSFilter=windowsservercore-ltsc2016"
           }
         },
         {
           "Name": "dotnet-framework-docker-windows-ltsc2016-amd64-images",
           "Parameters": {
             "PB_image-builder_path": "4.*-windowsservercore-ltsc2016/*",
-            "PB_image-builder_testVars": "--test-var VersionFilter=4.* --test-var OSFilter=windowsservercore-ltsc2016"
+            "PB_image-builder_vars": "--var VersionFilter=4.* --var OSFilter=windowsservercore-ltsc2016"
           }
         }
       ]
@@ -39,14 +39,14 @@
           "Name": "dotnet-framework-docker-windows-1709-amd64-images",
           "Parameters": {
             "PB_image-builder_path": "3.5-windowsservercore-1709/*",
-            "PB_image-builder_testVars": "--test-var VersionFilter=3.5 --test-var OSFilter=windowsservercore-1709"
+            "PB_image-builder_vars": "--var VersionFilter=3.5 --var OSFilter=windowsservercore-1709"
           }
         },
         {
           "Name": "dotnet-framework-docker-windows-1709-amd64-images",
           "Parameters": {
             "PB_image-builder_path": "4.*-windowsservercore-1709/*",
-            "PB_image-builder_testVars": "--test-var VersionFilter=4.* --test-var OSFilter=windowsservercore-1709"
+            "PB_image-builder_vars": "--var VersionFilter=4.* --var OSFilter=windowsservercore-1709"
           }
         }
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "testCommands": {
     "windows": [
-      "powershell -NoProfile -Command .\\tests\\run-tests.ps1 -VersionFilter $(VersionFilter) -OSFilter $(OSFilter)"
+      "powershell -NoProfile -Command .\\tests\\run-tests.ps1 -VersionFilter $(VersionFilter) -OSFilter $(OSFilter) -RepoOwner $(System:RepoOwner)"
     ]
   },
   "repos": [

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         private const string WSC_1709 = "windowsservercore-1709";
 
         private static string OSFilter => Environment.GetEnvironmentVariable("IMAGE_OS_FILTER");
-        private static string RepoOwner => Environment.GetEnvironmentVariable("REPO_OWNER") ?? "Microsoft";
+        private static string RepoOwner => Environment.GetEnvironmentVariable("REPO_OWNER") ?? "microsoft";
         private static string VersionFilter => Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
 
         private static ImageDescriptor[] TestData = new ImageDescriptor[]

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         private const string WSC_1709 = "windowsservercore-1709";
 
         private static string OSFilter => Environment.GetEnvironmentVariable("IMAGE_OS_FILTER");
+        private static string RepoOwner => Environment.GetEnvironmentVariable("REPO_OWNER") ?? "Microsoft";
         private static string VersionFilter => Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
 
         private static ImageDescriptor[] TestData = new ImageDescriptor[]
@@ -60,10 +61,10 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         [MemberData(nameof(GetVerifyImagesData))]
         public void VerifyImages(ImageDescriptor imageDescriptor)
         {
-            string baseBuildImage = $"microsoft/dotnet-framework-build:{imageDescriptor.BuildVersion}-{imageDescriptor.OsVariant}";
+            string baseBuildImage = $"{RepoOwner}/dotnet-framework-build:{imageDescriptor.BuildVersion}-{imageDescriptor.OsVariant}";
             VerifyImageExist(baseBuildImage);
 
-            string baseRuntimeImage = $"microsoft/dotnet-framework:{imageDescriptor.RuntimeVersion}-{imageDescriptor.OsVariant}";
+            string baseRuntimeImage = $"{RepoOwner}/dotnet-framework:{imageDescriptor.RuntimeVersion}-{imageDescriptor.OsVariant}";
             VerifyImageExist(baseRuntimeImage);
 
             string appId = $"dotnetapp-{DateTime.Now.ToFileTime()}";

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -6,7 +6,8 @@
 [cmdletbinding()]
 param(
     [string]$VersionFilter,
-    [string]$OSFilter
+    [string]$OSFilter,
+    [string]$RepoOwner
 )
 
 Set-StrictMode -Version Latest
@@ -31,6 +32,7 @@ if ($LASTEXITCODE -ne 0) { throw "Failed to install the .NET Core SDK" }
 # Run Tests
 $env:IMAGE_OS_FILTER = $OSFilter
 $env:IMAGE_VERSION_FILTER = $VersionFilter
+$env:REPO_OWNER = $RepoOwner
 
 & dotnet test -c Release -v n $PSScriptRoot/Microsoft.DotNet.Framework.Docker.Tests/Microsoft.DotNet.Framework.Docker.Tests.csproj
 if ($LASTEXITCODE -ne 0) { throw "Tests Failed" }


### PR DESCRIPTION
This allows the repo to easily get built and pushed to an Azure Container Registry which is needed at times for testing purposes.