### PR TITLE
Remove COMPLUS_NGenProtectedProcess_FeatureEnabled env var

### DIFF
--- a/3.5/runtime/windowsservercore-1803/Dockerfile
+++ b/3.5/runtime/windowsservercore-1803/Dockerfile
@@ -19,7 +19,6 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/s
     && rmdir /S /Q patch
 
 # ngen .NET 3.5 Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
 RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
     && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/3.5/runtime/windowsservercore-1903/Dockerfile
+++ b/3.5/runtime/windowsservercore-1903/Dockerfile
@@ -11,7 +11,6 @@ RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.win
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # ngen .NET 3.5 Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
 RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
     && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/3.5/runtime/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/runtime/windowsservercore-ltsc2019/Dockerfile
@@ -19,7 +19,6 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/s
     && rmdir /S /Q patch
 
 # ngen .NET 3.5 Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
 RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
     && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/4.7.2/runtime/windowsservercore-1803/Dockerfile
+++ b/4.7.2/runtime/windowsservercore-1803/Dockerfile
@@ -1,3 +1,1 @@
 FROM mcr.microsoft.com/windows/servercore:1803
-
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0

--- a/4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile
+++ b/4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile
@@ -1,3 +1,1 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
-
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0

--- a/4.8/runtime/windowsservercore-1803/Dockerfile
+++ b/4.8/runtime/windowsservercore-1803/Dockerfile
@@ -17,7 +17,6 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/s
     && rmdir /S /Q patch
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.8/runtime/windowsservercore-1903/Dockerfile
+++ b/4.8/runtime/windowsservercore-1903/Dockerfile
@@ -1,3 +1,1 @@
 FROM mcr.microsoft.com/windows/servercore:1903
-
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0

--- a/4.8/runtime/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/runtime/windowsservercore-ltsc2019/Dockerfile
@@ -17,7 +17,6 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/s
     && rmdir /S /Q patch
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update


### PR DESCRIPTION
The need to set the COMPLUS_NGenProtectedProcess_FeatureEnabled environment variable in order to run ngen in a container has been removed due to an update made in the Windows base images starting in RS4.  The runtime Dockerfiles have been updated to remove the setting of this variable.  The only runtime Dockerfiles that are left unchanged are for 2016 LTSC.

Fixes #231 