### PR TITLE
Fixup samples build

### DIFF
--- a/.vsts-pipelines/phases/build-all.yml
+++ b/.vsts-pipelines/phases/build-all.yml
@@ -20,16 +20,19 @@ phases:
   - template: build-amd64.yml
     parameters:
       phase: Build_WindowsServerCoreLtsc2016_amd64
+      osVersion: windowsservercore-ltsc2016
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
       matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixWindowsservercoreLtsc2016Amd64'] ]
   - template: build-amd64.yml
     parameters:
       phase: Build_WindowsServerCore1709_amd64
+      osVersion: windowsservercore-1709
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
       matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixWindowsservercore1709Amd64'] ]
   - template: build-amd64.yml
     parameters:
       phase: Build_WindowsServerCore1803_amd64
+      osVersion: windowsservercore-1803
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
       matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixWindowsservercore1803Amd64'] ]
 
@@ -67,16 +70,19 @@ phases:
   - template: copy-images.yml
     parameters:
       phase: Copy_Images_WindowsServerCoreLtsc2016_amd64
+      osVersion: windowsservercore-ltsc2016
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_with_Containers
       matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixWindowsservercoreLtsc2016Amd64'] ]
   - template: copy-images.yml
     parameters:
       phase: Copy_Images_WindowsServerCore1709_amd64
+      osVersion: windowsservercore-1709
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS3
       matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixWindowsservercore1709Amd64'] ]
   - template: copy-images.yml
     parameters:
       phase: Copy_Images_WindowsServerCore1803_amd64
+      osVersion: windowsservercore-1803
       demands: VSTS_OS -equals Windows_Server_2016_Data_Center_RS4
       matrix: $[ dependencies.GenerateMatrices.outputs['buildMatrix.buildMatrixWindowsservercore1803Amd64'] ]
 

--- a/.vsts-pipelines/phases/build-amd64.yml
+++ b/.vsts-pipelines/phases/build-amd64.yml
@@ -1,5 +1,6 @@
 parameters:
   phase: null
+  osVersion: null
   demands: []
   matrix: {}
 phases:
@@ -12,8 +13,10 @@ phases:
       parallel: 100
       timeoutInMinutes: 180
       matrix: ${{ parameters.matrix }}
+    variables:
+      osVersion: ${{ parameters.osVersion }}
     steps:
       - template: ../steps/docker-init-windows.yml
-      - script: $(runImageBuilderCmd) build --manifest $(manifest) $(imageBuilderPaths) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --repo-override microsoft/$(repo)-build=$(acr.server)/$(repo)-build-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: $(runImageBuilderCmd) build --manifest $(manifest) $(imageBuilderPaths) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --repo-override microsoft/$(repo)-build=$(acr.server)/$(repo)-build-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/phases/copy-images.yml
+++ b/.vsts-pipelines/phases/copy-images.yml
@@ -1,5 +1,6 @@
 parameters:
   phase: null
+  osVersion: null
   demands: []
   matrix: {}
 phases:
@@ -15,8 +16,10 @@ phases:
       demands: ${{ parameters.demands }}
       parallel: 100
       matrix: ${{ parameters.matrix }}
+    variables:
+      osVersion: ${{ parameters.osVersion }}
     steps:
       - template: ../steps/docker-init-windows.yml
-      - script: $(runImageBuilderCmd) copyImages --manifest $(manifest) $(imageBuilderPaths) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
+      - script: $(runImageBuilderCmd) copyImages --manifest $(manifest) $(imageBuilderPaths) --os-version $(osVersion) --source-server $(acr.server) --source-username $(acr.userName) --source-password $(BotAccount-dotnet-docker-acr-bot-password) --destination-username $(dockerRegistry.userName) --destination-password $(BotAccount-dotnet-dockerhub-bot-password) $(imageBuilder.queueArgs) $(imageBuilder.publishQueueArgs) $(acr.server)/$(repo)-$(stagingRepo.suffix)
         displayName: Copy Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/.vsts-pipelines/steps/docker-init-windows.yml
+++ b/.vsts-pipelines/steps/docker-init-windows.yml
@@ -10,7 +10,7 @@ steps:
   ################################################################################
   # Setup Image Builder (Optional)
   ################################################################################
-  - ${{ if parameters.setupImageBuilder }}:
+  - ${{ if eq(parameters.setupImageBuilder, 'true') }}:
     - script: echo "##vso[task.setvariable variable=imageBuilder.image]microsoft/dotnet-buildtools-prereqs:image-builder-nanoserver-20180904151412
       displayName: Define imageBuilder.image Variable
     - powershell: $(Build.Repository.LocalPath)/scripts/Invoke-PullImage.ps1 '$(imageBuilder.image)'


### PR DESCRIPTION
- Some recent build changes broke the samples build.  The samples build the same Dockerfiles on multiple platforms therefore there needs to be an os-version filter specified in order to select the correct entry within the manifest.
- Fixed an `if` condition to use the correct syntax.