### PR TITLE
Add 4.6.1 SDK to 4.7.2 SDK images

### DIFF
--- a/4.7.2/sdk/windowsservercore-1803/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-1803/Dockerfile
@@ -22,6 +22,7 @@ RUN `
     && start /w vs_BuildTools.exe ^ `
         --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
         --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Net.Component.4.6.1.SDK ^ `
         --add Microsoft.Net.Component.4.7.2.SDK ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `
@@ -43,7 +44,9 @@ ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\201
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\WinMDExp.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `

--- a/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -37,6 +37,7 @@ RUN `
     && start /w vs_BuildTools.exe ^ `
         --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
         --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Net.Component.4.6.1.SDK ^ `
         --add Microsoft.Net.Component.4.7.2.SDK ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `
@@ -64,7 +65,9 @@ ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\201
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\WinMDExp.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `

--- a/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -22,6 +22,7 @@ RUN `
     && start /w vs_BuildTools.exe ^ `
         --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
         --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Net.Component.4.6.1.SDK ^ `
         --add Microsoft.Net.Component.4.7.2.SDK ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `
@@ -43,7 +44,9 @@ ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\201
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
 RUN `
     # Workaround for issue with 32 bit assemblies from Microsoft.Net.Component.4.7.2.SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\WinMDExp.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\WinMDExp.exe" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `


### PR DESCRIPTION
Adds 4.6.1 SDK to the 4.7.2 SDK images to fix some issues with MSBuild that requires 4.6.1 to be installed.

Related to #214 
