### PR TITLE
Fix broken Dockerfile links in the readmes

### DIFF
--- a/README.wcf.md
+++ b/README.wcf.md
@@ -47,33 +47,30 @@ docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.
 ## Windows Server, version 1903 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20190709-windowsservercore-1903, 4.8-windowsservercore-1903, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/runtime/windowsservercore-1903/Dockerfile)
-
+4.8-20190709-windowsservercore-1903, 4.8-windowsservercore-1903, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/wcf/windowsservercore-1903/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20190709-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/runtime/windowsservercore-ltsc2019/Dockerfile)
-4.7.2-20190709-windowsservercore-ltsc2019, 4.7.2-windowsservercore-ltsc2019, 4.7.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile)
-
+4.8-20190709-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/wcf/windowsservercore-ltsc2019/Dockerfile)
+4.7.2-20190709-windowsservercore-ltsc2019, 4.7.2-windowsservercore-ltsc2019, 4.7.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7.2/wcf/windowsservercore-ltsc2019/Dockerfile)
 
 ## Windows Server, version 1803 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20190709-windowsservercore-1803, 4.8-windowsservercore-1803, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/runtime/windowsservercore-1803/Dockerfile)
-4.7.2-20190709-windowsservercore-1803, 4.7.2-windowsservercore-1803, 4.7.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-1803/Dockerfile)
+4.8-20190709-windowsservercore-1803, 4.8-windowsservercore-1803, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/wcf/windowsservercore-1803/Dockerfile)
+4.7.2-20190709-windowsservercore-1803, 4.7.2-windowsservercore-1803, 4.7.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7.2/wcf/windowsservercore-1803/Dockerfile)
 
 ## Windows Server 2016 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20190709-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/runtime/windowsservercore-ltsc2016/Dockerfile)
-4.7.2-20190709-windowsservercore-ltsc2016, 4.7.2-windowsservercore-ltsc2016, 4.7.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile)
-4.7.1-20190709-windowsservercore-ltsc2016, 4.7.1-windowsservercore-ltsc2016, 4.7.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile)
-4.7-20190709-windowsservercore-ltsc2016, 4.7-windowsservercore-ltsc2016, 4.7 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7/runtime/windowsservercore-ltsc2016/Dockerfile)
-4.6.2-20190709-windowsservercore-ltsc2016, 4.6.2-windowsservercore-ltsc2016, 4.6.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile)
+4.8-20190709-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/wcf/windowsservercore-ltsc2016/Dockerfile)
+4.7.2-20190709-windowsservercore-ltsc2016, 4.7.2-windowsservercore-ltsc2016, 4.7.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7.2/wcf/windowsservercore-ltsc2016/Dockerfile)
+4.7.1-20190709-windowsservercore-ltsc2016, 4.7.1-windowsservercore-ltsc2016, 4.7.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7.1/wcf/windowsservercore-ltsc2016/Dockerfile)
+4.7-20190709-windowsservercore-ltsc2016, 4.7-windowsservercore-ltsc2016, 4.7 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.7/wcf/windowsservercore-ltsc2016/Dockerfile)
+4.6.2-20190709-windowsservercore-ltsc2016, 4.6.2-windowsservercore-ltsc2016, 4.6.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.6.2/wcf/windowsservercore-ltsc2016/Dockerfile)
 
-You can retrieve a list of all available tags for dotnet/framework/runtime at https://mcr.microsoft.com/v2/dotnet/framework/wcf/tags/list.
-
+You can retrieve a list of all available tags for dotnet/framework/wcf at https://mcr.microsoft.com/v2/dotnet/framework/wcf/tags/list.
 
 # Support
 

--- a/eng/Get-TagsDocumentation.ps1
+++ b/eng/Get-TagsDocumentation.ps1
@@ -5,4 +5,5 @@ $gitRepo = "https://github.com/microsoft/dotnet-framework-docker"
 
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 dotnet/framework/runtime README.runtime.md manifest.json master $gitRepo
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 dotnet/framework/sdk README.sdk.md manifest.json master $gitRepo -ReuseImageBuilderImage
+& $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 dotnet/framework/wcf README.wcf.md manifest.wcf.json master $gitRepo
 & $PSScriptRoot/common/Invoke-ReadmeGeneration.ps1 dotnet/framework/samples README.samples.md manifest.samples.json master $gitRepo -ReuseImageBuilderImage

--- a/eng/pipelines/variables/common.yml
+++ b/eng/pipelines/variables/common.yml
@@ -1,4 +1,4 @@
 variables:
 - template: ../../common/templates/variables/common.yml
 - name: publicGitRepoUri
-  value: https://github.com/dotnet/dotnet-framework-docker
+  value: https://github.com/microsoft/dotnet-framework-docker


### PR DESCRIPTION
1. The readme links on DH are currently broken as they reference `https://github.com/dotnet/dotnet-framework-docker/` instead of `https://github.com/dotnet/dotnet-framework-docker/`.  This was a regression the came in with the common eng infra.
1. Add WCF support to the Get-TagsDocumentation.ps1
1. Fix the incorrect Dockerfile links in the WCF readme