### PR TITLE
Dockerfile refactoring

### DIFF
--- a/3.5/runtime/windowsservercore-1803/Dockerfile
+++ b/3.5/runtime/windowsservercore-1803/Dockerfile
@@ -3,34 +3,23 @@
 FROM mcr.microsoft.com/windows/servercore:1803
 
 # Install .NET Fx 3.5
-RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1803.zip" `
-            -OutFile microsoft-windows-netfx3.zip; `
-        Expand-Archive microsoft-windows-netfx3.zip; `
-        Remove-Item -Force microsoft-windows-netfx3.zip; `
-        Add-WindowsPackage -Online -PackagePath .\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab; `
-        Remove-Item -Force -Recurse microsoft-windows-netfx3; `
-        Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1803.zip `
+    && tar -zxf microsoft-windows-netfx3.zip `
+    && del /F /Q microsoft-windows-netfx3.zip `
+    && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+    && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
-RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri "http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/05/windows10.0-kb4499167-x64_23697fcf76f2d755b492415eb89aa573c8804765.msu" `
-            -OutFile patch.msu; `
-        New-Item -Type Directory patch; `
-        Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
-        Remove-Item -Force patch.msu; `
-        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-kb4499167-x64.cab; `
-        Remove-Item -Force -Recurse \patch
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/05/windows10.0-kb4499167-x64_23697fcf76f2d755b492415eb89aa573c8804765.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4499167-x64.cab `
+    && rmdir /S /Q patch
 
 # ngen .NET 3.5 Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update & `
-    \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
+    && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/3.5/runtime/windowsservercore-1903/Dockerfile
+++ b/3.5/runtime/windowsservercore-1903/Dockerfile
@@ -3,20 +3,15 @@
 FROM mcr.microsoft.com/windows/servercore:1903
 
 # Install .NET Fx 3.5
-RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1903.zip" `
-            -OutFile microsoft-windows-netfx3.zip; `
-        Expand-Archive microsoft-windows-netfx3.zip; `
-        Remove-Item -Force microsoft-windows-netfx3.zip; `
-        Add-WindowsPackage -Online -PackagePath .\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab; `
-        Remove-Item -Force -Recurse microsoft-windows-netfx3; `
-        Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1903.zip `
+    && tar -zxf microsoft-windows-netfx3.zip `
+    && del /F /Q microsoft-windows-netfx3.zip `
+    && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+    && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
-# ngen .NET Fx
+# ngen .NET 3.5 Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update & `
-    \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
+    && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/3.5/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -11,28 +11,27 @@ RUN powershell -Command `
             -Uri "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-ltsc2016.zip" `
             -OutFile microsoft-windows-netfx3.zip; `
         Expand-Archive microsoft-windows-netfx3.zip; `
-        Remove-Item -Force microsoft-windows-netfx3.zip; `
-        Add-WindowsPackage -Online -PackagePath .\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package.cab; `
-        Remove-Item -Force -Recurse microsoft-windows-netfx3; `
-        Remove-Item -Force -Recurse ${Env:TEMP}\*
+    && del microsoft-windows-netfx3.zip `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package.cab `
+    && rmdir /S /Q microsoft-windows-netfx3 `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri "http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/05/windows10.0-kb4494440-x64_390f926659a23a56cc9cbb331e5940e132ad257d.msu" `
             -OutFile patch.msu; `
-        New-Item -Type Directory patch; `
-        Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
-        Remove-Item -Force patch.msu; `
-        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-kb4494440-x64.cab; `
-        Remove-Item -Force -Recurse \patch
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del patch.msu `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4494440-x64.cab `
+    && rmdir /S /Q patch
 
 # ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update & `
-    \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
+    && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/3.5/runtime/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/runtime/windowsservercore-ltsc2019/Dockerfile
@@ -3,21 +3,15 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 # Install .NET Fx 3.5
-RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri "https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1809.zip" `
-            -OutFile microsoft-windows-netfx3.zip; `
-        Expand-Archive microsoft-windows-netfx3.zip; `
-        Remove-Item -Force microsoft-windows-netfx3.zip; `
-        Add-WindowsPackage -Online -PackagePath .\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab; `
-        Remove-Item -Force -Recurse microsoft-windows-netfx3; `
-        Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1809.zip `
+    && tar -zxf microsoft-windows-netfx3.zip `
+    && del /F /Q microsoft-windows-netfx3.zip `
+    && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+    && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
-RUN curl -SL --output patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/05/windows10.0-kb4495618-x64_2d3245836cfd2467024a907947837e7879463a3b.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/05/windows10.0-kb4495618-x64_2d3245836cfd2467024a907947837e7879463a3b.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
@@ -26,5 +20,6 @@ RUN curl -SL --output patch.msu http://download.windowsupdate.com/d/msdownload/u
 
 # ngen .NET 3.5 Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update & `
-    \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
+    && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/3.5/sdk/windowsservercore-1803/Dockerfile
+++ b/3.5/sdk/windowsservercore-1803/Dockerfile
@@ -18,10 +18,12 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
-# Install VS Test Agent
-RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
@@ -32,6 +34,8 @@ RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/down
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    #Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/3.5/sdk/windowsservercore-1803/Dockerfile
+++ b/3.5/sdk/windowsservercore-1803/Dockerfile
@@ -18,6 +18,7 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `

--- a/3.5/sdk/windowsservercore-1803/Dockerfile
+++ b/3.5/sdk/windowsservercore-1803/Dockerfile
@@ -4,78 +4,70 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-1803
 
 # Install .NET 4.8 Fx
-RUN powershell -Command `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe" -OutFile dotnet-framework-installer.exe & `
-    .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe & `
-    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
+    && .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # ngen .NET Fx
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-
-# Can't set SHELL prior to installing 4.8 runtime - PowerShell being loaded prevents GAC from getting updated without restart
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip -OutFile sdk_tools48.zip; `
-    Expand-Archive sdk_tools48.zip; `
-    Start-Process msiexec -ArgumentList '/i', 'sdk_tools48\sdk_tools48.msi', '/quiet', 'VSEXTUI=1' -NoNewWindow -Wait; `
-    Remove-Item -Force -Recurse sdk_tools48; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48.zip `
+    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
+    && del sdk_tools48.msi `
+    && del sdk_tools48.zip `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from .NET Framework 4.8 SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -83,9 +75,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/3.5/sdk/windowsservercore-1903/Dockerfile
+++ b/3.5/sdk/windowsservercore-1903/Dockerfile
@@ -8,10 +8,12 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
-# Install VS Test Agent
-RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
@@ -22,6 +24,8 @@ RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/down
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    #Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/3.5/sdk/windowsservercore-1903/Dockerfile
+++ b/3.5/sdk/windowsservercore-1903/Dockerfile
@@ -3,66 +3,61 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-1903
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip -OutFile sdk_tools48.zip; `
-    Expand-Archive sdk_tools48.zip; `
-    Start-Process msiexec -ArgumentList '/i', 'sdk_tools48\sdk_tools48.msi', '/quiet', 'VSEXTUI=1' -NoNewWindow -Wait; `
-    Remove-Item -Force -Recurse sdk_tools48; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48.zip `
+    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
+    && del sdk_tools48.msi `
+    && del sdk_tools48.zip `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from .NET Framework 4.8 SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -70,9 +65,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/3.5/sdk/windowsservercore-1903/Dockerfile
+++ b/3.5/sdk/windowsservercore-1903/Dockerfile
@@ -8,6 +8,7 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `

--- a/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -29,8 +29,9 @@ RUN mkdir "%ProgramFiles%\NuGet" `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
             -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
-# Install VS Test Agent
-RUN powershell -Command `
+RUN `
+    # Install VS Test Agent
+    powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
@@ -38,6 +39,7 @@ RUN powershell -Command `
             -OutFile vs_TestAgent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -53,6 +55,8 @@ RUN powershell -Command `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    # Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -6,76 +6,101 @@ FROM $REPO:3.5-windowsservercore-ltsc2016
 # Install .NET 4.8 Fx
 RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe" -OutFile dotnet-framework-installer.exe & `
-    .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe & `
-    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe" `
+            -OutFile dotnet-framework-installer.exe `
+    && .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # ngen .NET Fx
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-
-# Can't set SHELL prior to installing 4.8 runtime - PowerShell being loaded prevents GAC from getting updated without restart
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe" `
+            -OutFile vs_TestAgent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe" `
+            -OutFile vs_BuildTools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip -OutFile sdk_tools48.zip; `
-    Expand-Archive sdk_tools48.zip; `
-    Start-Process msiexec -ArgumentList '/i', 'sdk_tools48\sdk_tools48.msi', '/quiet', 'VSEXTUI=1' -NoNewWindow -Wait; `
-    Remove-Item -Force -Recurse sdk_tools48; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip" `
+            -OutFile sdk_tools48.zip; `
+        Expand-Archive sdk_tools48.zip `
+    && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
+    && rmdir /S /Q sdk_tools48 `
+    && del sdk_tools48.zip `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+            -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip; `
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from .NET Framework 4.8 SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -83,9 +108,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -29,6 +29,7 @@ RUN mkdir "%ProgramFiles%\NuGet" `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
             -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     powershell -Command `

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -18,10 +18,12 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
-# Install VS Test Agent
-RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
@@ -32,6 +34,8 @@ RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/down
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    #Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -4,78 +4,70 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-ltsc2019
 
 # Install .NET 4.8 Fx
-RUN powershell -Command `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe" -OutFile dotnet-framework-installer.exe & `
-    .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe & `
-    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
+    && .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # ngen .NET Fx
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-
-# Can't set SHELL prior to installing 4.8 runtime - PowerShell being loaded prevents GAC from getting updated without restart
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip -OutFile sdk_tools48.zip; `
-    Expand-Archive sdk_tools48.zip; `
-    Start-Process msiexec -ArgumentList '/i', 'sdk_tools48\sdk_tools48.msi', '/quiet', 'VSEXTUI=1' -NoNewWindow -Wait; `
-    Remove-Item -Force -Recurse sdk_tools48; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48.zip `
+    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
+    && del sdk_tools48.msi `
+    && del sdk_tools48.zip `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from .NET Framework 4.8 SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -83,9 +75,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -18,6 +18,7 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `

--- a/4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -3,5 +3,5 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -3,26 +3,30 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 # Install .NET 4.7.1
-RUN powershell Invoke-WebRequest -Uri "https://download.microsoft.com/download/9/E/6/9E63300C-0941-4B45-A0EC-0008F96DD480/NDP471-KB4033342-x86-x64-AllOS-ENU.exe" -OutFile dotnet-framework-installer.exe & `
-    .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe & `
-    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://download.microsoft.com/download/9/E/6/9E63300C-0941-4B45-A0EC-0008F96DD480/NDP471-KB4033342-x86-x64-AllOS-ENU.exe" `
+            -OutFile dotnet-framework-installer.exe `
+    && start /w .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri "http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/05/windows10.0-kb4494440-x64_390f926659a23a56cc9cbb331e5940e132ad257d.msu" `
             -OutFile patch.msu; `
-        New-Item -Type Directory patch; `
-        Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
-        Remove-Item -Force patch.msu; `
-        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-kb4494440-x64.cab; `
-        Remove-Item -Force -Recurse \patch
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del patch.msu `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4494440-x64.cab `
+    && rmdir /S /Q patch
 
 # ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -3,60 +3,75 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.7.1-windowsservercore-ltsc2016
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+            -OutFile vs_TestAgent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
+            -OutFile vs_BuildTools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.1.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Net.Component.4.7.1.SDK ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+            -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip; `
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.1.SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.1 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.1 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.1 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.1 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -64,9 +79,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.1') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.1') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -13,8 +13,9 @@ RUN mkdir "%ProgramFiles%\NuGet" `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
             -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
-# Install VS Test Agent
-RUN powershell -Command `
+RUN `
+    # Install VS Test Agent
+    powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
@@ -22,6 +23,7 @@ RUN powershell -Command `
             -OutFile vs_TestAgent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -38,6 +40,8 @@ RUN powershell -Command `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    # Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -13,6 +13,7 @@ RUN mkdir "%ProgramFiles%\NuGet" `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
             -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     powershell -Command `

--- a/4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -3,26 +3,30 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 # Install .NET 4.7.2
-RUN powershell Invoke-WebRequest -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" -OutFile dotnet-framework-installer.exe & `
-    .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe & `
-    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" `
+            -OutFile dotnet-framework-installer.exe `
+    && start /w .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri "http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/05/windows10.0-kb4494440-x64_390f926659a23a56cc9cbb331e5940e132ad257d.msu" `
             -OutFile patch.msu; `
-        New-Item -Type Directory patch; `
-        Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
-        Remove-Item -Force patch.msu; `
-        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-kb4494440-x64.cab; `
-        Remove-Item -Force -Recurse \patch
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del patch.msu `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4494440-x64.cab `
+    && rmdir /S /Q patch
 
 # ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.7.2/sdk/windowsservercore-1803/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-1803/Dockerfile
@@ -8,10 +8,12 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
-# Install VS Test Agent
-RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
@@ -23,6 +25,8 @@ RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/down
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    # Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/4.7.2/sdk/windowsservercore-1803/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-1803/Dockerfile
@@ -3,59 +3,54 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.7.2-windowsservercore-1803
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Net.Component.4.7.2.SDK ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+# Install web targets
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -63,9 +58,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/4.7.2/sdk/windowsservercore-1803/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-1803/Dockerfile
@@ -8,6 +8,7 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `

--- a/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -13,8 +13,9 @@ RUN mkdir "%ProgramFiles%\NuGet" `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
             -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
-# Install VS Test Agent
-RUN powershell -Command `
+RUN `
+    # Install VS Test Agent
+    powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
@@ -22,6 +23,7 @@ RUN powershell -Command `
             -OutFile vs_TestAgent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -38,6 +40,8 @@ RUN powershell -Command `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    # Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -3,60 +3,75 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.7.2-windowsservercore-ltsc2016
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+            -OutFile vs_TestAgent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
+            -OutFile vs_BuildTools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Net.Component.4.7.2.SDK ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+            -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip; `
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -64,9 +79,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -13,6 +13,7 @@ RUN mkdir "%ProgramFiles%\NuGet" `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
             -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     powershell -Command `

--- a/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -8,10 +8,12 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
-# Install VS Test Agent
-RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
@@ -23,6 +25,8 @@ RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/down
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    # Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -3,60 +3,54 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.7.2-windowsservercore-ltsc2019
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Net.Component.4.7.2.SDK', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Net.Component.4.7.2.SDK ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -64,9 +58,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -8,6 +8,7 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `

--- a/4.7/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -3,26 +3,30 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 # Install .NET 4.7
-RUN powershell Invoke-WebRequest -Uri "https://download.microsoft.com/download/D/D/3/DD35CC25-6E9C-484B-A746-C5BE0C923290/NDP47-KB3186497-x86-x64-AllOS-ENU.exe" -OutFile dotnet-framework-installer.exe & `
-    .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe & `
-    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://download.microsoft.com/download/D/D/3/DD35CC25-6E9C-484B-A746-C5BE0C923290/NDP47-KB3186497-x86-x64-AllOS-ENU.exe" `
+            -OutFile dotnet-framework-installer.exe `
+    && start /w .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri "http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/05/windows10.0-kb4494440-x64_390f926659a23a56cc9cbb331e5940e132ad257d.msu" `
             -OutFile patch.msu; `
-        New-Item -Type Directory patch; `
-        Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
-        Remove-Item -Force patch.msu; `
-        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-kb4494440-x64.cab; `
-        Remove-Item -Force -Recurse \patch
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del patch.msu `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4494440-x64.cab `
+    && rmdir /S /Q patch
 
 # ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.8/runtime/windowsservercore-1803/Dockerfile
+++ b/4.8/runtime/windowsservercore-1803/Dockerfile
@@ -3,28 +3,21 @@
 FROM mcr.microsoft.com/windows/servercore:1803
 
 # Install .NET 4.8
-RUN powershell -Command `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe" -OutFile dotnet-framework-installer.exe & `
-    .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe & `
-    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
+    && .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
-RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri "http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/05/windows10.0-kb4499167-x64_23697fcf76f2d755b492415eb89aa573c8804765.msu" `
-            -OutFile patch.msu; `
-        New-Item -Type Directory patch; `
-        Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
-        Remove-Item -Force patch.msu; `
-        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-kb4499167-x64.cab; `
-        Remove-Item -Force -Recurse \patch
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/05/windows10.0-kb4499167-x64_23697fcf76f2d755b492415eb89aa573c8804765.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4499167-x64.cab `
+    && rmdir /S /Q patch
 
 # ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.8/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/4.8/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -5,26 +5,28 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 # Install .NET 4.8
 RUN powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe" -OutFile dotnet-framework-installer.exe & `
-    .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe & `
-    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe" `
+            -OutFile dotnet-framework-installer.exe `
+    && .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest patch
 RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri "http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/05/windows10.0-kb4494440-x64_390f926659a23a56cc9cbb331e5940e132ad257d.msu" `
             -OutFile patch.msu; `
-        New-Item -Type Directory patch; `
-        Start-Process expand -ArgumentList 'patch.msu', 'patch', '-F:*' -NoNewWindow -Wait; `
-        Remove-Item -Force patch.msu; `
-        Add-WindowsPackage -Online -PackagePath C:\patch\Windows10.0-kb4494440-x64.cab; `
-        Remove-Item -Force -Recurse \patch
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del patch.msu `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4494440-x64.cab `
+    && rmdir /S /Q patch
 
 # ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.8/runtime/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/runtime/windowsservercore-ltsc2019/Dockerfile
@@ -3,15 +3,13 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 # Install .NET 4.8
-RUN powershell -Command `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe" -OutFile dotnet-framework-installer.exe & `
-    .\dotnet-framework-installer.exe /q & `
-    del .\dotnet-framework-installer.exe & `
-    powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
+    && .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Apply latest 
-RUN curl -SL --output patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/05/windows10.0-kb4495618-x64_2d3245836cfd2467024a907947837e7879463a3b.msu `
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/05/windows10.0-kb4495618-x64_2d3245836cfd2467024a907947837e7879463a3b.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
@@ -20,5 +18,6 @@ RUN curl -SL --output patch.msu http://download.windowsupdate.com/d/msdownload/u
 
 # ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update & `
-    \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.8/sdk/windowsservercore-1803/Dockerfile
+++ b/4.8/sdk/windowsservercore-1803/Dockerfile
@@ -8,10 +8,12 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
-# Install VS Test Agent
-RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
@@ -22,6 +24,8 @@ RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/down
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    # Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/4.8/sdk/windowsservercore-1803/Dockerfile
+++ b/4.8/sdk/windowsservercore-1803/Dockerfile
@@ -3,66 +3,61 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-1803
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip -OutFile sdk_tools48.zip; `
-    Expand-Archive sdk_tools48.zip; `
-    Start-Process msiexec -ArgumentList '/i', 'sdk_tools48\sdk_tools48.msi', '/quiet', 'VSEXTUI=1' -NoNewWindow -Wait; `
-    Remove-Item -Force -Recurse sdk_tools48; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48.zip `
+    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
+    && del sdk_tools48.msi `
+    && del sdk_tools48.zip `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from .NET Framework 4.8 SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -70,9 +65,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/4.8/sdk/windowsservercore-1803/Dockerfile
+++ b/4.8/sdk/windowsservercore-1803/Dockerfile
@@ -8,6 +8,7 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `

--- a/4.8/sdk/windowsservercore-1903/Dockerfile
+++ b/4.8/sdk/windowsservercore-1903/Dockerfile
@@ -8,10 +8,12 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
-# Install VS Test Agent
-RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
@@ -22,6 +24,8 @@ RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/down
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    # Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/4.8/sdk/windowsservercore-1903/Dockerfile
+++ b/4.8/sdk/windowsservercore-1903/Dockerfile
@@ -3,66 +3,61 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-1903
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip -OutFile sdk_tools48.zip; `
-    Expand-Archive sdk_tools48.zip; `
-    Start-Process msiexec -ArgumentList '/i', 'sdk_tools48\sdk_tools48.msi', '/quiet', 'VSEXTUI=1' -NoNewWindow -Wait; `
-    Remove-Item -Force -Recurse sdk_tools48; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48.zip `
+    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
+    && del sdk_tools48.msi `
+    && del sdk_tools48.zip `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from .NET Framework 4.8 SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -70,9 +65,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/4.8/sdk/windowsservercore-1903/Dockerfile
+++ b/4.8/sdk/windowsservercore-1903/Dockerfile
@@ -8,6 +8,7 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `

--- a/4.8/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -3,66 +3,88 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-ltsc2016
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+            -OutFile vs_TestAgent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && powershell -Command `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
+            -OutFile vs_BuildTools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip -OutFile sdk_tools48.zip; `
-    Expand-Archive sdk_tools48.zip; `
-    Start-Process msiexec -ArgumentList '/i', 'sdk_tools48\sdk_tools48.msi', '/quiet', 'VSEXTUI=1' -NoNewWindow -Wait; `
-    Remove-Item -Force -Recurse sdk_tools48; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri "https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip" `
+            -OutFile sdk_tools48.zip; `
+        Expand-Archive sdk_tools48.zip `
+    && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
+    && rmdir /S /Q sdk_tools48 `
+    && del sdk_tools48.zip `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+            -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip; `
+        Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from .NET Framework 4.8 SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -70,9 +92,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/4.8/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -13,8 +13,9 @@ RUN mkdir "%ProgramFiles%\NuGet" `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
             -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
-# Install VS Test Agent
-RUN powershell -Command `
+RUN `
+    # Install VS Test Agent
+    powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         Invoke-WebRequest `
             -UseBasicParsing `
@@ -22,6 +23,7 @@ RUN powershell -Command `
             -OutFile vs_TestAgent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -37,6 +39,8 @@ RUN powershell -Command `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    # Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/4.8/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -13,6 +13,7 @@ RUN mkdir "%ProgramFiles%\NuGet" `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
             -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     powershell -Command `

--- a/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -8,10 +8,12 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
-# Install VS Test Agent
-RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
     && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
     && del vs_TestAgent.exe `
+    `
     # Install VS Build Tools
     && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
@@ -22,6 +24,8 @@ RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/down
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --quiet --norestart --nocache --wait `
     && del vs_BuildTools.exe `
+    `
+    # Cleanup
     && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"

--- a/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -3,66 +3,61 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-ltsc2019
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 # Install NuGet CLI
 ENV NUGET_VERSION 4.4.1
-RUN New-Item -Type Directory $Env:ProgramFiles\NuGet; `
-    Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS Test Agent
-RUN Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe -OutFile vs_TestAgent.exe; `
-    Start-Process vs_TestAgent.exe -ArgumentList '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait; `
-    Remove-Item -Force vs_TestAgent.exe; `
+RUN curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && del vs_TestAgent.exe `
     # Install VS Build Tools
-    Invoke-WebRequest -UseBasicParsing https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe -OutFile vs_BuildTools.exe; `
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/4da568ff-b8aa-43ab-92ec-a8129370b49a/6fb89b999fed6f395622e004bfe442eb/vs_buildtools.exe `
     # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
-    setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1; `
-    Start-Process vs_BuildTools.exe `
-        -ArgumentList `
-            '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', `
-            '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', `
-            '--add', 'Microsoft.Component.ClickOnce.MSBuild', `
-            '--quiet', '--norestart', '--nocache' `
-        -NoNewWindow -Wait; `
-    Remove-Item -Force vs_buildtools.exe; `
-    Remove-Item -Force -Recurse \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\"; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*; `
-    Remove-Item -Force -Recurse \"${Env:ProgramData}\Package Cache\"
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --quiet --norestart --nocache --wait `
+    && del vs_BuildTools.exe `
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip -OutFile sdk_tools48.zip; `
-    Expand-Archive sdk_tools48.zip; `
-    Start-Process msiexec -ArgumentList '/i', 'sdk_tools48\sdk_tools48.msi', '/quiet', 'VSEXTUI=1' -NoNewWindow -Wait; `
-    Remove-Item -Force -Recurse sdk_tools48; `
-    Remove-Item -Force -Recurse ${Env:TEMP}\*
+RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48.zip `
+    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
+    && del sdk_tools48.msi `
+    && del sdk_tools48.zip `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets
-RUN Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip -OutFile MSBuild.Microsoft.VisualStudio.Web.targets.zip;`
-    Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\"; `
-    Remove-Item -Force MSBuild.Microsoft.VisualStudio.Web.targets.zip
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2019.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-SHELL ["cmd", "/S", "/C"]
 RUN `
     # Workaround for issue with 32 bit assemblies from .NET Framework 4.8 SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
     # Workaround VS installer/ngen issues
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "C:\Program Files (x86)\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\VSWebLauncher.exe" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.CommandLineSwitch.pkgdef" `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\Editor\Microsoft.VisualStudio.Diff.pkgdef" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Set PATH in one layer to keep image size down.
-RUN setx /M PATH $(${Env:PATH} `
+RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
@@ -70,9 +65,17 @@ RUN setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
     | %{ `
-        Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
-    }
+    }"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -8,6 +8,7 @@ ENV NUGET_VERSION 4.4.1
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
+# Install VS components
 RUN `
     # Install VS Test Agent
     curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/4eef3cca-9da8-417a-889f-53212671e83b/50a7f7a24b21910a7cbe093fa150fd31/vs_testagent.exe `


### PR DESCRIPTION
Refactors all of the Dockerfiles to address several issues:
* Removes switching between shells.  The default CMD shell is now used throughout the Dockerfile and only switches the shell to be PowerShell at the very end of the Dockerfile.  In certain cases PowerShell commands are required for certain operations but those are done by explicitly calling the PowerShell exe in the CMD shell.
* Fixes inconsistencies for certain actions.  Example: #232 
* Ensure failed commands are not hidden by using '&&' instead of '&' when batching together multiple commands.
* Overall cleanup of formatting.

Related to #251 
Related to #232 
Related to #202 
Related to #43 