### PR TITLE
Ensure runtime images are ngen'd

### DIFF
--- a/4.7.2/runtime/windowsservercore-1803/Dockerfile
+++ b/4.7.2/runtime/windowsservercore-1803/Dockerfile
@@ -1,3 +1,9 @@
+# escape=`
+
 FROM mcr.microsoft.com/windows/servercore:1803
 
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile
+++ b/4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile
@@ -1,3 +1,9 @@
+# escape=`
+
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.8/runtime/windowsservercore-1903/Dockerfile
+++ b/4.8/runtime/windowsservercore-1903/Dockerfile
@@ -1,3 +1,9 @@
+# escape=`
+
 FROM mcr.microsoft.com/windows/servercore:1903
 
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update


### PR DESCRIPTION
The Windows base images do not have ngen images included in them which leads to poor performance.  Most of our images are installing .NET on top of the Windows base image and we are ngen-ing as part of that.  But there are a few remaining which do not since they have the required version of .NET Framework already installed in the base image.  For those, we need to ensure that we run ngen.

Fixes #211 