### PR TITLE
Fix CI to run with local images

### DIFF
--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -23,7 +23,7 @@ if (!(Test-Path "$dotnetInstallDir")) {
 $dotnetInstallScript = "dotnet-install.ps1";
 $dotnetInstallScriptPath = "$dotnetInstallDir/$DotnetInstallScript"
 if (!(Test-Path $dotnetInstallScriptPath)) {
-    $dotnetInstallScriptUrl = "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/$dotnetInstallScript"
+    $dotnetInstallScriptUrl = "https://raw.githubusercontent.com/dotnet/cli/release/2.1/scripts/obtain/$dotnetInstallScript"
     Invoke-WebRequest $dotnetInstallScriptUrl -OutFile $dotnetInstallScriptPath
 }
 
@@ -34,6 +34,10 @@ if ($LASTEXITCODE -ne 0) { throw "Failed to install the .NET Core SDK" }
 $env:IMAGE_OS_FILTER = $OSFilter
 $env:IMAGE_VERSION_FILTER = $VersionFilter
 $env:REPO = $Repo
+
+if ($IsLocalRun) {
+    $env:LOCAL_RUN = 1
+}
 
 & dotnet test -c Release --logger:trx $PSScriptRoot/Microsoft.DotNet.Framework.Docker.Tests/Microsoft.DotNet.Framework.Docker.Tests.csproj
 if ($LASTEXITCODE -ne 0) { throw "Tests Failed" }


### PR DESCRIPTION
- Fixed an issue with CI in that the tests are not running with the images built by CI.  
- Update the version of .NET Core used by the tests to 2.1 since 2.0 is EOL.