### PR TITLE
Fix pipeline timeouts

### DIFF
--- a/eng/pipelines/dotnet-framework.yml
+++ b/eng/pipelines/dotnet-framework.yml
@@ -9,7 +9,8 @@ variables:
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml
   parameters:
-    windowsAmdBuildJobTimeout: 180
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      windowsAmdBuildJobTimeout: 180
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       buildMatrixType: platformVersionedOs
       customBuildLegGrouping: pr-build


### PR DESCRIPTION
The pipeline fails when running in the public project because it ends up with duplicate `windowsAmdBuildJobTimeout` parameters being defined.