### PR TITLE
Modify runtime ngen Dockerfile comments to be consistent

### DIFF
--- a/3.5/runtime/windowsservercore-1803/Dockerfile
+++ b/3.5/runtime/windowsservercore-1803/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/s
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4520008-x64.cab `
     && rmdir /S /Q patch
 
-# ngen .NET 3.5 Fx
+# ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
 RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `

--- a/3.5/runtime/windowsservercore-1903/Dockerfile
+++ b/3.5/runtime/windowsservercore-1903/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/s
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4515871-x64.cab `
     && rmdir /S /Q patch
 
-# ngen .NET 3.5 Fx
+# ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
 RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `

--- a/3.5/runtime/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/runtime/windowsservercore-ltsc2019/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/s
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\Windows10.0-kb4515843-x64.cab `
     && rmdir /S /Q patch
 
-# ngen .NET 3.5 Fx
+# ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
 RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `

--- a/4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile
+++ b/4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.8/runtime/windowsservercore-1903/Dockerfile
+++ b/4.8/runtime/windowsservercore-1903/Dockerfile
@@ -2,8 +2,8 @@
 
 FROM mcr.microsoft.com/windows/servercore:1903
 
+# ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update


### PR DESCRIPTION
The runtime Dockerfiles were not all following a consistent pattern around the ngen section.

1. The various Dockerfiles did not all of a comment around this section.
1. Some sections had a space between the ENV and RUN instructions.
1. The some but not all 3.5 Dockerfiles used `3.5` in the comment.