### PR TITLE
Integrate eng/common folder

### DIFF
--- a/eng/common/Invoke-CleanupDocker.ps1
+++ b/eng/common/Invoke-CleanupDocker.ps1
@@ -5,11 +5,17 @@ docker ps -a -q | ForEach-Object { docker rm -f $_ }
 
 docker volume prune -f
 
-# Windows base images are large, preserve them to avoid the overhead of pulling each time.
-docker images |
+# Preserve the Windows base images and the common eng infra images (e.g. ImageBuilder)
+# to avoid the expense of having to repull continuously.
+$engInfraImages = Get-Content ./eng/common/templates/variables/docker-images.yml |
+    Where-Object { $_.Trim() -notlike 'variables:' } |
+    ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[1] }
+
+docker images --format "{{.Repository}}:{{.Tag}} {{.ID}}"|
     Where-Object {
-        -Not ($_.StartsWith("mcr.microsoft.com/windows")`
-        -Or $_.StartsWith("REPOSITORY ")) } |
-    ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[2] } |
+        $localImage = $_
+        -Not ($localImage.StartsWith("mcr.microsoft.com/windows")`
+            -Or ($engInfraImages.Where({ $localImage.StartsWith($_) }, 'First').Count -gt 0)) } |
+    ForEach-Object { $_.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)[1] } |
     Select-Object -Unique |
     ForEach-Object { docker rmi -f $_ }

--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -17,15 +17,10 @@ jobs:
   variables:
     osVersion: ${{ parameters.osVersion }}
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      imageBuilderBuildArgs: >
-        --registry-override $(acr.server)
-        --repo-prefix $(stagingRepoPrefix)
-        --push
-        --username $(acr.userName)
-        --password $(BotAccount-dotnet-docker-acr-bot-password)
-        $(imageBuilder.queueArgs)
+      imageBuilderBuildArgs: --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --push --username $(acr.userName) --password $(BotAccount-dotnet-docker-acr-bot-password) $(imageBuilder.queueArgs)
     ${{ if eq(variables['System.TeamProject'], 'public') }}:
       imageBuilderBuildArgs: $(imageBuilder.queueArgs)
+    imageBuilderDockerRunExtraOptions: $(build.imageBuilderDockerRunExtraOptions)
   steps:
   # This script is necessary to workaround there not being a matching architecture when pulling images
   # on an aarch64 machine. By using the multi-arch tag for the images referenced in the sample
@@ -57,15 +52,14 @@ jobs:
       --os-type $(osType)
       --os-version "$(osVersion)"
       --architecture $(architecture)
-      --image-info-output-path "$(imageBuilderArtifactsPath)/$(legName)-image-info.json"
       --retry
       $(imageBuilderBuildArgs)
+      $(imageBuilderImageInfoArg)
     displayName: Build Images
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: $(legName)-image-info
-      targetPath: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
-    displayName: Publish Image Info File Artifact
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
+      artifact: $(legName)-image-info
+      displayName: Publish Image Info File Artifact
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
       parameters:

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -1,0 +1,17 @@
+jobs:
+- job: Build
+  pool: # linuxAmd64Pool
+    name: Hosted Ubuntu 1604
+  steps:
+  - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+  - script: >
+      $(runImageBuilderCmd) mergeImageInfo
+      $(artifactsPath)
+      $(artifactsPath)/image-info.json
+    displayName: Merge Image Info Files
+  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
+    artifact: image-info
+    displayName: Publish Image Info File Artifact

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -15,6 +15,10 @@ jobs:
       publicSourceBranch: master
   steps:
   - template: ../steps/init-docker-linux.yml
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: image-info
   - script: >
       $(runImageBuilderCmd) copyAcrImages
       $(stagingRepoPrefix)
@@ -26,6 +30,7 @@ jobs:
       --os-type '*'
       --architecture '*'
       --repo-prefix $(publishRepoPrefix)
+      --image-info $(artifactsPath)/image-info.json
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Copy Images
@@ -47,26 +52,29 @@ jobs:
       $(publicGitRepoUri)/blob/$(publicSourceBranch)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Readme
-  - task: DownloadPipelineArtifact@1
-    inputs:
-      buildType: specific
-      project: $(System.TeamProject)
-      pipline: $(System.DefinitionId)
-      buildVersionToDownload: specific
-      buildId: $(sourceBuildId)
-      targetPath: $(Build.ArtifactStagingDirectory)
-    displayName: Download Pipline Artifacts
+    condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
+  - script: >
+      $(runImageBuilderCmd) publishImageInfo
+      $(dotnetBot-userName)
+      $(dotnetBot-email)
+      $(dotnet-bot-user-repo-adminrepohook-pat)
+      $(artifactsPath)/image-info.json
+      --git-owner dotnet
+      --git-repo versions
+      --git-branch master
+      --git-path build-info/docker/image-info.json
+    displayName: Publish Image Info (legacy)
     condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
   - script: >
       $(runImageBuilderCmd) publishImageInfo
       $(dotnetBot-userName)
       $(dotnetBot-email)
       $(dotnet-bot-user-repo-adminrepohook-pat)
-      $(imageBuilderArtifactsPath)
+      $(artifactsPath)/image-info.json
       --git-owner dotnet
       --git-repo versions
       --git-branch master
-      --git-path build-info/docker/image-info.json
+      --git-path build-info/docker/image-info.$(Build.Repository.Name)-$(publicSourceBranch).json
     displayName: Publish Image Info
     condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -164,10 +164,19 @@ stages:
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   ################################################################################
+  # Post-Build
+  ################################################################################
+  - stage: Post_Build
+    dependsOn: Build
+    condition: and(succeeded(), or(eq(variables['singlePhase'], ''), eq(variables['singlePhase'], 'build')))
+    jobs:
+    - template: ../jobs/post-build.yml
+
+  ################################################################################
   # Test Images
   ################################################################################
   - stage: Test
-    dependsOn: Build
+    dependsOn: Post_Build
     condition: "
       and(
         not(contains(variables['manifest'], 'samples')),

--- a/eng/common/templates/steps/cleanup-docker-linux.yml
+++ b/eng/common/templates/steps/cleanup-docker-linux.yml
@@ -11,12 +11,12 @@ steps:
   # owned by this build.
   ################################################################################
 - ${{ if and(eq(parameters.cleanupRemoteDockerServer, 'true'), eq(parameters.initCleanup, 'false')) }}:
-  - script: docker run --rm $(dockerArmRunArgs) --entrypoint docker $(dockerClientImage) system prune -f --volumes
+  - script: docker run --rm $(dockerArmRunOptions) --entrypoint docker $(dockerClientImage) system prune -f --volumes
     displayName: Cleanup Remote Docker Server (basic)
     condition: always()
     continueOnError: true
   - script: >
-      docker run --rm $(dockerArmRunArgs) --entrypoint /bin/bash $(dockerClientImage) -c
+      docker run --rm $(dockerArmRunOptions) --entrypoint /bin/bash $(dockerClientImage) -c
       'docker rmi -f $(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v -e ^arm32v7/ -e ^arm64v8/ -e ^mcr\\.microsoft\\.com/windows)'
     displayName: Cleanup Remote Docker Server (images)
     condition: always()

--- a/eng/common/templates/steps/download-build-artifact.yml
+++ b/eng/common/templates/steps/download-build-artifact.yml
@@ -1,0 +1,18 @@
+parameters:
+  targetPath: ""
+  artifactName: ""
+  requiresPublicRepoPrefix: false
+
+steps:
+- task: DownloadPipelineArtifact@1
+  inputs:
+    buildType: specific
+    project: $(System.TeamProject)
+    pipline: $(System.DefinitionId)
+    buildVersionToDownload: specific
+    buildId: $(sourceBuildId)
+    targetPath: ${{ parameters.targetPath }}
+    artifactName: ${{ parameters.artifactName }}
+  displayName: Download Build Artifact(s)
+  ${{ if eq(parameters.requiresPublicRepoPrefix, true) }}:
+    condition: and(succeeded(), eq(variables['publishRepoPrefix'], 'public/'))

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -5,6 +5,16 @@ parameters:
   cleanupDocker: true
 
 steps:
+- script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"
+  displayName: Define Artifacts Path Variable
+
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json'
+    displayName: Set Image Info Arg for Image Builder
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]'
+    displayName: Set Image Info Arg for Image Builder
+
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
@@ -19,12 +29,12 @@ steps:
   ################################################################################
 - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:
   - script: >
-      echo "##vso[task.setvariable variable=dockerArmRunArgs]
+      echo "##vso[task.setvariable variable=dockerArmRunOptions]
       -v $(DOCKER_CERT_PATH):/docker-certs
       -e DOCKER_CERT_PATH=/docker-certs
       -e DOCKER_TLS_VERIFY=1
       -e DOCKER_HOST=tcp://$(DOCKER_HOST_IP):2376"
-    displayName: Define dockerArmRunArgs Variable
+    displayName: Define dockerArmRunOptions Variable
 
   ################################################################################
   # Setup Image Builder (Optional)
@@ -38,15 +48,14 @@ steps:
       --build-arg IMAGE=$(imageNames.imageBuilder.linux)
       -f $(engCommonPath)/Dockerfile.WithRepo .
     displayName: Build Image for Image Builder
-  - script: echo "##vso[task.setvariable variable=imageBuilderArtifactsPath]/artifacts"
-    displayName: Define Image Builder Artifacts Path Variable
   - script: >
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       docker run --rm
       -v /var/run/docker.sock:/var/run/docker.sock
-      -v $(Build.ArtifactStagingDirectory):$(imageBuilderArtifactsPath)
+      -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
       -w /repo
-      $(dockerArmRunArgs)
+      $(dockerArmRunOptions)
+      $(imageBuilderDockerRunExtraOptions)
       $(imageNames.imageBuilder.withrepo)"
     displayName: Define runImageBuilderCmd Variable
   - ${{ if eq(parameters.setupRemoteDockerServer, 'true') }}:

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -2,6 +2,16 @@ parameters:
   setupImageBuilder:  true
 
 steps:
+- script: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)
+  displayName: Define Artifacts Path Variable
+
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]--image-info-output-path $(artifactsPath)/$(legName)-image-info.json
+    displayName: Set Image Info Arg for Image Builder
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - script: echo '##vso[task.setvariable variable=imageBuilderImageInfoArg]
+    displayName: Set Image Info Arg for Image Builder
+
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
@@ -28,5 +38,3 @@ steps:
       echo "##vso[task.setvariable variable=runImageBuilderCmd]
       $(Build.BinariesDirectory)\.Microsoft.DotNet.ImageBuilder\Microsoft.DotNet.ImageBuilder.exe
     displayName: Define runImageBuilderCmd Variable
-  - script: echo "##vso[task.setvariable variable=imageBuilderArtifactsPath]$(Build.ArtifactStagingDirectory)
-    displayName: Define Image Builder Artifacts Path Variable

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -2,6 +2,12 @@ parameters:
   useRemoteDockerServer: false
 
 steps:
+- template: init-docker-linux.yml
+  parameters:
+    setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
+    setupImageBuilder: false
+    setupTestRunner: true
+    cleanupDocker: ${{ eq(variables['System.TeamProject'], 'internal') }}
 - script: |
     echo "##vso[task.setvariable variable=testRunner.container]testrunner-$(Build.BuildId)-$(System.JobId)"
 
@@ -10,22 +16,17 @@ steps:
       optionalTestArgs="-DisableHttpVerification"
     fi
     if [ "${{ eq(variables['System.TeamProject'], 'public') }}" == "False" ]; then
-      optionalTestArgs="$optionalTestArgs -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix)"
+      optionalTestArgs="$optionalTestArgs -Registry $(acr.server) -RepoPrefix $(stagingRepoPrefix) -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
     else
       optionalTestArgs="$optionalTestArgs -IsLocalRun"
     fi
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
-- template: init-docker-linux.yml
-  parameters:
-    setupRemoteDockerServer: ${{ parameters.useRemoteDockerServer }}
-    setupImageBuilder: false
-    setupTestRunner: true
-    cleanupDocker: ${{ eq(variables['System.TeamProject'], 'internal') }}
 - script: >
     docker run -t -d
     -v /var/run/docker.sock:/var/run/docker.sock
-    -w /repo $(dockerArmRunArgs)
+    -v $(Build.ArtifactStagingDirectory):$(artifactsPath)
+    -w /repo $(dockerArmRunOptions)
     -e RUNNING_TESTS_IN_CONTAINER=true 
     --name $(testRunner.container)
     $(imageNames.testRunner.withrepo)
@@ -36,12 +37,15 @@ steps:
       -File $(engCommonRelativePath)/Invoke-WithRetry.ps1
       "docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)"
     displayName: Docker login
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
 - script: >
     docker exec $(testRunner.container) pwsh
     -File ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)
-    -OSFilter $(osVariant)*
-    -ArchitectureFilter $(architecture)
+    -VersionFilter '$(dotnetVersion)'
+    -OSFilter '$(osVariant)*'
+    -ArchitectureFilter '$(architecture)'
     $(optionalTestArgs)
   displayName: Test Images
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -66,7 +70,7 @@ steps:
     searchFolder: $(Common.TestResultsDirectory)
     mergeTestResults: true
     publishRunAttachments: true
-    testRunTitle: Linux $(dotnetVersion) $(osVariant) $(architecture)
+    testRunTitle: $(dotnetVersion) $(osVariant) $(architecture)
 - script: docker rm -f $(testRunner.container)
   displayName: Cleanup TestRunner Container
   condition: always()

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -1,7 +1,13 @@
 steps:
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - template: init-docker-windows.yml
+    parameters:
+      setupImageBuilder: false
+  - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
+    displayName: Docker login
 - powershell: |
     if ("${{ eq(variables['System.TeamProject'], 'public') }}" -eq "False") {
-      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX"
+      $optionalTestArgs="-Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info/image-info.json"
     } else {
       $optionalTestArgs="-IsLocalRun"
     }
@@ -10,18 +16,16 @@ steps:
     }
     echo "##vso[task.setvariable variable=optionalTestArgs]$optionalTestArgs"
   displayName: Set Test Variables
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - template: init-docker-windows.yml
-    parameters:
-      setupImageBuilder: false
-  - script: docker login -u $(acr.userName) -p $(BotAccount-dotnet-docker-acr-bot-password) $(acr.server)
-    displayName: Docker login
 - powershell: Get-ChildItem -Path tests -r | Where {$_.Extension -match "trx"} | Remove-Item
   displayName: Cleanup Old Test Results
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - template: ../steps/download-build-artifact.yml
+    parameters:
+      targetPath: $(Build.ArtifactStagingDirectory)
 - powershell: >
     ./tests/run-tests.ps1
-    -VersionFilter $(dotnetVersion)
-    -OSFilter $(osVariant)
+    -VersionFilter '$(dotnetVersion)'
+    -OSFilter '$(osVariant)'
     $(optionalTestArgs)
   displayName: Test Images
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -38,6 +42,6 @@ steps:
     testResultsFiles: 'tests/**/*.trx'
     mergeTestResults: true
     publishRunAttachments: true
-    testRunTitle: Windows $(dotnetVersion) $(osVariant) amd64
+    testRunTitle: $(dotnetVersion) $(osVariant) amd64
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - template: cleanup-docker-windows.yml

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -3,8 +3,14 @@ variables:
 - template: common-paths.yml
 - name: stagingRepoPrefix
   value: build-staging/$(sourceBuildId)/
+- name: publishReadme
+  value: true
 - name: skipComponentGovernanceDetection
   value: true
+- name: build.imageBuilderDockerRunExtraOptions
+  value: ""
+- name: imageBuilderDockerRunExtraOptions
+  value: ""
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-Docker-Common
   - group: DotNet-Docker-Secrets

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,6 +1,6 @@
 variables:
-  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190807123248
-  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190807123248
+  imageNames.imageBuilder.linux: mcr.microsoft.com/dotnet-buildtools/image-builder:debian-20190809142145
+  imageNames.imageBuilder.windows: mcr.microsoft.com/dotnet-buildtools/image-builder:nanoserver-20190809142145
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
-  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-docker-testrunner-63f2145-20184325094343
+  imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-d61254f-20190807161111
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
@@ -306,14 +306,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                 }
             }
 
-            if (isUsingCustomRegistry)
-            {
-                Debug.Assert(!String.IsNullOrEmpty(Registry), "Registry is not set.");
-                Debug.Assert(!String.IsNullOrEmpty(RepoPrefix), "RepoPrefix is not set.");
-                return $"{Registry}/{RepoPrefix}";
-            }
-            
-            return "mcr.microsoft.com/";
+            return isUsingCustomRegistry ? $"{Registry}/{RepoPrefix}" : $"{GetManifestRegistry()}/";
         }
 
         private static string GetManifestRegistry()

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -82,6 +83,8 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { RuntimeVersion = "4.8", OsVariant = WSC_1903 },
         };
 
+        private static Lazy<JArray> ImageInfoData;
+
         private DockerHelper _dockerHelper;
         private ITestOutputHelper _outputHelper;
 
@@ -89,6 +92,21 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         {
             _outputHelper = outputHelper;
             _dockerHelper = new DockerHelper(outputHelper);
+        }
+
+        static ImageTests()
+        {
+            ImageInfoData = new Lazy<JArray>(() =>
+            {
+                string imageInfoPath = Environment.GetEnvironmentVariable("IMAGE_INFO_PATH");
+                if (!String.IsNullOrEmpty(imageInfoPath))
+                {
+                    string imageInfoContents = File.ReadAllText(imageInfoPath);
+                    return JsonConvert.DeserializeObject<JArray>(imageInfoContents);
+                }
+
+                return null;
+            });
         }
 
         public static IEnumerable<object[]> GetVerifyRuntimeImagesData()
@@ -245,7 +263,10 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
 
         private string GetImage(string imageType, string version, string osVariant)
         {
-            string image = $"{Registry}/{RepoPrefix}dotnet/framework/{imageType}:{version}-{osVariant}";
+            string repo = $"dotnet/framework/{imageType}";
+            string tag = $"{version}-{osVariant}";
+            string registry = GetRegistryName(repo, tag);
+            string image = $"{registry}{repo}:{tag}";
 
             // Ensure image exists locally
             if (IsLocalRun)
@@ -258,6 +279,33 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             }
 
             return image;
+        }
+
+        private static string GetRegistryName(string repo, string tag)
+        {
+            bool imageExistsInStaging = true;
+
+            // In the case of running this in a local development environment, there would likely be no image info file
+            // provided. In that case, the assumption is that the images exist in the staging location.
+
+            if (ImageTests.ImageInfoData.Value != null)
+            {
+                JObject repoInfo = (JObject)ImageTests.ImageInfoData.Value
+                    .FirstOrDefault(imageInfoRepo => imageInfoRepo["repo"].ToString() == repo);
+
+                if (repoInfo["images"] != null)
+                {
+                    imageExistsInStaging = repoInfo["images"]
+                        .Cast<JProperty>()
+                        .Any(imageInfo => imageInfo.Value["simpleTags"].Any(imageTag => imageTag.ToString() == tag));
+                }
+                else
+                {
+                    imageExistsInStaging = false;
+                }
+            }
+
+            return imageExistsInStaging ? $"{Registry}/{RepoPrefix}" : "mcr.microsoft.com/";
         }
 
         private static string GetManifestRegistry()

--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -10,7 +10,8 @@ param(
     [string]$Registry,
     [string]$RepoPrefix,
     [string]$TestCategory,
-    [switch]$IsLocalRun
+    [switch]$IsLocalRun,
+    [string]$ImageInfoPath
 )
 
 Set-StrictMode -Version Latest
@@ -37,6 +38,7 @@ $env:IMAGE_OS_FILTER = $OSFilter
 $env:IMAGE_VERSION_FILTER = $VersionFilter
 $env:REGISTRY = $Registry
 $env:REPO_PREFIX = $RepoPrefix
+$env:IMAGE_INFO_PATH = $ImageInfoPath
 
 if ($IsLocalRun) {
     $env:LOCAL_RUN = 1


### PR DESCRIPTION
Integrates the latest changes in the eng/common folder.

Since the logic in eng/common folder is now passing the ImageInfoPath argument to the run-tests PowerShell script, I've updated the script and test code to honor that argument and to pull images from the appropriate location (staging or MCR) based on whether the image tag is contained in the image info file.