### PR TITLE
Ensure that VS packages folder is not deleted as part of cleanup

### DIFF
--- a/3.5/sdk/windowsservercore-1803/Dockerfile
+++ b/3.5/sdk/windowsservercore-1803/Dockerfile
@@ -29,7 +29,6 @@ RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.c
     Remove-Item -Force vs_buildtools.exe; `
     Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
     Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
     Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets

--- a/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -40,7 +40,6 @@ RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.c
     Remove-Item -Force vs_buildtools.exe; `
     Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
     Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
     Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -29,7 +29,6 @@ RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.c
     Remove-Item -Force vs_buildtools.exe; `
     Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
     Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
     Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets

--- a/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -29,7 +29,6 @@ RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.c
     Remove-Item -Force vs_buildtools.exe; `
     Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
     Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
     Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets

--- a/4.7.2/sdk/windowsservercore-1803/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-1803/Dockerfile
@@ -29,7 +29,6 @@ RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.c
     Remove-Item -Force vs_buildtools.exe; `
     Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
     Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
     Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.04.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`

--- a/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -29,7 +29,6 @@ RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.c
     Remove-Item -Force vs_buildtools.exe; `
     Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
     Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
     Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets

--- a/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -29,7 +29,6 @@ RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.c
     Remove-Item -Force vs_buildtools.exe; `
     Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
     Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Microsoft\VisualStudio\Packages\"; `
     Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
 
 # Install web targets


### PR DESCRIPTION
It was originally thought that the VS packages folder could be deleted from the image to provide some savings on image size.  But that folder is actually needed in order to execute any VS installer commands.  For example, modifying the existing installation with an additional component.  Without the VS packages folder, the installer will not recognize VS as already being installed.  So we should revert the change to remove this folder.