### PR TITLE
Remove references to the microsoft/dotnet-framework-build repo

### DIFF
--- a/.vsts-pipelines/phases/build-amd64.yml
+++ b/.vsts-pipelines/phases/build-amd64.yml
@@ -17,6 +17,6 @@ phases:
       osVersion: ${{ parameters.osVersion }}
     steps:
       - template: ../steps/docker-init-windows.yml
-      - script: $(runImageBuilderCmd) build --manifest $(manifest) $(imageBuilderPaths) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --repo-override microsoft/$(repo)-build=$(acr.server)/$(repo)-build-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
+      - script: $(runImageBuilderCmd) build --manifest $(manifest) $(imageBuilderPaths) --os-version $(osVersion) --repo-override microsoft/$(repo)=$(acr.server)/$(repo)-$(stagingRepo.suffix) --skip-test --push --server $(acr.server) --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
         displayName: Build Images
       - template: ../steps/docker-cleanup-windows.yml

--- a/README.dotnet-framework-build.md
+++ b/README.dotnet-framework-build.md
@@ -1,1 +1,0 @@
-The .NET Framework build images have moved to [microsoft/dotnet-framework](https://hub.docker.com/r/microsoft/dotnet-framework/). This repository will be deleted on 1/1/2019. See the [announcement](https://github.com/Microsoft/dotnet-framework-docker/issues/125) for additional details.

--- a/manifest.json
+++ b/manifest.json
@@ -302,59 +302,6 @@
           ]
         }
       ]
-    },
-    {
-      "name": "microsoft/dotnet-framework-build",
-      "readmePath": "README.dotnet-framework-build.md",
-      "images": [
-        {
-          "sharedTags": {
-            "4.7.1": {},
-            "latest": {}
-          },
-          "platforms": [
-            {
-              "dockerfile": "4.7.1/sdk/windowsservercore-ltsc2016",
-              "os": "windows",
-              "osVersion": "windowsservercore-ltsc2016",
-              "tags": {
-                "4.7.1-windowsservercore-ltsc2016": {}
-              }
-            },
-            {
-              "dockerfile": "4.7.1/sdk/windowsservercore-1709",
-              "os": "windows",
-              "osVersion": "windowsservercore-1709",
-              "tags": {
-                "4.7.1-windowsservercore-1709": {}
-              }
-            }
-          ]
-        },
-        {
-          "sharedTags": {
-            "3.5": {}
-          },
-          "platforms": [
-            {
-              "dockerfile": "3.5/sdk/windowsservercore-ltsc2016",
-              "os": "windows",
-              "osVersion": "windowsservercore-ltsc2016",
-              "tags": {
-                "3.5-windowsservercore-ltsc2016": {}
-              }
-            },
-            {
-              "dockerfile": "3.5/sdk/windowsservercore-1709",
-              "os": "windows",
-              "osVersion": "windowsservercore-1709",
-              "tags": {
-                "3.5-windowsservercore-1709": {}
-              }
-            }
-          ]
-        }
-      ]
     }
   ]
 }

--- a/netci.groovy
+++ b/netci.groovy
@@ -35,7 +35,7 @@ platformList.each { platform ->
             Utilities.setMachineAffinity(newJob, 'Windows_2016', 'latest-docker')
         }
         Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-        Utilities.setJobTimeout(newJob, 180)
+        Utilities.setJobTimeout(newJob, 210)
         Utilities.addGithubPRTriggerForBranch(newJob, branch, "${platform} - ${version} Dockerfiles")
     }
 }

--- a/samples/aspnetapp/README.md
+++ b/samples/aspnetapp/README.md
@@ -2,7 +2,7 @@
 
 This [sample](Dockerfile) demonstrates how to use ASP.NET and Docker together. There are also instructions that demonstrate how to push the sample to [Azure Container Registry](../dotnetapp/push-image-to-acr.md) and test it with [Azure Container Instance](deploy-container-to-aci.md). The sample can also be used without Docker.
 
-The sample builds the application in a container based on the larger [.NET Framework SDK Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-build/). It builds the application and then copies the final build result into a Docker image based on the smaller [ASP.NET Runtime Docker image](https://hub.docker.com/r/microsoft/aspnet/). It uses Docker [multi-stage build](https://github.com/dotnet/announcements/issues/18) and [multi-arch tags](https://github.com/dotnet/announcements/issues/14).
+The sample builds the application in a container based on the larger [.NET Framework SDK Docker image](https://hub.docker.com/r/microsoft/dotnet-framework/). It builds the application and then copies the final build result into a Docker image based on the smaller [ASP.NET Runtime Docker image](https://hub.docker.com/r/microsoft/aspnet/). It uses Docker [multi-stage build](https://github.com/dotnet/announcements/issues/18) and [multi-arch tags](https://github.com/dotnet/announcements/issues/14).
 
 This sample requires [Docker 17.06](https://docs.docker.com/release-notes/docker-ce) or later of the [Docker client](https://store.docker.com/editions/community/docker-ce-desktop-windows).
 

--- a/samples/aspnetmvcapp/README.md
+++ b/samples/aspnetmvcapp/README.md
@@ -2,7 +2,7 @@
 
 This [sample](Dockerfile) demonstrates how to use ASP.NET MVC and Docker together. See [ASP.NET Docker Sample](../aspnetapp/README.md) and [.NET Framework Console Docker Sample](../dotnetapp/README.md) for using Docker in other scenarios.
 
-The sample builds the application in a container based on the larger [.NET Framework SDK Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-build/). It builds the application and then copies the final build result into a Docker image based on the smaller [ASP.NET Runtime Docker image](https://hub.docker.com/r/microsoft/aspnet/). It uses Docker [multi-stage build](https://github.com/dotnet/announcements/issues/18) and [multi-arch tags](https://github.com/dotnet/announcements/issues/14).
+The sample builds the application in a container based on the larger [.NET Framework SDK Docker image](https://hub.docker.com/r/microsoft/dotnet-framework/). It builds the application and then copies the final build result into a Docker image based on the smaller [ASP.NET Runtime Docker image](https://hub.docker.com/r/microsoft/aspnet/). It uses Docker [multi-stage build](https://github.com/dotnet/announcements/issues/18) and [multi-arch tags](https://github.com/dotnet/announcements/issues/14).
 
 This sample requires [Docker 17.06](https://docs.docker.com/release-notes/docker-ce) or later of the [Docker client](https://store.docker.com/editions/community/docker-ce-desktop-windows).
 

--- a/samples/dotnetapp/README.md
+++ b/samples/dotnetapp/README.md
@@ -2,7 +2,7 @@
 
 This [sample](Dockerfile) demonstrates how to use .NET Core and Docker together. It builds multiple projects and executes unit tests in a container. The sample can also be used without Docker.
 
-The sample builds the application in a container based on the larger [.NET Framework SDK Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-build/). It builds and [tests](dotnet-docker-unit-testing.md) the application and then copies the final build result into a Docker image based on the smaller [.NET Framework Runtime Docker image](https://hub.docker.com/r/microsoft/dotnet-framework/). It uses Docker [multi-stage build](https://github.com/dotnet/announcements/issues/18) and [multi-arch tags](https://github.com/dotnet/announcements/issues/14).
+The sample builds the application in a container based on the larger [.NET Framework SDK Docker image](https://hub.docker.com/r/microsoft/dotnet-framework/). It builds and [tests](dotnet-docker-unit-testing.md) the application and then copies the final build result into a Docker image based on the smaller [.NET Framework Runtime Docker image](https://hub.docker.com/r/microsoft/dotnet-framework/). It uses Docker [multi-stage build](https://github.com/dotnet/announcements/issues/18) and [multi-arch tags](https://github.com/dotnet/announcements/issues/14).
 
 This sample requires [Docker 17.06](https://docs.docker.com/release-notes/docker-ce) or later of the [Docker client](https://store.docker.com/editions/community/docker-ce-desktop-windows).
 
@@ -127,5 +127,4 @@ Docs and More Information:
 
 * [microsoft/aspnet](https://hub.docker.com/r/microsoft/aspnet/) for ASP.NET Web Forms and MVC images.
 * [microsoft/dotnet-framework](https://hub.docker.com/r/microsoft/dotnet-framework/) for .NET Framework images.
-* [microsoft/dotnet-framework-build](https://hub.docker.com/r/microsoft/dotnet-framework-build/) for building .NET Framework applications with Docker.
 * [microsoft/dotnet-framework-samples](https://hub.docker.com/r/microsoft/dotnet-framework-samples/) for .NET Framework and ASP.NET sample images.

--- a/samples/wcfapp/README.md
+++ b/samples/wcfapp/README.md
@@ -1,7 +1,7 @@
 # WCF Docker Sample
 This sample demonstrates how to dockerize WCF services, either IIS-hosted or self-hosted. A simple "hello world" service contract is used in all samples for both HTTP and NET.TCP transport bindings. The sample can also be used without Docker.
 
-The sample builds the application in a container based on the larger [.NET Framework SDK Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-build/). It builds the application and then copies the final build result into a Docker image based on the smaller [WCF Runtime Docker image](https://hub.docker.com/r/microsoft/wcf/) or [.NET Framework Runtime Docker image](https://hub.docker.com/r/microsoft/dotnet-framework/). It uses Docker [multi-stage build](https://github.com/dotnet/announcements/issues/18) and [multi-arch tags](https://github.com/dotnet/announcements/issues/14).
+The sample builds the application in a container based on the larger [.NET Framework SDK Docker image](https://hub.docker.com/r/microsoft/dotnet-framework/). It builds the application and then copies the final build result into a Docker image based on the smaller [WCF Runtime Docker image](https://hub.docker.com/r/microsoft/wcf/) or [.NET Framework Runtime Docker image](https://hub.docker.com/r/microsoft/dotnet-framework/). It uses Docker [multi-stage build](https://github.com/dotnet/announcements/issues/18) and [multi-arch tags](https://github.com/dotnet/announcements/issues/14).
 
 This sample requires [Docker 17.06](https://docs.docker.com/release-notes/docker-ce) or later of the [Docker client](https://store.docker.com/editions/community/docker-ce-desktop-windows).
 
@@ -137,5 +137,4 @@ Docs and More Information:
 * [microsoft/wcf](https://hub.docker.com/r/microsoft/wcf/) for WCF images.
 * [microsoft/aspnet](https://hub.docker.com/r/microsoft/aspnet/) for ASP.NET Web Forms and MVC images.
 * [microsoft/dotnet-framework](https://hub.docker.com/r/microsoft/dotnet-framework/) for .NET Framework images.
-* [microsoft/dotnet-framework-build](https://hub.docker.com/r/microsoft/dotnet-framework-build/) for building .NET Framework applications with Docker.
 * [microsoft/dotnet-framework-samples](https://hub.docker.com/r/microsoft/dotnet-framework-samples/) for .NET Framework and ASP.NET sample images.


### PR DESCRIPTION
This is in preparation for deleting the repo which was announced in https://github.com/Microsoft/dotnet-framework-docker/issues/125

Fixes https://github.com/Microsoft/dotnet-framework-docker/issues/201