### PR TITLE
Clean up sdk_tools48.cab file

### DIFF
--- a/3.5/sdk/windowsservercore-1803/Dockerfile
+++ b/3.5/sdk/windowsservercore-1803/Dockerfile
@@ -43,8 +43,8 @@ RUN `
 
 # Install .NET 4.8 SDK
 RUN mkdir sdk_tools48 `
-    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && curl -fSLo sdk_tools48\sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48\sdk_tools48.zip -C sdk_tools48 `
     && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*

--- a/3.5/sdk/windowsservercore-1803/Dockerfile
+++ b/3.5/sdk/windowsservercore-1803/Dockerfile
@@ -45,7 +45,7 @@ RUN `
 RUN mkdir sdk_tools48 `
     && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
-    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 

--- a/3.5/sdk/windowsservercore-1803/Dockerfile
+++ b/3.5/sdk/windowsservercore-1803/Dockerfile
@@ -45,8 +45,7 @@ RUN `
 RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48.zip `
     && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.msi `
-    && del sdk_tools48.zip `
+    && del sdk_tools48.* `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/3.5/sdk/windowsservercore-1803/Dockerfile
+++ b/3.5/sdk/windowsservercore-1803/Dockerfile
@@ -42,10 +42,11 @@ RUN `
     && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48.zip `
-    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.* `
+RUN mkdir sdk_tools48 `
+    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/3.5/sdk/windowsservercore-1903/Dockerfile
+++ b/3.5/sdk/windowsservercore-1903/Dockerfile
@@ -35,8 +35,7 @@ RUN `
 RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48.zip `
     && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.msi `
-    && del sdk_tools48.zip `
+    && del sdk_tools48.* `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/3.5/sdk/windowsservercore-1903/Dockerfile
+++ b/3.5/sdk/windowsservercore-1903/Dockerfile
@@ -32,10 +32,11 @@ RUN `
     && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48.zip `
-    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.* `
+RUN mkdir sdk_tools48 `
+    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/3.5/sdk/windowsservercore-1903/Dockerfile
+++ b/3.5/sdk/windowsservercore-1903/Dockerfile
@@ -35,7 +35,7 @@ RUN `
 RUN mkdir sdk_tools48 `
     && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
-    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 

--- a/3.5/sdk/windowsservercore-1903/Dockerfile
+++ b/3.5/sdk/windowsservercore-1903/Dockerfile
@@ -33,8 +33,8 @@ RUN `
 
 # Install .NET 4.8 SDK
 RUN mkdir sdk_tools48 `
-    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && curl -fSLo sdk_tools48\sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48\sdk_tools48.zip -C sdk_tools48 `
     && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -43,8 +43,8 @@ RUN `
 
 # Install .NET 4.8 SDK
 RUN mkdir sdk_tools48 `
-    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && curl -fSLo sdk_tools48\sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48\sdk_tools48.zip -C sdk_tools48 `
     && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -45,7 +45,7 @@ RUN `
 RUN mkdir sdk_tools48 `
     && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
-    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -45,8 +45,7 @@ RUN `
 RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48.zip `
     && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.msi `
-    && del sdk_tools48.zip `
+    && del sdk_tools48.* `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -42,10 +42,11 @@ RUN `
     && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48.zip `
-    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.* `
+RUN mkdir sdk_tools48 `
+    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/4.8/sdk/windowsservercore-1803/Dockerfile
+++ b/4.8/sdk/windowsservercore-1803/Dockerfile
@@ -35,8 +35,7 @@ RUN `
 RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48.zip `
     && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.msi `
-    && del sdk_tools48.zip `
+    && del sdk_tools48.* `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/4.8/sdk/windowsservercore-1803/Dockerfile
+++ b/4.8/sdk/windowsservercore-1803/Dockerfile
@@ -32,10 +32,11 @@ RUN `
     && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48.zip `
-    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.* `
+RUN mkdir sdk_tools48 `
+    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/4.8/sdk/windowsservercore-1803/Dockerfile
+++ b/4.8/sdk/windowsservercore-1803/Dockerfile
@@ -35,7 +35,7 @@ RUN `
 RUN mkdir sdk_tools48 `
     && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
-    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 

--- a/4.8/sdk/windowsservercore-1803/Dockerfile
+++ b/4.8/sdk/windowsservercore-1803/Dockerfile
@@ -33,8 +33,8 @@ RUN `
 
 # Install .NET 4.8 SDK
 RUN mkdir sdk_tools48 `
-    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && curl -fSLo sdk_tools48\sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48\sdk_tools48.zip -C sdk_tools48 `
     && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*

--- a/4.8/sdk/windowsservercore-1903/Dockerfile
+++ b/4.8/sdk/windowsservercore-1903/Dockerfile
@@ -35,8 +35,7 @@ RUN `
 RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48.zip `
     && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.msi `
-    && del sdk_tools48.zip `
+    && del sdk_tools48.* `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/4.8/sdk/windowsservercore-1903/Dockerfile
+++ b/4.8/sdk/windowsservercore-1903/Dockerfile
@@ -32,10 +32,11 @@ RUN `
     && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48.zip `
-    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.* `
+RUN mkdir sdk_tools48 `
+    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/4.8/sdk/windowsservercore-1903/Dockerfile
+++ b/4.8/sdk/windowsservercore-1903/Dockerfile
@@ -35,7 +35,7 @@ RUN `
 RUN mkdir sdk_tools48 `
     && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
-    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 

--- a/4.8/sdk/windowsservercore-1903/Dockerfile
+++ b/4.8/sdk/windowsservercore-1903/Dockerfile
@@ -33,8 +33,8 @@ RUN `
 
 # Install .NET 4.8 SDK
 RUN mkdir sdk_tools48 `
-    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && curl -fSLo sdk_tools48\sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48\sdk_tools48.zip -C sdk_tools48 `
     && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*

--- a/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -35,8 +35,7 @@ RUN `
 RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48.zip `
     && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.msi `
-    && del sdk_tools48.zip `
+    && del sdk_tools48.* `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -32,10 +32,11 @@ RUN `
     && rmdir /S /Q "%ProgramData%\Package Cache"
 
 # Install .NET 4.8 SDK
-RUN curl -fSLo sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48.zip `
-    && start /w msiexec /i sdk_tools48.msi /quiet VSEXTUI=1 `
-    && del sdk_tools48.* `
+RUN mkdir sdk_tools48 `
+    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 
 # Install web targets

--- a/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -35,7 +35,7 @@ RUN `
 RUN mkdir sdk_tools48 `
     && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
     && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
-    && start /w msiexec /i sdk_tools48/sdk_tools48.msi /quiet VSEXTUI=1 `
+    && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 

--- a/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -33,8 +33,8 @@ RUN `
 
 # Install .NET 4.8 SDK
 RUN mkdir sdk_tools48 `
-    && curl -fSLo sdk_tools48/sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
-    && tar -zxf sdk_tools48/sdk_tools48.zip -C sdk_tools48 `
+    && curl -fSLo sdk_tools48\sdk_tools48.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/sdk_tools48.zip `
+    && tar -zxf sdk_tools48\sdk_tools48.zip -C sdk_tools48 `
     && start /w msiexec /i sdk_tools48\sdk_tools48.msi /quiet VSEXTUI=1 `
     && rmdir /S /Q sdk_tools48 `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*


### PR DESCRIPTION
When extracting the sdk_tools48.zip file, both a .cab and .msi file are placed in the directory but only the .msi file is being cleaned up.  These changes ensure that everything is properly cleaned up.

Fixes #297 