### PR TITLE
Trim test matrix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -70,16 +70,7 @@
               "tags": {
                 "4.7.2-$(RuntimeReleaseDateStamp)-windowsservercore-ltsc2016": {},
                 "4.7.2-windowsservercore-ltsc2016": {}
-              },
-              "customBuildLegGrouping": [
-                {
-                  "name": "pr-build",
-                  "dependencies": [
-                    "$(Repo:runtime):4.8-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.8-windowsservercore-ltsc2016"
-                  ]
-                }
-              ]
+              }
             },
             {
               "dockerfile": "4.7.2/runtime/windowsservercore-1803",
@@ -88,16 +79,7 @@
               "tags": {
                 "4.7.2-$(RuntimeReleaseDateStamp)-windowsservercore-1803": {},
                 "4.7.2-windowsservercore-1803": {}
-              },
-              "customBuildLegGrouping": [
-                {
-                  "name": "pr-build",
-                  "dependencies": [
-                    "$(Repo:runtime):4.8-windowsservercore-1803",
-                    "$(Repo:sdk):4.8-windowsservercore-1803"
-                  ]
-                }
-              ]
+              }
             },
             {
               "dockerfile": "4.7.2/runtime/windowsservercore-ltsc2019",
@@ -106,16 +88,7 @@
               "tags": {
                 "4.7.2-$(RuntimeReleaseDateStamp)-windowsservercore-ltsc2019": {},
                 "4.7.2-windowsservercore-ltsc2019": {}
-              },
-              "customBuildLegGrouping": [
-                {
-                  "name": "pr-build",
-                  "dependencies": [
-                    "$(Repo:runtime):4.8-windowsservercore-ltsc2019",
-                    "$(Repo:sdk):4.8-windowsservercore-ltsc2019"
-                  ]
-                }
-              ]
+              }
             }
           ]
         },
@@ -131,16 +104,7 @@
               "tags": {
                 "4.7.1-$(RuntimeReleaseDateStamp)-windowsservercore-ltsc2016": {},
                 "4.7.1-windowsservercore-ltsc2016": {}
-              },
-              "customBuildLegGrouping": [
-                {
-                  "name": "pr-build",
-                  "dependencies": [
-                    "$(Repo:runtime):4.8-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.8-windowsservercore-ltsc2016"
-                  ]
-                }
-              ]
+              }
             }
           ]
         },
@@ -161,10 +125,8 @@
                 {
                   "name": "pr-build",
                   "dependencies": [
-                    "$(Repo:runtime):4.7.1-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.7.1-windowsservercore-ltsc2016",
-                    "$(Repo:runtime):4.8-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.8-windowsservercore-ltsc2016"
+                    "$(Repo:runtime):4.7.2-windowsservercore-ltsc2016",
+                    "$(Repo:sdk):4.7.2-windowsservercore-ltsc2016"
                   ]
                 }
               ]
@@ -188,8 +150,6 @@
                 {
                   "name": "pr-build",
                   "dependencies": [
-                    "$(Repo:runtime):4.7.2-windowsservercore-ltsc2016",
-                    "$(Repo:sdk):4.7.2-windowsservercore-ltsc2016",
                     "$(Repo:runtime):4.8-windowsservercore-ltsc2016",
                     "$(Repo:sdk):4.8-windowsservercore-ltsc2016"
                   ]

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
@@ -29,71 +29,71 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         public static string RepoPrefix { get; } = Environment.GetEnvironmentVariable("REPO_PREFIX") ?? string.Empty;
         public static string Registry { get; } = Environment.GetEnvironmentVariable("REGISTRY") ?? GetManifestRegistry();
         private static string VersionFilter => Environment.GetEnvironmentVariable("IMAGE_VERSION_FILTER");
-        private static ImageDescriptor[] RuntimeTestData = new ImageDescriptor[]
+        private static RuntimeImageDescriptor[] RuntimeTestData = new RuntimeImageDescriptor[]
         {
-            new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_1903 },
-            new ImageDescriptor { RuntimeVersion = "4.6.2", BuildVersion = "4.8", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7", BuildVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.1", BuildVersion = "4.7.1", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", BuildVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", BuildVersion = "4.7.2", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", BuildVersion = "4.7.2", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "4.8", BuildVersion = "4.8", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "4.8", BuildVersion = "4.8", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.8", BuildVersion = "4.8", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "4.8", BuildVersion = "4.8", OsVariant = WSC_1903 },
+            new RuntimeImageDescriptor { Version = "3.5", SdkVersion = "3.5", OsVariant = WSC_LTSC2016 },
+            new RuntimeImageDescriptor { Version = "3.5", SdkVersion = "3.5", OsVariant = WSC_1803 },
+            new RuntimeImageDescriptor { Version = "3.5", SdkVersion = "3.5", OsVariant = WSC_LTSC2019 },
+            new RuntimeImageDescriptor { Version = "3.5", SdkVersion = "3.5", OsVariant = WSC_1903 },
+            new RuntimeImageDescriptor { Version = "4.6.2", SdkVersion = "4.8", OsVariant = WSC_LTSC2016 },
+            new RuntimeImageDescriptor { Version = "4.7", SdkVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
+            new RuntimeImageDescriptor { Version = "4.7.1", SdkVersion = "4.7.1", OsVariant = WSC_LTSC2016 },
+            new RuntimeImageDescriptor { Version = "4.7.2", SdkVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
+            new RuntimeImageDescriptor { Version = "4.7.2", SdkVersion = "4.7.2", OsVariant = WSC_1803 },
+            new RuntimeImageDescriptor { Version = "4.7.2", SdkVersion = "4.7.2", OsVariant = WSC_LTSC2019 },
+            new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = WSC_1803 },
+            new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = WSC_LTSC2016 },
+            new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = WSC_LTSC2019 },
+            new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = WSC_1903 },
         };
 
         private static ImageDescriptor[] SdkTestData = new ImageDescriptor[]
         {
-            new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "3.5", BuildVersion = "3.5", OsVariant = WSC_1903 },
-            new ImageDescriptor { RuntimeVersion = "4.7.1", BuildVersion = "4.7.1", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", BuildVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", BuildVersion = "4.7.2", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", BuildVersion = "4.7.2", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "4.8", BuildVersion = "4.8", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "4.8", BuildVersion = "4.8", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.8", BuildVersion = "4.8", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "4.8", BuildVersion = "4.8", OsVariant = WSC_1903 },
+            new ImageDescriptor { Version = "3.5", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "3.5", OsVariant = WSC_1803 },
+            new ImageDescriptor { Version = "3.5", OsVariant = WSC_LTSC2019 },
+            new ImageDescriptor { Version = "3.5", OsVariant = WSC_1903 },
+            new ImageDescriptor { Version = "4.7.1", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_1803 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_LTSC2019 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_1803 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_LTSC2019 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_1903 },
         };
 
         private static ImageDescriptor[] AspnetTestData = new ImageDescriptor[]
         {
-            new ImageDescriptor { RuntimeVersion = "3.5", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "3.5", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "3.5", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "3.5", OsVariant = WSC_1903 },
-            new ImageDescriptor { RuntimeVersion = "4.6.2", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.1", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", OsVariant = WSC_1903 },
-            new ImageDescriptor { RuntimeVersion = "4.8", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.8", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "4.8", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "4.8",  OsVariant = WSC_1903 },
+            new ImageDescriptor { Version = "3.5", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "3.5", OsVariant = WSC_1803 },
+            new ImageDescriptor { Version = "3.5", OsVariant = WSC_LTSC2019 },
+            new ImageDescriptor { Version = "3.5", OsVariant = WSC_1903 },
+            new ImageDescriptor { Version = "4.6.2", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.1", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_1803 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_LTSC2019 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_1903 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_1803 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_LTSC2019 },
+            new ImageDescriptor { Version = "4.8",  OsVariant = WSC_1903 },
         };
 
         private static ImageDescriptor[] WcfTestData = new ImageDescriptor[]
         {
-            new ImageDescriptor { RuntimeVersion = "4.6.2", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.1", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "4.7.2", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "4.8", OsVariant = WSC_1803 },
-            new ImageDescriptor { RuntimeVersion = "4.8", OsVariant = WSC_LTSC2016 },
-            new ImageDescriptor { RuntimeVersion = "4.8", OsVariant = WSC_LTSC2019 },
-            new ImageDescriptor { RuntimeVersion = "4.8", OsVariant = WSC_1903 },
+            new ImageDescriptor { Version = "4.6.2", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.1", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_1803 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = WSC_LTSC2019 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_1803 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_LTSC2019 },
+            new ImageDescriptor { Version = "4.8", OsVariant = WSC_1903 },
         };
 
         private static Lazy<JArray> ImageInfoData;
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                 .Where(imageDescriptor => OSFilter == null
                     || Regex.IsMatch(imageDescriptor.OsVariant, osFilterPattern, RegexOptions.IgnoreCase))
                 .Where(imageDescriptor => VersionFilter == null
-                    || Regex.IsMatch(imageDescriptor.RuntimeVersion, versionFilterPattern, RegexOptions.IgnoreCase))
+                    || Regex.IsMatch(imageDescriptor.Version, versionFilterPattern, RegexOptions.IgnoreCase))
                 .Select(imageDescriptor => new object[] { imageDescriptor });
         }
 
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         [Trait("Category", "runtime")]
         [Trait("Category", "sdk")]
         [MemberData(nameof(GetVerifyRuntimeImagesData))]
-        public void VerifyImagesWithApps(ImageDescriptor imageDescriptor)
+        public void VerifyImagesWithApps(RuntimeImageDescriptor imageDescriptor)
         {
             VerifyFxImages(imageDescriptor, "dotnetapp", "", true);
         }
@@ -174,7 +174,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         [Trait("Category", "runtime")]
         [Trait("Category", "sdk")]
         [MemberData(nameof(GetVerifyRuntimeImagesData))]
-        public void VerifyImagesWithWebApps(ImageDescriptor imageDescriptor)
+        public void VerifyImagesWithWebApps(RuntimeImageDescriptor imageDescriptor)
         {
             VerifyFxImages(imageDescriptor, "webapp", "powershell -command \"dir ./bin/SimpleWebApplication.dll\"", false);
         }
@@ -202,7 +202,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                 new Version("4.8")
             };
 
-            string baseBuildImage = GetImage("sdk", imageDescriptor.BuildVersion, imageDescriptor.OsVariant);
+            string baseBuildImage = GetImage("sdk", imageDescriptor.Version, imageDescriptor.OsVariant);
             string appId = $"targetingpacks-{DateTime.Now.ToFileTime()}";
             string command = @"cmd /c dir /B ""C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework""";
             string output = _dockerHelper.Run(image: baseBuildImage, name: appId, command: command);
@@ -210,8 +210,13 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             IEnumerable<Version> actualVersions = output.Split(Environment.NewLine)
                 .Select(name => new Version(name.Substring(1))); // Trim the first character (v4.0 => 4.0)
 
-            Version buildVersion = new Version(imageDescriptor.BuildVersion);
-            IEnumerable<Version> expectedVersions = allFrameworkVersions.Where(version => version <= buildVersion);
+            Version buildVersion = new Version(imageDescriptor.Version);
+
+            IEnumerable<Version> expectedVersions = allFrameworkVersions;
+            if (imageDescriptor.Version != "3.5")
+            {
+                expectedVersions = allFrameworkVersions.Where(version => version <= buildVersion);
+            }
 
             Assert.Equal(expectedVersions, actualVersions);
         }
@@ -233,14 +238,14 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             VerifyWcfImages(imageDescriptor);
         }
 
-        private void VerifyFxImages(ImageDescriptor imageDescriptor, string appDescriptor, string runCommand, bool includeRuntime)
+        private void VerifyFxImages(RuntimeImageDescriptor imageDescriptor, string appDescriptor, string runCommand, bool includeRuntime)
         {
-            string baseBuildImage = GetImage("sdk", imageDescriptor.BuildVersion, imageDescriptor.OsVariant);
+            string baseBuildImage = GetImage("sdk", imageDescriptor.SdkVersion, imageDescriptor.OsVariant);
 
             List<string> appBuildArgs = new List<string> { $"BASE_BUILD_IMAGE={baseBuildImage}" };
             if (includeRuntime)
             {
-                string baseRuntimeImage = GetImage("runtime", imageDescriptor.RuntimeVersion, imageDescriptor.OsVariant);
+                string baseRuntimeImage = GetImage("runtime", imageDescriptor.Version, imageDescriptor.OsVariant);
                 appBuildArgs.Add($"BASE_RUNTIME_IMAGE={baseRuntimeImage}");
             }
 
@@ -257,7 +262,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         {
             List<string> appBuildArgs = new List<string> { };
 
-            string baseAspnetImage = GetImage("aspnet", imageDescriptor.RuntimeVersion, imageDescriptor.OsVariant);
+            string baseAspnetImage = GetImage("aspnet", imageDescriptor.Version, imageDescriptor.OsVariant);
             appBuildArgs.Add($"BASE_ASPNET_IMAGE={baseAspnetImage}");
 
             VerifyImages(
@@ -273,7 +278,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         {
             List<string> appBuildArgs = new List<string> { };
 
-            string baseWCFImage = GetImage("wcf", imageDescriptor.RuntimeVersion, imageDescriptor.OsVariant);
+            string baseWCFImage = GetImage("wcf", imageDescriptor.Version, imageDescriptor.OsVariant);
             appBuildArgs.Add($"BASE_WCF_IMAGE={baseWCFImage}");
 
             VerifyImages(
@@ -296,7 +301,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             string workDir = Path.Combine(
                 Directory.GetCurrentDirectory(),
                 "projects",
-                $"{appDescriptor}-{imageDescriptor.RuntimeVersion}");
+                $"{appDescriptor}-{imageDescriptor.Version}");
 
             try
             {

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeImageDescriptor.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeImageDescriptor.cs
@@ -4,9 +4,8 @@
 
 namespace Microsoft.DotNet.Framework.Docker.Tests
 {
-    public class ImageDescriptor
+    public class RuntimeImageDescriptor : ImageDescriptor
     {
-        public string Version { get; set; }
-        public string OsVariant { get; set; }
+        public string SdkVersion { get; set; }
     }
 }


### PR DESCRIPTION
Trims down the test matrix so that we don't have so much testing overhead but still maintain decent coverage.

Adds an additional test which verifies the expected targeting packs are installed on the SDK images.

Fixes #404 