### PR TITLE
Misc changes to build definitions related to cleanup and stabilization

### DIFF
--- a/.vsts-pipelines/builds/microsoft-dotnet-framework.yml
+++ b/.vsts-pipelines/builds/microsoft-dotnet-framework.yml
@@ -2,6 +2,7 @@ trigger: none
 phases:
  - template: ../phases/build-all.yml
    parameters:
+     manifest: manifest.json
      repo: dotnet-framework
      matrixWindowsLtsc2016Amd64:
        3_5:

--- a/.vsts-pipelines/phases/build-all.yml
+++ b/.vsts-pipelines/phases/build-all.yml
@@ -1,7 +1,7 @@
 parameters:
-  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180627140652
-  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180627070723
-  manifest: manifest.json
+  imageBuilderLinuxImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180712175314
+  imageBuilderWindowsImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180712112709
+  manifest: null
   repo: null
   matrixWindowsLtsc2016Amd64: {}
   matrixWindows1709Amd64: {}

--- a/.vsts-pipelines/phases/build-amd64.yml
+++ b/.vsts-pipelines/phases/build-amd64.yml
@@ -7,7 +7,7 @@ parameters:
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: and(succeeded(), eq(variables['startingPhase'], 'build'))
+    condition: or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build'))
     queue:
       name: DotNetCore-Infra
       demands: ${{ parameters.demands }}
@@ -15,21 +15,13 @@ phases:
       timeoutInMinutes: 180
       matrix: ${{ parameters.matrix }}
     variables:
-      docker.setupContainerName: build_setup_$(Build.BuildId)
-      imageBuilder.image: ${{ parameters.imageBuilderImage }}
+      imageBuilder.path: $(dotnetVersion)-*
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
     steps:
-      - template: ../steps/docker-cleanup-windows.yml
-      - script: docker pull $(imageBuilder.image)
-        displayName: Pull Image Builder
-      - script: docker create --name $(docker.setupContainerName) $(imageBuilder.image)
-        displayName: Create Setup Container
-      - script: docker cp $(docker.setupContainerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
-        displayName: Copy Image Builder
-      - script: docker rm -f $(docker.setupContainerName)
-        displayName: Cleanup Setup Container
-        continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --path $(dotnetVersion)* --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --repo-override microsoft/$(repo)-build=$(acr.server)/$(repo)-build-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - template: ../steps/docker-init-windows.yml
+        parameters:
+          imageBuilderImage: ${{ parameters.imageBuilderImage }}
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe build --manifest $(manifest) --path $(imageBuilder.path) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --repo-override microsoft/$(repo)-build=$(acr.server)/$(repo)-build-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/copy-images.yml
+++ b/.vsts-pipelines/phases/copy-images.yml
@@ -2,13 +2,12 @@ parameters:
   phase: null
   imageBuilderImage: null
   manifest: null
-  dependsOn: null
   repo: null
   demands: []
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: or(succeeded(), eq(variables['startingPhase'], 'publish'), and(eq(variables['repo'], 'dotnet-framework-samples'), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))
+    condition: or(eq(variables['singlePhase'], 'publish'), and(eq(variables['singlePhase'], ''), or(succeeded(), and(eq(variables['repo'], 'dotnet-framework-samples'), eq(variables['singlePhase'], ''), succeeded('Build_NanoServerSac2016_amd64'), succeeded('Build_NanoServer1709_amd64'), succeeded('Build_NanoServer1803_amd64')))))
     dependsOn:
       - Test_NanoServerSac2016_amd64
       - Test_NanoServer1709_amd64
@@ -19,21 +18,13 @@ phases:
       parallel: 100
       matrix: ${{ parameters.matrix }}
     variables:
-      docker.setupContainerName: publish_setup_$(Build.BuildId)
-      imageBuilder.image: ${{ parameters.imageBuilderImage }}
+      imageBuilder.path: $(dotnetVersion)-*
       manifest: ${{ parameters.manifest }}
       repo: ${{ parameters.repo }}
     steps:
-      - template: ../steps/docker-cleanup-windows.yml
-      - script: docker pull $(imageBuilder.image)
-        displayName: Pull Image Builder
-      - script: docker create --name $(docker.setupContainerName) $(imageBuilder.image)
-        displayName: Create Setup Container
-      - script: docker cp $(docker.setupContainerName):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
-        displayName: Copy Image Builder
-      - script: docker rm -f $(docker.setupContainerName)
-        displayName: Cleanup Setup Container
-        continueOnError: true
-      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --path $(dotnetVersion)* --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - template: ../steps/docker-init-windows.yml
+        parameters:
+          imageBuilderImage: ${{ parameters.imageBuilderImage }}
+      - script: $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder/Microsoft.DotNet.ImageBuilder.exe copyImages --manifest $(manifest) --path $(imageBuilder.path) --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/publish-finalize.yml
+++ b/.vsts-pipelines/phases/publish-finalize.yml
@@ -13,14 +13,16 @@ phases:
       demands:
         - agent.os -equals linux
     variables:
-      docker.commonRunArgs: --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(Build.SourcesDirectory):/repo -w /repo $(imageBuilder.image)
+      docker.commonRunArgs: --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(repoVolume):/repo -w /repo $(imageBuilder.image)
       imageBuilder.commonCmdArgs: --manifest $(manifest) --username $(dockerRegistry.userName) --password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs)
       imageBuilder.image: ${{ parameters.imageBuilderImage }}
       manifest: ${{ parameters.manifest }}
+      repoVolume: publish-repo-$(Build.BuildId)
     steps:
-      - template: ../steps/docker-cleanup-linux.yml
-      - script: docker pull $(imageBuilder.image)
-        displayName: Pull Image Builder
+      - template: ../steps/docker-init-linux.yml
+        parameters:
+          image: $(imageBuilder.image)
+          repoVolume: $(repoVolume)
       - script: docker run $(docker.commonRunArgs) publishManifest $(imageBuilder.commonCmdArgs)
         displayName: Publish Manifest
       - script: docker run $(docker.commonRunArgs) updateReadme $(imageBuilder.commonCmdArgs)

--- a/.vsts-pipelines/phases/test-amd64.yml
+++ b/.vsts-pipelines/phases/test-amd64.yml
@@ -6,7 +6,7 @@ parameters:
   matrix: {}
 phases:
   - phase: ${{ parameters.phase }}
-    condition: and(ne(variables['repo'], 'dotnet-framework-samples'), or(succeeded(), eq(variables['startingPhase'], 'test')))
+    condition: and(ne(variables['repo'], 'dotnet-framework-samples'), or(and(succeeded(), eq(variables['singlePhase'], '')), eq(variables['singlePhase'], 'test')))
     dependsOn: ${{ parameters.dependsOn }}
     queue:
       name: DotNetCore-Infra
@@ -16,7 +16,7 @@ phases:
     variables:
       repo: ${{ parameters.repo }}
     steps:
-      - template: ../steps/docker-cleanup-windows.yml
+      - template: ../steps/docker-init-windows.yml
       - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
         displayName: Docker login
       - powershell: ./tests/run-tests.ps1 -VersionFilter $(dotnetVersion) -OSFilter $(osVersion) -Repo $(acr.server)/$(repo)-$(stagingRepo.suffix)

--- a/.vsts-pipelines/steps/docker-init-linux.yml
+++ b/.vsts-pipelines/steps/docker-init-linux.yml
@@ -1,0 +1,32 @@
+parameters:
+  imageBuilderImage: microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180712175314
+  repoVolume: ''
+
+steps:
+  ################################################################################
+  # Cleanup Docker Resources
+  ################################################################################
+  - template: docker-cleanup-linux.yml
+
+  ################################################################################
+  # Create Repo Volume (Optional)
+  ################################################################################
+  - ${{ if ne(parameters.repoVolume, '') }}:
+    - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh buildpack-deps:stretch-scm
+      displayName: Pull Image buildpack-deps:stretch-scm
+    - script: docker run --rm -v $repoVolume:/repo buildpack-deps:stretch-scm git clone https://github.com/microsoft/dotnet-framework-docker.git /repo
+      displayName: Clone Repo
+      env:
+        repoVolume: ${{ parameters.repoVolume }}
+    - script: docker run --rm -v $repoVolume:/repo -w /repo buildpack-deps:stretch-scm git checkout $(Build.SourceVersion)
+      displayName: Checkout Source
+      env:
+        repoVolume: ${{ parameters.repoVolume }}
+
+  ################################################################################
+  # Get ImageBuilder
+  ################################################################################
+  - script: $(Build.Repository.LocalPath)/scripts/pull-image.sh $image
+    displayName: ${{ format('Pull Image {0}', parameters.image) }}
+    env:
+      image: ${{ parameters.imageBuilderImage }}

--- a/.vsts-pipelines/steps/docker-init-windows.yml
+++ b/.vsts-pipelines/steps/docker-init-windows.yml
@@ -1,0 +1,26 @@
+parameters:
+  imageBuilderImage: microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180712112709
+
+steps:
+  ################################################################################
+  # Cleanup Docker Resources
+  ################################################################################
+  - template: docker-cleanup-windows.yml
+
+  ################################################################################
+  # Setup Image Builder (Optional)
+  ################################################################################
+  - ${{ if ne(parameters.imageBuilderImage, '') }}:
+    - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-PullImage.ps1 $env:image
+      displayName: ${{ format('Pull Image {0}', parameters.image) }}
+      env:
+        image: ${{ parameters.imageBuilderImage }}
+    - script: docker create --name setupImageBuilder_$(Build.BuildId) %image%
+      displayName: Create Setup Container
+      env:
+        image: ${{ parameters.imageBuilderImage }}
+    - script: docker cp setupImageBuilder_$(Build.BuildId):/image-builder $(Build.BinariesDirectory)/Microsoft.DotNet.ImageBuilder
+      displayName: Copy Image Builder
+    - script: docker rm -f setupImageBuilder_$(Build.BuildId)
+      displayName: Cleanup Setup Container
+      continueOnError: true

--- a/scripts/Invoke-PullImage.ps1
+++ b/scripts/Invoke-PullImage.ps1
@@ -1,0 +1,43 @@
+#!/usr/bin/env pwsh
+[cmdletbinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Image
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Executes a command and retries if it fails.
+function Exec {
+    param (
+        [Parameter(Mandatory = $true)][scriptblock]$cmd,
+        [Parameter(Mandatory = $false)][int]$retries = 5,
+        [Parameter(Mandatory = $false)][int]$waitFactor = 6
+    )
+
+    $count = 0
+    $completed = $false
+
+    while (-not $completed) {
+        & $cmd
+        $exit = $LASTEXITCODE
+        $count++
+
+        if ($exit -eq 0) {
+            $completed = $true
+        }
+        else {
+            if ($count -lt $retries) {
+                $wait = [Math]::Pow($waitFactor, $count - 1)
+                Write-Output "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+                Start-Sleep $wait
+            }
+            else {
+                Write-Output "Retry $count/$retries exited $exit, no more retries left."
+                $completed = $true
+            }
+        }
+    }
+}
+
+Exec { docker pull $Image }

--- a/scripts/pull-image.sh
+++ b/scripts/pull-image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+say_err() {
+    printf "%b\n" "Error: $1" >&2
+}
+
+# Executes a command and retries if it fails.
+execute() {
+    local count=0
+    until "$@"; do
+        local exit=$?
+        count=$(( $count + 1 ))
+        if [ $count -lt $retries ]; then
+            local wait=$(( waitFactor ** (( count - 1 )) ))
+            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else    
+            say_err "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+
+    return 0
+}
+
+scriptName=$0
+retries=5
+waitFactor=6
+image=$1
+
+echo "Pulling Docker image $image"
+execute docker pull $image


### PR DESCRIPTION
- Use latest image builder with fix for dotnet/docker-tools#105
- Add retry logic when pulling Docker images
- Refactor startingPhase into singlePhase. This provides more robust control such as being able to only perform a build.
- Encapsulate image-builder retrieval/setup within single yml - docker-init-windows.yml
- Fix issue with build path not getting set correctly between samples and product builds.

@dotnet-bot dotnet-bot Linked skip ci please