### PR TITLE
Fix PR build runs

### DIFF
--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -15,7 +15,7 @@ jobs:
   pool: ${{ parameters.pool }}
   strategy:
     matrix: $[ ${{ parameters.matrix }} ]
-  timeoutInMinutes: 240
+  timeoutInMinutes: 300
   variables:
     osVersion: ${{ parameters.osVersion }}
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/.vsts-pipelines/jobs/build-images.yml
+++ b/.vsts-pipelines/jobs/build-images.yml
@@ -15,7 +15,7 @@ jobs:
   pool: ${{ parameters.pool }}
   strategy:
     matrix: $[ ${{ parameters.matrix }} ]
-  timeoutInMinutes: 300
+  timeoutInMinutes: 330
   variables:
     osVersion: ${{ parameters.osVersion }}
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/.vsts-pipelines/steps/test-images-windows-client.yml
+++ b/.vsts-pipelines/steps/test-images-windows-client.yml
@@ -17,7 +17,7 @@ steps:
   displayName: Cleanup Old Test Results
 - powershell: >
     ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)*
+    -VersionFilter $(dotnetVersion)
     -OSFilter $(osVariant)
     $(optionalTestArgs)
   displayName: Test Images

--- a/manifest.json
+++ b/manifest.json
@@ -125,8 +125,6 @@
                 {
                   "name": "pr-build",
                   "dependencies": [
-                    "$(Repo:runtime):4.7.2-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.7.2-windowsservercore-ltsc2016",
                     "$(Repo:runtime):4.8-windowsservercore-ltsc2016",
                     "$(Repo:sdk):4.8-windowsservercore-ltsc2016"
                   ]

--- a/manifest.json
+++ b/manifest.json
@@ -127,8 +127,6 @@
                   "dependencies": [
                     "$(Repo:runtime):4.7.2-windowsservercore-ltsc2016",
                     "$(Repo:sdk):4.7.2-windowsservercore-ltsc2016",
-                    "$(Repo:runtime):4.7.2-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.7.2-windowsservercore-ltsc2016",
                     "$(Repo:runtime):4.8-windowsservercore-ltsc2016",
                     "$(Repo:sdk):4.8-windowsservercore-ltsc2016"
                   ]
@@ -154,8 +152,6 @@
                 {
                   "name": "pr-build",
                   "dependencies": [
-                    "$(Repo:runtime):4.7.1-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.7.1-windowsservercore-ltsc2016",
                     "$(Repo:runtime):4.7.2-windowsservercore-ltsc2016",
                     "$(Repo:sdk):4.7.2-windowsservercore-ltsc2016",
                     "$(Repo:runtime):4.8-windowsservercore-ltsc2016",
@@ -183,8 +179,6 @@
                 {
                   "name": "pr-build",
                   "dependencies": [
-                    "$(Repo:runtime):4.7.1-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.7.1-windowsservercore-ltsc2016",
                     "$(Repo:runtime):4.7.2-windowsservercore-ltsc2016",
                     "$(Repo:sdk):4.7.2-windowsservercore-ltsc2016",
                     "$(Repo:runtime):4.8-windowsservercore-ltsc2016",

--- a/manifest.json
+++ b/manifest.json
@@ -152,8 +152,8 @@
                 {
                   "name": "pr-build",
                   "dependencies": [
-                    "$(Repo:runtime):4.7.2-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.7.2-windowsservercore-ltsc2016",
+                    "$(Repo:runtime):4.7.1-windowsservercore-ltsc2016",
+                    "$(Repo:sdk):4.7.1-windowsservercore-ltsc2016",
                     "$(Repo:runtime):4.8-windowsservercore-ltsc2016",
                     "$(Repo:sdk):4.8-windowsservercore-ltsc2016"
                   ]

--- a/scripts/Invoke-CleanupDocker.ps1
+++ b/scripts/Invoke-CleanupDocker.ps1
@@ -1,6 +1,8 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Restart-Service docker
+
 docker ps -a -q | ForEach-Object { docker rm -f $_ }
 
 docker volume prune -f

--- a/scripts/Invoke-CleanupDocker.ps1
+++ b/scripts/Invoke-CleanupDocker.ps1
@@ -1,8 +1,6 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Restart-Service docker
-
 docker ps -a -q | ForEach-Object { docker rm -f $_ }
 
 docker volume prune -f

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
@@ -32,7 +32,6 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                 new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_LTSC2019 },
                 new ImageDescriptor { RuntimeVersion = "4.6.2", BuildVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
                 new ImageDescriptor { RuntimeVersion = "4.6.2", BuildVersion = "4.8", OsVariant = WSC_LTSC2016 },
-                new ImageDescriptor { RuntimeVersion = "4.7", BuildVersion = "4.7.1", OsVariant = WSC_LTSC2016 },
                 new ImageDescriptor { RuntimeVersion = "4.7", BuildVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
                 new ImageDescriptor { RuntimeVersion = "4.7", BuildVersion = "4.8", OsVariant = WSC_LTSC2016 },
                 new ImageDescriptor { RuntimeVersion = "4.7.1", BuildVersion = "4.7.1", OsVariant = WSC_LTSC2016 },

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                 new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_LTSC2019 },
                 new ImageDescriptor { RuntimeVersion = "4.6.2", BuildVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
                 new ImageDescriptor { RuntimeVersion = "4.6.2", BuildVersion = "4.8", OsVariant = WSC_LTSC2016 },
-                new ImageDescriptor { RuntimeVersion = "4.7", BuildVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
+                new ImageDescriptor { RuntimeVersion = "4.7", BuildVersion = "4.7.1", OsVariant = WSC_LTSC2016 },
                 new ImageDescriptor { RuntimeVersion = "4.7", BuildVersion = "4.8", OsVariant = WSC_LTSC2016 },
                 new ImageDescriptor { RuntimeVersion = "4.7.1", BuildVersion = "4.7.1", OsVariant = WSC_LTSC2016 },
                 new ImageDescriptor { RuntimeVersion = "4.7.1", BuildVersion = "4.8", OsVariant = WSC_LTSC2016 },


### PR DESCRIPTION
The PR build is having issues completing in a reasonable amount of time.  I've trimmed the test matrix a bit to cut down on the number of images that need to be built in a given leg but still provide decent enough coverage of runtime/sdk combos on the whole.

I also found that there was an issue in the definition of the versionFilter parameter for tests that was causing the 4.7 leg to attempt to run tests for 4.7.1 and 4.7.2.  This is due to the '*' character that was appended to the 4.7 string causing it to match those other versions.  I've removed it so that it will only match on the exact version string.