### PR TITLE
Explicitly add component governance task

### DIFF
--- a/.vsts-pipelines/jobs/build-test-publish-repo.yml
+++ b/.vsts-pipelines/jobs/build-test-publish-repo.yml
@@ -11,6 +11,8 @@ jobs:
   pool: # linuxAmd64Pool
     name: Hosted Ubuntu 1604
   steps:
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: Component Detection
   - template: ../steps/init-docker-linux.yml
   - template: ../steps/generate-matrix.yml
     parameters:

--- a/.vsts-pipelines/variables/common.yml
+++ b/.vsts-pipelines/variables/common.yml
@@ -1,4 +1,6 @@
 variables:
 - template: docker-images.yml
+- name: skipComponentGovernanceDetection
+  value: true
 - group: DotNet-Docker-Common
 - group: DotNet-Docker-Secrets


### PR DESCRIPTION
Ensure that the Component Detection task is only executed once for the entire build. Currently it gets run in every job which is not necessary. These changes explicitly add it to one job and sets a variable to ensure it is not automatically added to other jobs.