### PR TITLE
Use build-and-test script in official builds

### DIFF
--- a/build-pipeline/dotnet-framework-docker-post-image-build.json
+++ b/build-pipeline/dotnet-framework-docker-post-image-build.json
@@ -144,7 +144,7 @@
       "value": "microsoft/dotnet-buildtools-prereqs:image-builder-jessie-20180111155528"
     },
     "image-builder.common.args": {
-      "value": "--manifest manifest.json --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_customCommonArgs)",
+      "value": "--manifest manifest.json --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
       "allowOverride": true
     },
     "image-builder.publishManifest.args": {
@@ -158,7 +158,7 @@
     "image-builder.containerName": {
       "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
-    "PB_image-builder_customCommonArgs": {
+    "PB_image-builder_queueCustomArgs": {
       "value": ""
     },
     "PB_docker_password": {

--- a/build-pipeline/dotnet-framework-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-framework-docker-windows-1709-amd64-images.json
@@ -4,7 +4,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Cleanup Docker",
+      "displayName": "Run build-and-test",
       "timeoutInMinutes": 0,
       "condition": "succeeded()",
       "task": {
@@ -13,128 +13,12 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "",
-        "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
-        "failOnStandardError": "true"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Pull image-builder",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "pull $(image-builder.imageName)",
-        "workingFolder": "",
+        "scriptType": "filePath",
+        "scriptName": "$(Build.SourcesDirectory)\\build-and-test.ps1",
+        "arguments": "-VersionFilter \"$(PB_image-builder_VersionFilter)\" -OSFilter \"$(PB_image-builder_OSFilter)\" -ImageBuilderCustomArgs \"$(image-builder.args)\" -CleanupDocker",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "",
         "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Create container",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "create --name $(image-builder.containerName) $(image-builder.imageName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Copy image-builder locally",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker ",
-        "arguments": "cp $(image-builder.containerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Cleanup container",
-      "timeoutInMinutes": 0,
-      "condition": "always()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "rmi -f $(image-builder.imageName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Run image-builder",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe",
-        "arguments": "$(image-builder.args)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Cleanup Docker",
-      "timeoutInMinutes": 0,
-      "condition": "always()",
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "",
-        "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
-        "failOnStandardError": "true"
       }
     }
   ],
@@ -182,15 +66,9 @@
       "value": "false",
       "allowOverride": true
     },
-    "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180111160403"
-    },
     "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_vars) $(PB_image-builder_customCommonArgs)",
+      "value": "--push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_customCommonArgs)",
       "allowOverride": true
-    },
-    "image-builder.containerName": {
-      "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "PB_docker_password": {
       "value": null,
@@ -199,10 +77,10 @@
     "PB_image-builder_customCommonArgs": {
       "value": ""
     },
-    "PB_image-builder_path": {
+    "PB_image-builder_VersionFilter": {
       "value": ""
     },
-    "PB_image-builder_vars": {
+    "PB_image-builder_OSFilter": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-framework-docker-windows-1709-amd64-images.json
+++ b/build-pipeline/dotnet-framework-docker-windows-1709-amd64-images.json
@@ -15,7 +15,7 @@
       "inputs": {
         "scriptType": "filePath",
         "scriptName": "$(Build.SourcesDirectory)\\build-and-test.ps1",
-        "arguments": "-VersionFilter \"$(PB_image-builder_VersionFilter)\" -OSFilter \"$(PB_image-builder_OSFilter)\" -ImageBuilderCustomArgs \"$(image-builder.args)\" -CleanupDocker",
+        "arguments": "-VersionFilter $(PB_image-builder_versionFilter) -OSFilter $(PB_image-builder_osFilter) -ImageBuilderCustomArgs \"$(image-builder.customArgs)\" -CleanupDocker",
         "workingFolder": "$(Build.SourcesDirectory)",
         "inlineScript": "",
         "failOnStandardError": "false"
@@ -66,21 +66,21 @@
       "value": "false",
       "allowOverride": true
     },
-    "image-builder.args": {
-      "value": "--push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_customCommonArgs)",
+    "image-builder.customArgs": {
+      "value": "--push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
       "allowOverride": true
     },
     "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB_image-builder_customCommonArgs": {
+    "PB_image-builder_queueCustomArgs": {
       "value": ""
     },
-    "PB_image-builder_VersionFilter": {
+    "PB_image-builder_versionFilter": {
       "value": ""
     },
-    "PB_image-builder_OSFilter": {
+    "PB_image-builder_osFilter": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-framework-docker-windows-ltsc2016-amd64-images.json
+++ b/build-pipeline/dotnet-framework-docker-windows-ltsc2016-amd64-images.json
@@ -4,7 +4,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Cleanup Docker",
+      "displayName": "Run build-and-test",
       "timeoutInMinutes": 0,
       "condition": "succeeded()",
       "task": {
@@ -13,128 +13,12 @@
         "definitionType": "task"
       },
       "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "",
-        "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
-        "failOnStandardError": "true"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Pull image-builder",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "pull $(image-builder.imageName)",
-        "workingFolder": "",
+        "scriptType": "filePath",
+        "scriptName": "$(Build.SourcesDirectory)\\build-and-test.ps1",
+        "arguments": "-VersionFilter \"$(PB_image-builder_VersionFilter)\" -OSFilter \"$(PB_image-builder_OSFilter)\" -ImageBuilderCustomArgs \"$(image-builder.args)\" -CleanupDocker",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "",
         "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Create container",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "create --name $(image-builder.containerName) $(image-builder.imageName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Copy image-builder locally",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker ",
-        "arguments": "cp $(image-builder.containerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Cleanup container",
-      "timeoutInMinutes": 0,
-      "condition": "always()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "docker",
-        "arguments": "rmi -f $(image-builder.imageName)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": false,
-      "alwaysRun": false,
-      "displayName": "Run image-builder",
-      "timeoutInMinutes": 0,
-      "condition": "succeeded()",
-      "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "filename": "$(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe",
-        "arguments": "$(image-builder.args)",
-        "workingFolder": "",
-        "failOnStandardError": "false"
-      }
-    },
-    {
-      "enabled": true,
-      "continueOnError": true,
-      "alwaysRun": true,
-      "displayName": "Cleanup Docker",
-      "timeoutInMinutes": 0,
-      "condition": "always()",
-      "task": {
-        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
-        "versionSpec": "1.*",
-        "definitionType": "task"
-      },
-      "inputs": {
-        "scriptType": "inlineScript",
-        "scriptName": "",
-        "arguments": "",
-        "workingFolder": "",
-        "inlineScript": "docker ps -a -q | %{docker rm -f $_}\n\ndocker images | where {-Not ($_.StartsWith(\"microsoft/nanoserver \") -Or $_.StartsWith(\"microsoft/windowsservercore \") -Or $_.StartsWith(\"REPOSITORY \"))} | %{$_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2]} | select-object -unique | %{docker rmi -f $_}",
-        "failOnStandardError": "true"
       }
     }
   ],
@@ -182,15 +66,9 @@
       "value": "false",
       "allowOverride": true
     },
-    "image-builder.imageName": {
-      "value": "microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180111160403"
-    },
     "image-builder.args": {
-      "value": "build --manifest manifest.json --path $(PB_image-builder_path) --push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_vars) $(PB_image-builder_customCommonArgs)",
+      "value": "--push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_customCommonArgs)",
       "allowOverride": true
-    },
-    "image-builder.containerName": {
-      "value": "$(Build.DefinitionName)-$(Build.BuildId)"
     },
     "PB_docker_password": {
       "value": null,
@@ -199,10 +77,10 @@
     "PB_image-builder_customCommonArgs": {
       "value": ""
     },
-    "PB_image-builder_path": {
+    "PB_image-builder_VersionFilter": {
       "value": ""
     },
-    "PB_image-builder_vars": {
+    "PB_image-builder_OSFilter": {
       "value": ""
     }
   },

--- a/build-pipeline/dotnet-framework-docker-windows-ltsc2016-amd64-images.json
+++ b/build-pipeline/dotnet-framework-docker-windows-ltsc2016-amd64-images.json
@@ -15,7 +15,7 @@
       "inputs": {
         "scriptType": "filePath",
         "scriptName": "$(Build.SourcesDirectory)\\build-and-test.ps1",
-        "arguments": "-VersionFilter \"$(PB_image-builder_VersionFilter)\" -OSFilter \"$(PB_image-builder_OSFilter)\" -ImageBuilderCustomArgs \"$(image-builder.args)\" -CleanupDocker",
+        "arguments": "-VersionFilter $(PB_image-builder_versionFilter) -OSFilter $(PB_image-builder_osFilter) -ImageBuilderCustomArgs \"$(image-builder.customArgs)\" -CleanupDocker",
         "workingFolder": "$(Build.SourcesDirectory)",
         "inlineScript": "",
         "failOnStandardError": "false"
@@ -66,21 +66,21 @@
       "value": "false",
       "allowOverride": true
     },
-    "image-builder.args": {
-      "value": "--push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_customCommonArgs)",
+    "image-builder.customArgs": {
+      "value": "--push --username $(PB_docker_username) --password $(PB_docker_password) $(PB_image-builder_queueCustomArgs)",
       "allowOverride": true
     },
     "PB_docker_password": {
       "value": null,
       "isSecret": true
     },
-    "PB_image-builder_customCommonArgs": {
+    "PB_image-builder_queueCustomArgs": {
       "value": ""
     },
-    "PB_image-builder_VersionFilter": {
+    "PB_image-builder_versionFilter": {
       "value": ""
     },
-    "PB_image-builder_OSFilter": {
+    "PB_image-builder_osFilter": {
       "value": ""
     }
   },

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -16,15 +16,15 @@
         {
           "Name": "dotnet-framework-docker-windows-ltsc2016-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "3.5-windowsservercore-ltsc2016/*",
-            "PB_image-builder_vars": "--var VersionFilter=3.5 --var OSFilter=windowsservercore-ltsc2016"
+            "PB_image-builder_VersionFilter": "3.5",
+            "PB_image-builder_OSFilter": "windowsservercore-ltsc2016"
           }
         },
         {
           "Name": "dotnet-framework-docker-windows-ltsc2016-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "4.*-windowsservercore-ltsc2016/*",
-            "PB_image-builder_vars": "--var VersionFilter=4.* --var OSFilter=windowsservercore-ltsc2016"
+            "PB_image-builder_VersionFilter": "4.*",
+            "PB_image-builder_OSFilter": "windowsservercore-ltsc2016"
           }
         }
       ]
@@ -38,15 +38,15 @@
         {
           "Name": "dotnet-framework-docker-windows-1709-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "3.5-windowsservercore-1709/*",
-            "PB_image-builder_vars": "--var VersionFilter=3.5 --var OSFilter=windowsservercore-1709"
+            "PB_image-builder_VersionFilter": "3.5",
+            "PB_image-builder_OSFilter": "windowsservercore-1709"
           }
         },
         {
           "Name": "dotnet-framework-docker-windows-1709-amd64-images",
           "Parameters": {
-            "PB_image-builder_path": "4.*-windowsservercore-1709/*",
-            "PB_image-builder_vars": "--var VersionFilter=4.* --var OSFilter=windowsservercore-1709"
+            "PB_image-builder_VersionFilter": "4.*",
+            "PB_image-builder_OSFilter": "windowsservercore-1709"
           }
         }
       ]

--- a/build-pipeline/pipeline.json
+++ b/build-pipeline/pipeline.json
@@ -16,15 +16,15 @@
         {
           "Name": "dotnet-framework-docker-windows-ltsc2016-amd64-images",
           "Parameters": {
-            "PB_image-builder_VersionFilter": "3.5",
-            "PB_image-builder_OSFilter": "windowsservercore-ltsc2016"
+            "PB_image-builder_versionFilter": "3.5",
+            "PB_image-builder_osFilter": "windowsservercore-ltsc2016"
           }
         },
         {
           "Name": "dotnet-framework-docker-windows-ltsc2016-amd64-images",
           "Parameters": {
-            "PB_image-builder_VersionFilter": "4.*",
-            "PB_image-builder_OSFilter": "windowsservercore-ltsc2016"
+            "PB_image-builder_versionFilter": "4.*",
+            "PB_image-builder_osFilter": "windowsservercore-ltsc2016"
           }
         }
       ]
@@ -38,15 +38,15 @@
         {
           "Name": "dotnet-framework-docker-windows-1709-amd64-images",
           "Parameters": {
-            "PB_image-builder_VersionFilter": "3.5",
-            "PB_image-builder_OSFilter": "windowsservercore-1709"
+            "PB_image-builder_versionFilter": "3.5",
+            "PB_image-builder_osFilter": "windowsservercore-1709"
           }
         },
         {
           "Name": "dotnet-framework-docker-windows-1709-amd64-images",
           "Parameters": {
-            "PB_image-builder_VersionFilter": "4.*",
-            "PB_image-builder_OSFilter": "windowsservercore-1709"
+            "PB_image-builder_versionFilter": "4.*",
+            "PB_image-builder_osFilter": "windowsservercore-1709"
           }
         }
       ]


### PR DESCRIPTION
Update official builds to use `build-and-test.ps1`.  Thus, CI and official builds use the same pattern to build and test images.

Fixes https://github.com/Microsoft/dotnet-framework-docker/issues/82
