### PR TITLE
Add the yml for the WCF pipeline.

### DIFF
--- a/eng/pipelines/dotnet-framework-wcf.yml
+++ b/eng/pipelines/dotnet-framework-wcf.yml
@@ -1,0 +1,14 @@
+trigger: none
+pr:
+- master
+
+variables:
+- template: variables/common.yml
+- name: manifest
+  value: manifest.wcf.json
+stages:
+- template: ../common/templates/stages/build-test-publish-repo.yml
+  parameters:
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      buildMatrixType: platformVersionedOs
+      customBuildLegGrouping: pr-build


### PR DESCRIPTION
@MichaelSimons For step...

> Define a WCF build definition. I believe it will mimic the Samples build closely

of #302 

I just need to add this yml and then create a new build definition called "dotnet-framework-docker-wcf" that maps to this yml and add it to...
 'dnceng/internal/Pipelines/Builds' under Microsoft/dotnet-framework-docker.

Am I missing anything else?