### PR TITLE
Fix broken Dockerfile links in readmes

### DIFF
--- a/README.runtime.md
+++ b/README.runtime.md
@@ -44,27 +44,27 @@ docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 
 ## Windows Server 2019 amd64 tags
 
-- [`4.7.2-20190312-windowsservercore-ltsc2019`, `4.7.2-windowsservercore-ltsc2019`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile)
-- [`3.5-20190312-windowsservercore-ltsc2019`, `3.5-windowsservercore-ltsc2019`, `3.5` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.5/runtime/windowsservercore-ltsc2019/Dockerfile)
+- [`4.7.2-20190312-windowsservercore-ltsc2019`, `4.7.2-windowsservercore-ltsc2019`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile)
+- [`3.5-20190312-windowsservercore-ltsc2019`, `3.5-windowsservercore-ltsc2019`, `3.5` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-ltsc2019/Dockerfile)
 
 ## Windows Server, version 1803 amd64 tags
 
-- [`4.7.2-20190312-windowsservercore-1803`, `4.7.2-windowsservercore-1803`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.2/runtime/windowsservercore-1803/Dockerfile)
-- [`3.5-20190312-windowsservercore-1803`, `3.5-windowsservercore-1803`, `3.5` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.5/runtime/windowsservercore-1803/Dockerfile)
+- [`4.7.2-20190312-windowsservercore-1803`, `4.7.2-windowsservercore-1803`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-1803/Dockerfile)
+- [`3.5-20190312-windowsservercore-1803`, `3.5-windowsservercore-1803`, `3.5` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-1803/Dockerfile)
 
 ## Windows Server, version 1709 amd64 tags
 
-- [`4.7.2-20190312-windowsservercore-1709`, `4.7.2-windowsservercore-1709`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.2/runtime/windowsservercore-1709/Dockerfile)
-- [`4.7.1-20190312-windowsservercore-1709`, `4.7.1-windowsservercore-1709`, `4.7.1` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.1/runtime/windowsservercore-1709/Dockerfile)
-- [`3.5-20190312-windowsservercore-1709`, `3.5-windowsservercore-1709`, `3.5` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.5/runtime/windowsservercore-1709/Dockerfile)
+- [`4.7.2-20190312-windowsservercore-1709`, `4.7.2-windowsservercore-1709`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-1709/Dockerfile)
+- [`4.7.1-20190312-windowsservercore-1709`, `4.7.1-windowsservercore-1709`, `4.7.1` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/runtime/windowsservercore-1709/Dockerfile)
+- [`3.5-20190312-windowsservercore-1709`, `3.5-windowsservercore-1709`, `3.5` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-1709/Dockerfile)
 
 ## Windows Server 2016 amd64 tags
 
-- [`4.7.2-20190312-windowsservercore-ltsc2016`, `4.7.2-windowsservercore-ltsc2016`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile)
-- [`4.7.1-20190312-windowsservercore-ltsc2016`, `4.7.1-windowsservercore-ltsc2016`, `4.7.1` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile)
-- [`4.7-20190312-windowsservercore-ltsc2016`, `4.7-windowsservercore-ltsc2016`, `4.7` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7/runtime/windowsservercore-ltsc2016/Dockerfile)
-- [`4.6.2-20190312-windowsservercore-ltsc2016`, `4.6.2-windowsservercore-ltsc2016`, `4.6.2` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile)
-- [`3.5-20190312-windowsservercore-ltsc2016`, `3.5-windowsservercore-ltsc2016`, `3.5` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.5/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7.2-20190312-windowsservercore-ltsc2016`, `4.7.2-windowsservercore-ltsc2016`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7.1-20190312-windowsservercore-ltsc2016`, `4.7.1-windowsservercore-ltsc2016`, `4.7.1` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7-20190312-windowsservercore-ltsc2016`, `4.7-windowsservercore-ltsc2016`, `4.7` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`4.6.2-20190312-windowsservercore-ltsc2016`, `4.6.2-windowsservercore-ltsc2016`, `4.6.2` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile)
+- [`3.5-20190312-windowsservercore-ltsc2016`, `3.5-windowsservercore-ltsc2016`, `3.5` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-ltsc2016/Dockerfile)
 
 For more information about these images and their history, please see [(`microsoft/dotnet-framework-docker`)](https://github.com/Microsoft/dotnet-framework-docker). These images are updated via [pull requests to the `Microsoft/dotnet-framework-docker` GitHub repo](https://github.com/Microsoft/dotnet-framework-docker/pulls).
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -72,31 +72,31 @@ docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 mcr.microsoft
 
 ## Windows Server 2019 amd64 tags
 
-- [`dotnetapp-windowsservercore-ltsc2019`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-windowsservercore-ltsc2019`, `aspnetapp` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
-- [`wcfservice-windowsservercore-ltsc2019`, `wcfservice` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/wcfapp/Dockerfile.web)
-- [`wcfclient-windowsservercore-ltsc2019`, `wcfclient` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/wcfapp/Dockerfile.client)
+- [`dotnetapp-windowsservercore-ltsc2019`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
+- [`aspnetapp-windowsservercore-ltsc2019`, `aspnetapp` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`wcfservice-windowsservercore-ltsc2019`, `wcfservice` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
+- [`wcfclient-windowsservercore-ltsc2019`, `wcfclient` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
 
 ## Windows Server, version 1803 amd64 tags
 
-- [`dotnetapp-windowsservercore-1803`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-windowsservercore-1803`, `aspnetapp` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
-- [`wcfservice-windowsservercore-1803`, `wcfservice` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/wcfapp/Dockerfile.web)
-- [`wcfclient-windowsservercore-1803`, `wcfclient` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/wcfapp/Dockerfile.client)
+- [`dotnetapp-windowsservercore-1803`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
+- [`aspnetapp-windowsservercore-1803`, `aspnetapp` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`wcfservice-windowsservercore-1803`, `wcfservice` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
+- [`wcfclient-windowsservercore-1803`, `wcfclient` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
 
 ## Windows Server, version 1709 amd64 tags
 
-- [`dotnetapp-windowsservercore-1709`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-windowsservercore-1709`, `aspnetapp` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
-- [`wcfservice-windowsservercore-1709`, `wcfservice` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/wcfapp/Dockerfile.web)
-- [`wcfclient-windowsservercore-1709`, `wcfclient` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/wcfapp/Dockerfile.client)
+- [`dotnetapp-windowsservercore-1709`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
+- [`aspnetapp-windowsservercore-1709`, `aspnetapp` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`wcfservice-windowsservercore-1709`, `wcfservice` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
+- [`wcfclient-windowsservercore-1709`, `wcfclient` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
 
 ## Windows Server 2016 amd64 tags
 
-- [`dotnetapp-windowsservercore-ltsc2016`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/dotnetapp/Dockerfile)
-- [`aspnetapp-windowsservercore-ltsc2016`, `aspnetapp` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/aspnetapp/Dockerfile)
-- [`wcfservice-windowsservercore-ltsc2016`, `wcfservice` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/wcfapp/Dockerfile.web)
-- [`wcfclient-windowsservercore-ltsc2016`, `wcfclient` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/samples/wcfapp/Dockerfile.client)
+- [`dotnetapp-windowsservercore-ltsc2016`, `dotnetapp`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
+- [`aspnetapp-windowsservercore-ltsc2016`, `aspnetapp` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
+- [`wcfservice-windowsservercore-ltsc2016`, `wcfservice` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
+- [`wcfclient-windowsservercore-ltsc2016`, `wcfclient` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
 
 # Support
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -50,25 +50,25 @@ The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framewor
 
 ## Windows Server 2019 amd64 tags
 
-- [`4.7.2-20190312-windowsservercore-ltsc2019`, `4.7.2-windowsservercore-ltsc2019`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile)
-- [`3.5-20190312-windowsservercore-ltsc2019`, `3.5-windowsservercore-ltsc2019`, `3.5` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.5/sdk/windowsservercore-ltsc2019/Dockerfile)
+- [`4.7.2-20190312-windowsservercore-ltsc2019`, `4.7.2-windowsservercore-ltsc2019`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile)
+- [`3.5-20190312-windowsservercore-ltsc2019`, `3.5-windowsservercore-ltsc2019`, `3.5` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2019/Dockerfile)
 
 ## Windows Server, version 1803 amd64 tags
 
-- [`4.7.2-20190312-windowsservercore-1803`, `4.7.2-windowsservercore-1803`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.2/sdk/windowsservercore-1803/Dockerfile)
-- [`3.5-20190312-windowsservercore-1803`, `3.5-windowsservercore-1803`, `3.5` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.5/sdk/windowsservercore-1803/Dockerfile)
+- [`4.7.2-20190312-windowsservercore-1803`, `4.7.2-windowsservercore-1803`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-1803/Dockerfile)
+- [`3.5-20190312-windowsservercore-1803`, `3.5-windowsservercore-1803`, `3.5` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1803/Dockerfile)
 
 ## Windows Server, version 1709 amd64 tags
 
-- [`4.7.2-20190312-windowsservercore-1709`, `4.7.2-windowsservercore-1709`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.2/sdk/windowsservercore-1709/Dockerfile)
-- [`4.7.1-20190312-windowsservercore-1709`, `4.7.1-windowsservercore-1709`, `4.7.1` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.1/sdk/windowsservercore-1709/Dockerfile)
-- [`3.5-20190312-windowsservercore-1709`, `3.5-windowsservercore-1709`, `3.5` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.5/sdk/windowsservercore-1709/Dockerfile)
+- [`4.7.2-20190312-windowsservercore-1709`, `4.7.2-windowsservercore-1709`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-1709/Dockerfile)
+- [`4.7.1-20190312-windowsservercore-1709`, `4.7.1-windowsservercore-1709`, `4.7.1` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/sdk/windowsservercore-1709/Dockerfile)
+- [`3.5-20190312-windowsservercore-1709`, `3.5-windowsservercore-1709`, `3.5` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1709/Dockerfile)
 
 ## Windows Server 2016 amd64 tags
 
-- [`4.7.2-20190312-windowsservercore-ltsc2016`, `4.7.2-windowsservercore-ltsc2016`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile)
-- [`4.7.1-20190312-windowsservercore-ltsc2016`, `4.7.1-windowsservercore-ltsc2016`, `4.7.1` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile)
-- [`3.5-20190312-windowsservercore-ltsc2016`, `3.5-windowsservercore-ltsc2016`, `3.5` (*Dockerfile*)](https://github.com/dotnet/dotnet-docker/blob/master/3.5/sdk/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7.2-20190312-windowsservercore-ltsc2016`, `4.7.2-windowsservercore-ltsc2016`, `4.7.2`, `latest` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile)
+- [`4.7.1-20190312-windowsservercore-ltsc2016`, `4.7.1-windowsservercore-ltsc2016`, `4.7.1` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile)
+- [`3.5-20190312-windowsservercore-ltsc2016`, `3.5-windowsservercore-ltsc2016`, `3.5` (*Dockerfile*)](https://github.com/Microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2016/Dockerfile)
 
 For more information about these images and their history, please see [(`microsoft/dotnet-framework-docker`)](https://github.com/Microsoft/dotnet-framework-docker). These images are updated via [pull requests to the `Microsoft/dotnet-framework-docker` GitHub repo](https://github.com/Microsoft/dotnet-framework-docker/pulls).
 

--- a/scripts/Get-TagsDocumentation.ps1
+++ b/scripts/Get-TagsDocumentation.ps1
@@ -39,7 +39,7 @@ function GenerateDoc {
         + " --repo $Repo" `
         + " --template ./scripts/documentation-templates/$Template" `
         + " $skipValidationOption" `
-        + " https://github.com/dotnet/dotnet-docker/blob/master"
+        + " https://github.com/Microsoft/dotnet-framework-docker/blob/master"
 
     & "$PSScriptRoot/Invoke-ImageBuilder.ps1" `
         -ImageBuilderArgs $imageBuilderArgs `


### PR DESCRIPTION
This was a regression introduced during the move to MCR.

@dotnet-bot skip ci please.