### PR TITLE
Update Dockerfile link pattern used in readme tags section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,39 +33,39 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 # Windows Server 2019 amd64 tags
 
-- [`4.7.2-runtime-20181211-windowsservercore-ltsc2019`, `4.7.2-runtime-windowsservercore-ltsc2019`, `4.7.2-runtime`, `runtime`, `latest` (*4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile)
-- [`4.7.2-sdk-20181211-windowsservercore-ltsc2019`, `4.7.2-sdk-windowsservercore-ltsc2019`, `4.7.2-sdk`, `sdk` (*4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile)
-- [`3.5-runtime-20181211-windowsservercore-ltsc2019`, `3.5-runtime-windowsservercore-ltsc2019`, `3.5-runtime` (*3.5/runtime/windowsservercore-ltsc2019/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-ltsc2019/Dockerfile)
-- [`3.5-sdk-20181211-windowsservercore-ltsc2019`, `3.5-sdk-windowsservercore-ltsc2019`, `3.5-sdk` (*3.5/sdk/windowsservercore-ltsc2019/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2019/Dockerfile)
+- [`4.7.2-runtime-20181211-windowsservercore-ltsc2019`, `4.7.2-runtime-windowsservercore-ltsc2019`, `4.7.2-runtime`, `runtime`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile)
+- [`4.7.2-sdk-20181211-windowsservercore-ltsc2019`, `4.7.2-sdk-windowsservercore-ltsc2019`, `4.7.2-sdk`, `sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile)
+- [`3.5-runtime-20181211-windowsservercore-ltsc2019`, `3.5-runtime-windowsservercore-ltsc2019`, `3.5-runtime` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-ltsc2019/Dockerfile)
+- [`3.5-sdk-20181211-windowsservercore-ltsc2019`, `3.5-sdk-windowsservercore-ltsc2019`, `3.5-sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2019/Dockerfile)
 
 # Windows Server, version 1803 amd64 tags
 
-- [`4.7.2-runtime-20181211-windowsservercore-1803`, `4.7.2-runtime-windowsservercore-1803`, `4.7.2-runtime`, `runtime`, `latest` (*4.7.2/runtime/windowsservercore-1803/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-1803/Dockerfile)
-- [`4.7.2-sdk-20181211-windowsservercore-1803`, `4.7.2-sdk-windowsservercore-1803`, `4.7.2-sdk`, `sdk` (*4.7.2/sdk/windowsservercore-1803/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-1803/Dockerfile)
-- [`3.5-runtime-20181113-windowsservercore-1803`, `3.5-runtime-windowsservercore-1803`, `3.5-runtime` (*3.5/runtime/windowsservercore-1803/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-1803/Dockerfile)
-- [`3.5-sdk-20181113-windowsservercore-1803`, `3.5-sdk-windowsservercore-1803`, `3.5-sdk` (*3.5/sdk/windowsservercore-1803/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1803/Dockerfile)
+- [`4.7.2-runtime-20181211-windowsservercore-1803`, `4.7.2-runtime-windowsservercore-1803`, `4.7.2-runtime`, `runtime`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-1803/Dockerfile)
+- [`4.7.2-sdk-20181211-windowsservercore-1803`, `4.7.2-sdk-windowsservercore-1803`, `4.7.2-sdk`, `sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-1803/Dockerfile)
+- [`3.5-runtime-20181113-windowsservercore-1803`, `3.5-runtime-windowsservercore-1803`, `3.5-runtime` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-1803/Dockerfile)
+- [`3.5-sdk-20181113-windowsservercore-1803`, `3.5-sdk-windowsservercore-1803`, `3.5-sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1803/Dockerfile)
 
 # Windows Server, version 1709 amd64 tags
 
-- [`4.7.2-runtime-20181211-windowsservercore-1709`, `4.7.2-runtime-windowsservercore-1709`, `4.7.2-runtime`, `runtime`, `latest` (*4.7.2/runtime/windowsservercore-1709/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-1709/Dockerfile)
-- [`4.7.2-sdk-20181211-windowsservercore-1709`, `4.7.2-sdk-windowsservercore-1709`, `4.7.2-sdk`, `sdk` (*4.7.2/sdk/windowsservercore-1709/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-1709/Dockerfile)
-- [`4.7.1-runtime-20181211-windowsservercore-1709`, `4.7.1-runtime-windowsservercore-1709`, `4.7.1-runtime` (*4.7.1/runtime/windowsservercore-1709/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/runtime/windowsservercore-1709/Dockerfile)
-- [`4.7.1-sdk-20181211-windowsservercore-1709`, `4.7.1-sdk-windowsservercore-1709`, `4.7.1-sdk` (*4.7.1/sdk/windowsservercore-1709/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/sdk/windowsservercore-1709/Dockerfile)
-- [`3.5-runtime-20181211-windowsservercore-1709`, `3.5-runtime-windowsservercore-1709`, `3.5-runtime` (*3.5/runtime/windowsservercore-1709/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-1709/Dockerfile)
-- [`3.5-sdk-20181211-windowsservercore-1709`, `3.5-sdk-windowsservercore-1709`, `3.5-sdk` (*3.5/sdk/windowsservercore-1709/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1709/Dockerfile)
+- [`4.7.2-runtime-20181211-windowsservercore-1709`, `4.7.2-runtime-windowsservercore-1709`, `4.7.2-runtime`, `runtime`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-1709/Dockerfile)
+- [`4.7.2-sdk-20181211-windowsservercore-1709`, `4.7.2-sdk-windowsservercore-1709`, `4.7.2-sdk`, `sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-1709/Dockerfile)
+- [`4.7.1-runtime-20181211-windowsservercore-1709`, `4.7.1-runtime-windowsservercore-1709`, `4.7.1-runtime` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/runtime/windowsservercore-1709/Dockerfile)
+- [`4.7.1-sdk-20181211-windowsservercore-1709`, `4.7.1-sdk-windowsservercore-1709`, `4.7.1-sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/sdk/windowsservercore-1709/Dockerfile)
+- [`3.5-runtime-20181211-windowsservercore-1709`, `3.5-runtime-windowsservercore-1709`, `3.5-runtime` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-1709/Dockerfile)
+- [`3.5-sdk-20181211-windowsservercore-1709`, `3.5-sdk-windowsservercore-1709`, `3.5-sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1709/Dockerfile)
 
 # Windows Server 2016 amd64 tags
 
-- [`4.7.2-runtime-20181211-windowsservercore-ltsc2016`, `4.7.2-runtime-windowsservercore-ltsc2016`, `4.7.2-runtime`, `runtime`, `latest` (*4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile)
-- [`4.7.2-sdk-20181211-windowsservercore-ltsc2016`, `4.7.2-sdk-windowsservercore-ltsc2016`, `4.7.2-sdk`, `sdk` (*4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile)
-- [`4.7.1-runtime-20181211-windowsservercore-ltsc2016`, `4.7.1-runtime-windowsservercore-ltsc2016`, `4.7.1-runtime` (*4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile)
-- [`4.7.1-sdk-20181211-windowsservercore-ltsc2016`, `4.7.1-sdk-windowsservercore-ltsc2016`, `4.7.1-sdk` (*4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile)
-- [`4.7-runtime-20181211-windowsservercore-ltsc2016`, `4.7-runtime-windowsservercore-ltsc2016`, `4.7-runtime` (*4.7/runtime/windowsservercore-ltsc2016/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7/runtime/windowsservercore-ltsc2016/Dockerfile)
-- [`4.6.2-runtime-20181211-windowsservercore-ltsc2016`, `4.6.2-runtime-windowsservercore-ltsc2016`, `4.6.2-runtime` (*4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile)
-- [`3.5-runtime-20181211-windowsservercore-ltsc2016`, `3.5-runtime-windowsservercore-ltsc2016`, `3.5-runtime` (*3.5/runtime/windowsservercore-ltsc2016/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-ltsc2016/Dockerfile)
-- [`3.5-sdk-20181211-windowsservercore-ltsc2016`, `3.5-sdk-windowsservercore-ltsc2016`, `3.5-sdk` (*3.5/sdk/windowsservercore-ltsc2016/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7.2-runtime-20181211-windowsservercore-ltsc2016`, `4.7.2-runtime-windowsservercore-ltsc2016`, `4.7.2-runtime`, `runtime`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7.2-sdk-20181211-windowsservercore-ltsc2016`, `4.7.2-sdk-windowsservercore-ltsc2016`, `4.7.2-sdk`, `sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7.1-runtime-20181211-windowsservercore-ltsc2016`, `4.7.1-runtime-windowsservercore-ltsc2016`, `4.7.1-runtime` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7.1-sdk-20181211-windowsservercore-ltsc2016`, `4.7.1-sdk-windowsservercore-ltsc2016`, `4.7.1-sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7-runtime-20181211-windowsservercore-ltsc2016`, `4.7-runtime-windowsservercore-ltsc2016`, `4.7-runtime` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`4.6.2-runtime-20181211-windowsservercore-ltsc2016`, `4.6.2-runtime-windowsservercore-ltsc2016`, `4.6.2-runtime` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`3.5-runtime-20181211-windowsservercore-ltsc2016`, `3.5-runtime-windowsservercore-ltsc2016`, `3.5-runtime` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`3.5-sdk-20181211-windowsservercore-ltsc2016`, `3.5-sdk-windowsservercore-ltsc2016`, `3.5-sdk` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2016/Dockerfile)
 
-For more information about these images and their history, please see [(`microsoft/dotnet-framework-docker`)](https://github.com/Microsoft/dotnet-framework-docker). 
+For more information about these images and their history, please see [(`microsoft/dotnet-framework-docker`)](https://github.com/Microsoft/dotnet-framework-docker). These images are updated via [pull requests to the `Microsoft/dotnet-framework-docker` GitHub repo](https://github.com/Microsoft/dotnet-framework-docker/pulls).
 
 ## What is the .NET Framework?
 

--- a/samples/README.DockerHub.md
+++ b/samples/README.DockerHub.md
@@ -50,33 +50,33 @@ docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 microsoft/dot
 
 # Windows Server 2019 amd64 tags
 
-- [`dotnetapp-windowsservercore-ltsc2019`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-windowsservercore-ltsc2019`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
-- [`wcfservice-windowsservercore-ltsc2019`, `wcfservice` (*samples/wcfapp/Dockerfile.web*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
-- [`wcfclient-windowsservercore-ltsc2019`, `wcfclient` (*samples/wcfapp/Dockerfile.client*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
+- [`dotnetapp-windowsservercore-ltsc2019`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
+- [`aspnetapp-windowsservercore-ltsc2019`, `aspnetapp` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`wcfservice-windowsservercore-ltsc2019`, `wcfservice` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
+- [`wcfclient-windowsservercore-ltsc2019`, `wcfclient` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
 
-# Windows Server, version 1803 tags
+# Windows Server, version 1803 amd64 tags
 
-- [`dotnetapp-windowsservercore-1803`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-windowsservercore-1803`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
-- [`wcfservice-windowsservercore-1803`, `wcfservice` (*samples/wcfapp/Dockerfile.web*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
-- [`wcfclient-windowsservercore-1803`, `wcfclient` (*samples/wcfapp/Dockerfile.client*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
+- [`dotnetapp-windowsservercore-1803`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
+- [`aspnetapp-windowsservercore-1803`, `aspnetapp` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`wcfservice-windowsservercore-1803`, `wcfservice` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
+- [`wcfclient-windowsservercore-1803`, `wcfclient` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
 
 # Windows Server, version 1709 amd64 tags
 
-- [`dotnetapp-windowsservercore-1709`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-windowsservercore-1709`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
-- [`wcfservice-windowsservercore-1709`, `wcfservice` (*samples/wcfapp/Dockerfile.web*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
-- [`wcfclient-windowsservercore-1709`, `wcfclient` (*samples/wcfapp/Dockerfile.client*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
+- [`dotnetapp-windowsservercore-1709`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
+- [`aspnetapp-windowsservercore-1709`, `aspnetapp` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`wcfservice-windowsservercore-1709`, `wcfservice` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
+- [`wcfclient-windowsservercore-1709`, `wcfclient` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
 
 # Windows Server 2016 amd64 tags
 
-- [`dotnetapp-windowsservercore-ltsc2016`, `dotnetapp`, `latest` (*samples/dotnetapp/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-windowsservercore-ltsc2016`, `aspnetapp` (*samples/aspnetapp/Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
-- [`wcfservice-windowsservercore-ltsc2016`, `wcfservice` (*samples/wcfapp/Dockerfile.web*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
-- [`wcfclient-windowsservercore-ltsc2016`, `wcfclient` (*samples/wcfapp/Dockerfile.client*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
+- [`dotnetapp-windowsservercore-ltsc2016`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
+- [`aspnetapp-windowsservercore-ltsc2016`, `aspnetapp` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`wcfservice-windowsservercore-ltsc2016`, `wcfservice` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
+- [`wcfclient-windowsservercore-ltsc2016`, `wcfclient` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
 
-# What is the .NET Framework?
+## What is the .NET Framework?
 
 The [.NET Framework](https://www.microsoft.com/net/framework) is a general purpose development platform maintained by Microsoft. It is the most popular way to build client and server applications for Windows and Windows Server. It is included with Windows, Windows Server and Windows Server Core. It includes server technologies such as ASP.NET Web Forms, ASP.NET MVC and Windows Communication Framework (WCF) applications, which you can run in Docker containers.
 

--- a/scripts/Get-TagsDocumentation.ps1
+++ b/scripts/Get-TagsDocumentation.ps1
@@ -1,17 +1,38 @@
 param(
     [string]$Branch='master',
-    [string]$Manifest='manifest.json',
-    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-debian-20180522205353'
+    [string]$ImageBuilderImageName='microsoft/dotnet-buildtools-prereqs:image-builder-debian-20181030184558'
 )
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Path "$PSScriptRoot" -Parent
 
+function GenerateDoc {
+    param ([string] $Manifest, [string] $Repo, [string] $ReadmePath, [string] $Template)
+
+    & docker run --rm `
+        -v /var/run/docker.sock:/var/run/docker.sock `
+        -v "${repoRoot}:/repo" `
+        -w /repo `
+        $ImageBuilderImageName `
+            generateTagsReadme `
+            --manifest $Manifest `
+            --repo $Repo `
+            --update-readme `
+            --readme-path $ReadmePath `
+            --template $Template `
+            "https://github.com/Microsoft/dotnet-framework-docker/blob/${Branch}"
+}
+
 & docker pull $ImageBuilderImageName
 
-& docker run --rm `
-    -v /var/run/docker.sock:/var/run/docker.sock `
-    -v "${repoRoot}:/repo" `
-    -w /repo `
-    $ImageBuilderImageName `
-    generateTagsReadme --update-readme --manifest $Manifest "https://github.com/Microsoft/dotnet-framework-docker/blob/${Branch}"
+GenerateDoc `
+    -Manifest manifest.json `
+    -Repo microsoft/dotnet-framework `
+    -ReadmePath ./README.md `
+    -Template ./scripts/ReadmeTagsDocumentationTemplate.md
+
+GenerateDoc `
+    -Manifest manifest.samples.json `
+    -Repo microsoft/dotnet-framework-samples `
+    -ReadmePath ./samples/README.DockerHub.md `
+    -Template ./scripts/SamplesReadmeTagsDocumentationTemplate.md

--- a/scripts/ReadmeTagsDocumentationTemplate.md
+++ b/scripts/ReadmeTagsDocumentationTemplate.md
@@ -1,0 +1,38 @@
+## Complete set of Tags
+
+# Windows Server 2019 amd64 tags
+
+$(TagDoc:4.7.2-runtime-windowsservercore-ltsc2019)
+$(TagDoc:4.7.2-sdk-windowsservercore-ltsc2019)
+$(TagDoc:3.5-runtime-windowsservercore-ltsc2019)
+$(TagDoc:3.5-sdk-windowsservercore-ltsc2019)
+
+# Windows Server, version 1803 amd64 tags
+
+$(TagDoc:4.7.2-runtime-windowsservercore-1803)
+$(TagDoc:4.7.2-sdk-windowsservercore-1803)
+$(TagDoc:3.5-runtime-windowsservercore-1803)
+$(TagDoc:3.5-sdk-windowsservercore-1803)
+
+# Windows Server, version 1709 amd64 tags
+
+$(TagDoc:4.7.2-runtime-windowsservercore-1709)
+$(TagDoc:4.7.2-sdk-windowsservercore-1709)
+$(TagDoc:4.7.1-runtime-windowsservercore-1709)
+$(TagDoc:4.7.1-sdk-windowsservercore-1709)
+$(TagDoc:3.5-runtime-windowsservercore-1709)
+$(TagDoc:3.5-sdk-windowsservercore-1709)
+
+# Windows Server 2016 amd64 tags
+
+$(TagDoc:4.7.2-runtime-windowsservercore-ltsc2016)
+$(TagDoc:4.7.2-sdk-windowsservercore-ltsc2016)
+$(TagDoc:4.7.1-runtime-windowsservercore-ltsc2016)
+$(TagDoc:4.7.1-sdk-windowsservercore-ltsc2016)
+$(TagDoc:4.7-runtime-windowsservercore-ltsc2016)
+$(TagDoc:4.6.2-runtime-windowsservercore-ltsc2016)
+$(TagDoc:3.5-runtime-windowsservercore-ltsc2016)
+$(TagDoc:3.5-sdk-windowsservercore-ltsc2016)
+
+For more information about these images and their history, please see [(`microsoft/dotnet-framework-docker`)](https://github.com/Microsoft/dotnet-framework-docker). These images are updated via [pull requests to the `Microsoft/dotnet-framework-docker` GitHub repo](https://github.com/Microsoft/dotnet-framework-docker/pulls).
+

--- a/scripts/SamplesReadmeTagsDocumentationTemplate.md
+++ b/scripts/SamplesReadmeTagsDocumentationTemplate.md
@@ -1,0 +1,30 @@
+## Complete set of Tags
+
+# Windows Server 2019 amd64 tags
+
+$(TagDoc:dotnetapp-windowsservercore-ltsc2019)
+$(TagDoc:aspnetapp-windowsservercore-ltsc2019)
+$(TagDoc:wcfservice-windowsservercore-ltsc2019)
+$(TagDoc:wcfclient-windowsservercore-ltsc2019)
+
+# Windows Server, version 1803 amd64 tags
+
+$(TagDoc:dotnetapp-windowsservercore-1803)
+$(TagDoc:aspnetapp-windowsservercore-1803)
+$(TagDoc:wcfservice-windowsservercore-1803)
+$(TagDoc:wcfclient-windowsservercore-1803)
+
+# Windows Server, version 1709 amd64 tags
+
+$(TagDoc:dotnetapp-windowsservercore-1709)
+$(TagDoc:aspnetapp-windowsservercore-1709)
+$(TagDoc:wcfservice-windowsservercore-1709)
+$(TagDoc:wcfclient-windowsservercore-1709)
+
+# Windows Server 2016 amd64 tags
+
+$(TagDoc:dotnetapp-windowsservercore-ltsc2016)
+$(TagDoc:aspnetapp-windowsservercore-ltsc2016)
+$(TagDoc:wcfservice-windowsservercore-ltsc2016)
+$(TagDoc:wcfclient-windowsservercore-ltsc2016)
+


### PR DESCRIPTION
This new format is what is used in the [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) repo.

I also modified the infrastructure used to generate the tags section of the readme from the manifest.  Currently after the readme is generated it requires a few minor hand edits to get it in the desired format.  These changes eliminate that.