### PR TITLE
Reduce usage of SHELL command

### DIFF
--- a/3.5/sdk/windowsservercore-1803/Dockerfile
+++ b/3.5/sdk/windowsservercore-1803/Dockerfile
@@ -3,44 +3,49 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-1803
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        New-Item -Type Directory $Env:ProgramFiles\NuGet; `
+        Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
-    # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
-    # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
+        Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
+        Remove-Item -Force vs_TestAgent.exe; `
+        # Install VS Build Tools
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+        # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+        setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
+        Start-Process vs_BuildTools.exe `
+            -ArgumentList `
+                '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
+                '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
+                '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
+                '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
+                '--quiet', '--norestart', '--nocache' `
+            -NoNewWindow -Wait; `
+        Remove-Item -Force vs_buildtools.exe; `
+        Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
+        Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `

--- a/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -12,45 +12,50 @@ RUN powershell Invoke-WebRequest -Uri "https://download.microsoft.com/download/6
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
     \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
-# Can't set SHELL prior to installing 4.7.2 runtime - PowerShell being loaded prevents GAC from getting updated without restart
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        New-Item -Type Directory $Env:ProgramFiles\NuGet; `
+        Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
-    # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
-    # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
+        Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
+        Remove-Item -Force vs_TestAgent.exe; `
+        # Install VS Build Tools
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+        # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+        setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
+        Start-Process vs_BuildTools.exe `
+            -ArgumentList `
+                '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
+                '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
+                '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
+                '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
+                '--quiet', '--norestart', '--nocache' `
+            -NoNewWindow -Wait; `
+        Remove-Item -Force vs_buildtools.exe; `
+        Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
+        Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -3,44 +3,50 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-ltsc2019
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        New-Item -Type Directory $Env:ProgramFiles\NuGet; `
+        Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
-    # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
-    # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
+        Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
+        Remove-Item -Force vs_TestAgent.exe; `
+        # Install VS Build Tools
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+        # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+        setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
+        Start-Process vs_BuildTools.exe `
+            -ArgumentList `
+                '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
+                '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
+                '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
+                '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
+                '--quiet', '--norestart', '--nocache' `
+            -NoNewWindow -Wait; `
+        Remove-Item -Force vs_buildtools.exe; `
+        Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
+        Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `

--- a/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -3,44 +3,50 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.7.1-windowsservercore-ltsc2016
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        New-Item -Type Directory $Env:ProgramFiles\NuGet; `
+        Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
-    # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
-    # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.1.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
+        Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
+        Remove-Item -Force vs_TestAgent.exe; `
+        # Install VS Build Tools
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+        # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+        setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
+        Start-Process vs_BuildTools.exe `
+            -ArgumentList `
+                '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
+                '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
+                '--add', 'Microsoft.Net.Component.4.7.1.SDK', `
+                '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
+                '--quiet', '--norestart', '--nocache' `
+            -NoNewWindow -Wait; `
+        Remove-Item -Force vs_buildtools.exe; `
+        Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
+        Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.1.SDK being 64 bit ngen'ed
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.1 Tools\SecAnnotate.exe" `

--- a/4.7.2/sdk/windowsservercore-1803/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-1803/Dockerfile
@@ -3,43 +3,49 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.7.2-windowsservercore-1803
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        New-Item -Type Directory $Env:ProgramFiles\NuGet; `
+        Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
-    # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
-    # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
+        Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
+        Remove-Item -Force vs_TestAgent.exe; `
+        # Install VS Build Tools
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+        # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+        setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
+        Start-Process vs_BuildTools.exe `
+            -ArgumentList `
+                '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
+                '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
+                '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
+                '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
+                '--quiet', '--norestart', '--nocache' `
+            -NoNewWindow -Wait; `
+        Remove-Item -Force vs_buildtools.exe; `
+        Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
+        Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `

--- a/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -3,44 +3,50 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.7.2-windowsservercore-ltsc2016
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        New-Item -Type Directory $Env:ProgramFiles\NuGet; `
+        Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
-    # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
-    # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
+        Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
+        Remove-Item -Force vs_TestAgent.exe; `
+        # Install VS Build Tools
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+        # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+        setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
+        Start-Process vs_BuildTools.exe `
+            -ArgumentList `
+                '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
+                '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
+                '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
+                '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
+                '--quiet', '--norestart', '--nocache' `
+            -NoNewWindow -Wait; `
+        Remove-Item -Force vs_buildtools.exe; `
+        Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
+        Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `

--- a/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -3,44 +3,50 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.7.2-windowsservercore-ltsc2019
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        New-Item -Type Directory $Env:ProgramFiles\NuGet; `
+        Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
-    # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
-    # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/446c5efe-9162-41a1-b380-704c82d13afa/8c6c6f404ed99e477007f16a336f99a6/vs_testagent.exe -OutFile vs_TestAgent.exe; `
+        Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
+        Remove-Item -Force vs_TestAgent.exe; `
+        # Install VS Build Tools
+        Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/df649173-11e9-4af2-8eb7-0eb02ba8958a/cadb5bdac41e55bb8f6a6b7c45273370/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+        # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+        setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
+        Start-Process vs_BuildTools.exe `
+            -ArgumentList `
+                '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
+                '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
+                '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
+                '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
+                '--quiet', '--norestart', '--nocache' `
+            -NoNewWindow -Wait; `
+        Remove-Item -Force vs_buildtools.exe; `
+        Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
+        Remove-Item -Force -Recurse ${Env:TEMP}\*; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
+        Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
+        Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `


### PR DESCRIPTION
Using the SHELL command adds a layer to the image, so we should reduce the usage to only those that are necessary.  This is done by using the default shell, `cmd`, throughout the Dockerfile until we only have Powershell commands to execute (we want the image to use Powershell as the default shell) at which point we use `SHELL` to switch to Powershell.

Fixed #251.