### PR TITLE
Delete temp folder after installing .NET Fx

### DIFF
--- a/3.5/runtime/windowsservercore-1803/Dockerfile
+++ b/3.5/runtime/windowsservercore-1803/Dockerfile
@@ -13,7 +13,8 @@ RUN powershell -Command `
         Expand-Archive microsoft-windows-netfx3.zip; `
         Remove-Item -Force microsoft-windows-netfx3.zip; `
         Add-WindowsPackage -Online -PackagePath .\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab; `
-        Remove-Item -Force -Recurse microsoft-windows-netfx3
+        Remove-Item -Force -Recurse microsoft-windows-netfx3; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `

--- a/3.5/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -13,7 +13,8 @@ RUN powershell -Command `
         Expand-Archive microsoft-windows-netfx3.zip; `
         Remove-Item -Force microsoft-windows-netfx3.zip; `
         Add-WindowsPackage -Online -PackagePath .\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package.cab; `
-        Remove-Item -Force -Recurse microsoft-windows-netfx3
+        Remove-Item -Force -Recurse microsoft-windows-netfx3; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `

--- a/3.5/runtime/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/runtime/windowsservercore-ltsc2019/Dockerfile
@@ -13,7 +13,8 @@ RUN powershell -Command `
         Expand-Archive microsoft-windows-netfx3.zip; `
         Remove-Item -Force microsoft-windows-netfx3.zip; `
         Add-WindowsPackage -Online -PackagePath .\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab; `
-        Remove-Item -Force -Recurse microsoft-windows-netfx3
+        Remove-Item -Force -Recurse microsoft-windows-netfx3; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN curl -SL --output patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2019/02/windows10.0-kb4486553-x64_0c3111b07c3e2a33d66fed4a66c67dec989950a0.msu `

--- a/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -6,7 +6,8 @@ FROM $REPO:3.5-windowsservercore-ltsc2016
 # Install .NET 4.7.2
 RUN powershell Invoke-WebRequest -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" -OutFile dotnet-framework-installer.exe & `
     .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe
+    del .\dotnet-framework-installer.exe & `
+    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # ngen .NET Fx
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `

--- a/4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -5,7 +5,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # Install .NET 4.7.1
 RUN powershell Invoke-WebRequest -Uri "https://download.microsoft.com/download/9/E/6/9E63300C-0941-4B45-A0EC-0008F96DD480/NDP471-KB4033342-x86-x64-AllOS-ENU.exe" -OutFile dotnet-framework-installer.exe & `
     .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe
+    del .\dotnet-framework-installer.exe & `
+    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `

--- a/4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -5,7 +5,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # Install .NET 4.7.2
 RUN powershell Invoke-WebRequest -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" -OutFile dotnet-framework-installer.exe & `
     .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe
+    del .\dotnet-framework-installer.exe & `
+    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `

--- a/4.7/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -5,7 +5,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # Install .NET 4.7
 RUN powershell Invoke-WebRequest -Uri "https://download.microsoft.com/download/D/D/3/DD35CC25-6E9C-484B-A746-C5BE0C923290/NDP47-KB3186497-x86-x64-AllOS-ENU.exe" -OutFile dotnet-framework-installer.exe & `
     .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe
+    del .\dotnet-framework-installer.exe & `
+    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `


### PR DESCRIPTION
.NET Fx leaves files in the TEMP folder after running the installer.  These should be cleaned up.

Fixes #255 