### PR TITLE
Stebon/hongli wcf/wcfchanges

### DIFF
--- a/eng/common/templates/jobs/test-images-windows-client.yml
+++ b/eng/common/templates/jobs/test-images-windows-client.yml
@@ -11,3 +11,5 @@ jobs:
     matrix: $[ ${{ parameters.matrix }} ]
   steps:
   - template: ../steps/test-images-windows-client.yml
+    parameters:
+      filterTests: $(_testCategory)

--- a/eng/common/templates/jobs/test-images-windows-client.yml
+++ b/eng/common/templates/jobs/test-images-windows-client.yml
@@ -11,5 +11,3 @@ jobs:
     matrix: $[ ${{ parameters.matrix }} ]
   steps:
   - template: ../steps/test-images-windows-client.yml
-    parameters:
-      filterTests: $(testCategory)

--- a/eng/common/templates/jobs/test-images-windows-client.yml
+++ b/eng/common/templates/jobs/test-images-windows-client.yml
@@ -12,4 +12,4 @@ jobs:
   steps:
   - template: ../steps/test-images-windows-client.yml
     parameters:
-      filterTests: $(_testCategory)
+      filterTests: $(testCategory)

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -10,9 +10,9 @@ steps:
       optionalTestArgs="-DisableHttpVerification"
     fi
     if [ "${{ eq(variables['System.TeamProject'], 'public') }}" == "False" ]; then
-      optionalTestArgs="$optionalTestArgs -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix)"
+      optionalTestArgs="$optionalTestArgs -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -TestCategory $(testCategory)"
     else
-      optionalTestArgs="$optionalTestArgs -IsLocalRun"
+      optionalTestArgs="$optionalTestArgs -IsLocalRun -TestCategory $(testCategory)"
     fi
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,16 +1,12 @@
-parameters:
-  filterTests: ''
 steps:
 - powershell: |
     if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
-      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -TestCategory $env:FILTERTESTS"
+      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -TestCategory $env:TESTCATEGORY"
     } else {
-      $optionalTestArgs="-IsLocalRun -TestCategory $env:FILTERTESTS"
+      $optionalTestArgs="-IsLocalRun -TestCategory $env:TESTCATEGORY"
     }
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
-  env:
-    FILTERTESTS: ${{ parameters.filterTests }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: init-docker-windows.yml
     parameters:

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,12 +1,16 @@
+parameters:
+  filterTests: ''
 steps:
 - powershell: |
     if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
-      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -TestCategory $(filterTests)"
+      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -TestCategory $env:FILTERTESTS"
     } else {
-      $optionalTestArgs="-IsLocalRun -TestCategory $(filterTests)"
+      $optionalTestArgs="-IsLocalRun -TestCategory $env:FILTERTESTS"
     }
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
+  env:
+    FILTERTESTS: ${{ parameters.filterTests }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: init-docker-windows.yml
     parameters:

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,9 +1,9 @@
 steps:
 - powershell: |
     if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
-      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX"
+      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -TestCategory $(filterTests)"
     } else {
-      $optionalTestArgs="-IsLocalRun"
+      $optionalTestArgs="-IsLocalRun -TestCategory $(filterTests)"
     }
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables

--- a/eng/pipelines/dotnet-framework-wcf.yml
+++ b/eng/pipelines/dotnet-framework-wcf.yml
@@ -6,6 +6,8 @@ variables:
 - template: variables/common.yml
 - name: manifest
   value: manifest.wcf.json
+- name: _testCategory
+  value: WCF
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml
   parameters:

--- a/eng/pipelines/dotnet-framework-wcf.yml
+++ b/eng/pipelines/dotnet-framework-wcf.yml
@@ -6,7 +6,7 @@ variables:
 - template: variables/common.yml
 - name: manifest
   value: manifest.wcf.json
-- name: _testCategory
+- name: testCategory
   value: WCF
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-framework.yml
+++ b/eng/pipelines/dotnet-framework.yml
@@ -6,7 +6,7 @@ variables:
 - template: variables/common.yml
 - name: manifest
   value: manifest.json
-- name: _testCategory
+- name: testCategory
   value: Runtime
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml

--- a/eng/pipelines/dotnet-framework.yml
+++ b/eng/pipelines/dotnet-framework.yml
@@ -6,6 +6,8 @@ variables:
 - template: variables/common.yml
 - name: manifest
   value: manifest.json
+- name: _testCategory
+  value: Runtime
 stages:
 - template: ../common/templates/stages/build-test-publish-repo.yml
   parameters:

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         }
 
         [Theory]
-        [Category("Runtime")]
+        [Trait("Category", "Runtime")]
         [MemberData(nameof(GetVerifyImagesData))]
         public void VerifyImagesWithApps(ImageDescriptor imageDescriptor)
         {
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         }
 
         [Theory]
-        [Category("Runtime")]
+        [Trait("Category", "Runtime")]
         [MemberData(nameof(GetVerifyImagesData))]
         public void VerifyImagesWithWebApps(ImageDescriptor imageDescriptor)
         {
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         }
 
         [Theory]
-        [Category("WCF")]
+        [Trait("Category", "WCF")]
         [MemberData(nameof(GetVerifyImagesData))]
         public void VerifyWCFImagesWithApps(ImageDescriptor imageDescriptor)
         {

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -9,7 +9,7 @@ param(
     [string]$OSFilter,
     [string]$Registry,
     [string]$RepoPrefix,
-		[string]$TestCategory,
+    [string]$TestCategory,
     [switch]$IsLocalRun
 )
 
@@ -42,5 +42,5 @@ if ($IsLocalRun) {
     $env:LOCAL_RUN = 1
 }
 
-& dotnet test --filter TestCategory=$TestCategory -c Release --logger:trx $PSScriptRoot/Microsoft.DotNet.Framework.Docker.Tests/Microsoft.DotNet.Framework.Docker.Tests.csproj
+& dotnet test --filter Category=$TestCategory -c Release --logger:trx $PSScriptRoot/Microsoft.DotNet.Framework.Docker.Tests/Microsoft.DotNet.Framework.Docker.Tests.csproj
 if ($LASTEXITCODE -ne 0) { throw "Tests Failed" }

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -9,6 +9,7 @@ param(
     [string]$OSFilter,
     [string]$Registry,
     [string]$RepoPrefix,
+		[string]$TestCategory,
     [switch]$IsLocalRun
 )
 
@@ -41,5 +42,5 @@ if ($IsLocalRun) {
     $env:LOCAL_RUN = 1
 }
 
-& dotnet test -c Release --logger:trx $PSScriptRoot/Microsoft.DotNet.Framework.Docker.Tests/Microsoft.DotNet.Framework.Docker.Tests.csproj
+& dotnet test --filter TestCategory=$TestCategory -c Release --logger:trx $PSScriptRoot/Microsoft.DotNet.Framework.Docker.Tests/Microsoft.DotNet.Framework.Docker.Tests.csproj
 if ($LASTEXITCODE -ne 0) { throw "Tests Failed" }


### PR DESCRIPTION
This PR deals with adding support for the infrastructure to know if the current build is for WCF or Runtime and then only running tests that apply.
We are using the "dotnet test" filtering expression to select which tests to run.
https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests#xunit

I've verified that these changes will correctly differentiate between 'WCF' and 'Runtime' and run the correct tests in ImageTests.cs
https://dev.azure.com/dnceng/internal/_build/results?buildId=271563

I was not able to test the change made to `steps/test-images-linux-client.yml` because I'm not sure how to trigger the Linux build path when kicking off the build def.