### PR TITLE
Update timestamp to get re-released Windows base image

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "readmePath": "README.md",
   "registry": "mcr.microsoft.com",
   "variables": {
-    "RuntimeReleaseDateStamp": "20190514",
-    "SdkReleaseDateStamp": "20190514"
+    "RuntimeReleaseDateStamp": "20190520",
+    "SdkReleaseDateStamp": "20190520"
   },
   "repos": [
     {


### PR DESCRIPTION
Windows re-released an update for last week's patch Tuesday.  Updating the timestamps so we can release updated images.