### PR TITLE
Fix environment variable declarations in Dockerfiles for Windows 1909

### DIFF
--- a/3.5/runtime/windowsservercore-1909/Dockerfile
+++ b/3.5/runtime/windowsservercore-1909/Dockerfile
@@ -3,9 +3,9 @@
 FROM mcr.microsoft.com/windows/servercore:1909
 
 # Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true `
+ENV DOTNET_RUNNING_IN_CONTAINER=true `
     # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
-    COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+    COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 # Install .NET Fx 3.5
 RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1909.zip `
@@ -17,7 +17,5 @@ RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.win
 
 # ngen .NET 3.5 Fx
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.VisualC, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=msil" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "Microsoft.VisualC, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=msil" `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/3.5/sdk/windowsservercore-1909/Dockerfile
+++ b/3.5/sdk/windowsservercore-1909/Dockerfile
@@ -40,8 +40,8 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
     && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV DOTNET_USE_POLLING_FILE_WATCHER true `
-    ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
+    ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
 RUN `

--- a/3.5/sdk/windowsservercore-1909/Dockerfile
+++ b/3.5/sdk/windowsservercore-1909/Dockerfile
@@ -48,7 +48,6 @@ RUN `
     # Workaround for issues with 64-bit ngen 
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=msil" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
@@ -67,7 +66,6 @@ RUN `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn\VBCSCompiler.exe.config" `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn\Microsoft.DiaSymReader.Native.amd64.dll" `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn\Microsoft.DiaSymReader.Native.x86.dll" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=msil" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/4.8/runtime/windowsservercore-1909/Dockerfile
+++ b/4.8/runtime/windowsservercore-1909/Dockerfile
@@ -3,12 +3,10 @@
 FROM mcr.microsoft.com/windows/servercore:1909
 
 # Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER true `
+ENV DOTNET_RUNNING_IN_CONTAINER=true `
     # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
-    COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+    COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.VisualC, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=msil" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "Microsoft.VisualC, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=msil" `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/4.8/sdk/windowsservercore-1909/Dockerfile
+++ b/4.8/sdk/windowsservercore-1909/Dockerfile
@@ -40,8 +40,8 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
     && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV DOTNET_USE_POLLING_FILE_WATCHER true `
-    ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
+    ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
 RUN `

--- a/4.8/sdk/windowsservercore-1909/Dockerfile
+++ b/4.8/sdk/windowsservercore-1909/Dockerfile
@@ -48,7 +48,6 @@ RUN `
     # Workaround for issues with 64-bit ngen 
     \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=msil" `
     `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     `
@@ -67,7 +66,6 @@ RUN `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn\VBCSCompiler.exe.config" `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn\Microsoft.DiaSymReader.Native.amd64.dll" `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn\Microsoft.DiaSymReader.Native.x86.dll" `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen uninstall "System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=Neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=msil" `
     `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -52,8 +52,8 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20191112-windowsservercore-1909, 4.8-windowsservercore-1909, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/aspnet/windowsservercore-1909/Dockerfile)
-3.5-20191112-windowsservercore-1909, 3.5-windowsservercore-1909, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/aspnet/windowsservercore-1909/Dockerfile)
+4.8-20191118-windowsservercore-1909, 4.8-windowsservercore-1909, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/aspnet/windowsservercore-1909/Dockerfile)
+3.5-20191118-windowsservercore-1909, 3.5-windowsservercore-1909, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/aspnet/windowsservercore-1909/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 Tag | Dockerfile

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -45,8 +45,8 @@ docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20191112-windowsservercore-1909, 4.8-windowsservercore-1909, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/runtime/windowsservercore-1909/Dockerfile)
-3.5-20191112-windowsservercore-1909, 3.5-windowsservercore-1909, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-1909/Dockerfile)
+4.8-20191118-windowsservercore-1909, 4.8-windowsservercore-1909, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/runtime/windowsservercore-1909/Dockerfile)
+3.5-20191118-windowsservercore-1909, 3.5-windowsservercore-1909, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/runtime/windowsservercore-1909/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 Tag | Dockerfile

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -51,8 +51,8 @@ The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framewor
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20191112-windowsservercore-1909, 4.8-windowsservercore-1909, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/sdk/windowsservercore-1909/Dockerfile)
-3.5-20191112-windowsservercore-1909, 3.5-windowsservercore-1909, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1909/Dockerfile)
+4.8-20191118-windowsservercore-1909, 4.8-windowsservercore-1909, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/sdk/windowsservercore-1909/Dockerfile)
+3.5-20191118-windowsservercore-1909, 3.5-windowsservercore-1909, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1909/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 Tag | Dockerfile

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -49,7 +49,7 @@ docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.
 ## Windows Server, version 1909 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20191112-windowsservercore-1909, 4.8-windowsservercore-1909, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/wcf/windowsservercore-1909/Dockerfile)
+4.8-20191118-windowsservercore-1909, 4.8-windowsservercore-1909, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/wcf/windowsservercore-1909/Dockerfile)
 
 ## Windows Server, version 1903 amd64 Tags
 Tag | Dockerfile

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,11 @@
     "11B-RuntimeReleaseDateStamp": "20191112",
     "11B-SdkReleaseDateStamp": "20191112",
     "11B-AspnetReleaseDateStamp": "20191112",
-    "11B-WcfReleaseDateStamp": "20191112"
+    "11B-WcfReleaseDateStamp": "20191112",
+    "EnvVarFix-RuntimeReleaseDateStamp": "20191118",
+    "EnvVarFix-SdkReleaseDateStamp": "20191118",
+    "EnvVarFix-AspnetReleaseDateStamp": "20191118",
+    "EnvVarFix-WcfReleaseDateStamp": "20191118"
   },
   "repos": [
     {
@@ -56,7 +60,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1909",
               "tags": {
-                "4.8-$(11B-RuntimeReleaseDateStamp)-windowsservercore-1909": {},
+                "4.8-$(EnvVarFix-RuntimeReleaseDateStamp)-windowsservercore-1909": {},
                 "4.8-windowsservercore-1909": {}
               }
             }
@@ -217,7 +221,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1909",
               "tags": {
-                "3.5-$(11B-RuntimeReleaseDateStamp)-windowsservercore-1909": {},
+                "3.5-$(EnvVarFix-RuntimeReleaseDateStamp)-windowsservercore-1909": {},
                 "3.5-windowsservercore-1909": {}
               }
             }
@@ -281,7 +285,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1909",
               "tags": {
-                "4.8-$(11B-SdkReleaseDateStamp)-windowsservercore-1909": {},
+                "4.8-$(EnvVarFix-SdkReleaseDateStamp)-windowsservercore-1909": {},
                 "4.8-windowsservercore-1909": {}
               }
             }
@@ -336,7 +340,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1909",
               "tags": {
-                "3.5-$(11B-SdkReleaseDateStamp)-windowsservercore-1909": {},
+                "3.5-$(EnvVarFix-SdkReleaseDateStamp)-windowsservercore-1909": {},
                 "3.5-windowsservercore-1909": {}
               }
             }
@@ -400,7 +404,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1909",
               "tags": {
-                "4.8-$(11B-AspnetReleaseDateStamp)-windowsservercore-1909": {},
+                "4.8-$(EnvVarFix-AspnetReleaseDateStamp)-windowsservercore-1909": {},
                 "4.8-windowsservercore-1909": {}
               }
             }
@@ -543,7 +547,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1909",
               "tags": {
-                "3.5-$(11B-AspnetReleaseDateStamp)-windowsservercore-1909": {},
+                "3.5-$(EnvVarFix-AspnetReleaseDateStamp)-windowsservercore-1909": {},
                 "3.5-windowsservercore-1909": {}
               }
             }
@@ -607,7 +611,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1909",
               "tags": {
-                "4.8-$(11B-WcfReleaseDateStamp)-windowsservercore-1909": {},
+                "4.8-$(EnvVarFix-WcfReleaseDateStamp)-windowsservercore-1909": {},
                 "4.8-windowsservercore-1909": {}
               }
             }

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/EnvironmentVariableInfo.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/EnvironmentVariableInfo.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.DotNet.Framework.Docker.Tests
+{
+    public class EnvironmentVariableInfo
+    {
+        public bool AllowAnyValue { get; private set; }
+        public string ExpectedValue { get; private set; }
+        public string Name { get; private set; }
+
+        public EnvironmentVariableInfo(string name, string expectedValue)
+        {
+            this.Name = name;
+            this.ExpectedValue = expectedValue;
+        }
+
+        public EnvironmentVariableInfo(string name, bool allowAnyValue)
+        {
+            this.Name = name;
+            this.AllowAnyValue = allowAnyValue;
+        }
+
+        public static void Validate(
+            IEnumerable<EnvironmentVariableInfo> variables,
+            string imageType,
+            ImageDescriptor imageDescriptor,
+            ImageTestHelper imageTestHelper)
+        {
+            const char delimiter = '|';
+            IEnumerable<string> echoParts;
+            string invokeCommand;
+            char delimiterEscape;
+
+            if (DockerHelper.IsLinuxContainerModeEnabled)
+            {
+                echoParts = variables.Select(envVar => $"${envVar.Name}");
+                invokeCommand = $"/bin/sh -c";
+                delimiterEscape = '\\';
+            }
+            else
+            {
+                echoParts = variables.Select(envVar => $"%{envVar.Name}%");
+                invokeCommand = $"CMD /S /C";
+                delimiterEscape = '^';
+            }
+
+            string appId = $"envvar-{DateTime.Now.ToFileTime()}";
+
+            string combinedValues = imageTestHelper.DockerHelper.Run(
+                image: imageTestHelper.GetImage(imageType, imageDescriptor.Version, imageDescriptor.OsVariant),
+                name: appId,
+                command: $"{invokeCommand} \"echo {String.Join($"{delimiterEscape}{delimiter}", echoParts)}\"");
+
+            string[] values = combinedValues.Split(delimiter);
+            Assert.Equal(variables.Count(), values.Count());
+
+            for (int i = 0; i < values.Count(); i++)
+            {
+                EnvironmentVariableInfo variable = variables.ElementAt(i);
+
+                string actualValue;
+                // Process unset variables in Windows
+                if (!DockerHelper.IsLinuxContainerModeEnabled
+                    && string.Equals(values[i], $"%{variable.Name}%", StringComparison.Ordinal))
+                {
+                    actualValue = string.Empty;
+                }
+                else
+                {
+                    actualValue = values[i];
+                }
+
+                if (variable.AllowAnyValue)
+                {
+                    Assert.NotEmpty(actualValue);
+                }
+                else
+                {
+                    Assert.Equal(variable.ExpectedValue, actualValue);
+                }
+            }
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         }
 
         [Theory]
+        [Trait("Category", "runtime")]
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(ImageDescriptor imageDescriptor)
         {

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Framework.Docker.Tests
+{
+    public class RuntimeOnlyImageTests
+    {
+        private static ImageDescriptor[] ImageData = new ImageDescriptor[]
+        {
+            new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_LTSC2016 },
+            new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_LTSC2019 },
+            new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_1903 },
+            new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_1909 },
+            new ImageDescriptor { Version = "4.6.2", OsVariant = OsVersion.WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7", OsVariant = OsVersion.WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.1", OsVariant = OsVersion.WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = OsVersion.WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.7.2", OsVariant = OsVersion.WSC_LTSC2019 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2019 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1903 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1909 },
+        };
+
+        private readonly ImageTestHelper imageTestHelper;
+
+        public RuntimeOnlyImageTests(ITestOutputHelper outputHelper)
+        {
+            imageTestHelper = new ImageTestHelper(outputHelper);
+        }
+
+        public static IEnumerable<object[]> GetImageData()
+        {
+            return ImageTestHelper.ApplyImageDataFilters(ImageData);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyEnvironmentVariables(ImageDescriptor imageDescriptor)
+        {
+            EnvironmentVariableInfo.Validate(
+                GetRuntimeEnvironmentVariableInfos(imageDescriptor), "runtime", imageDescriptor, imageTestHelper);
+        }
+
+        public static IEnumerable<EnvironmentVariableInfo> GetRuntimeEnvironmentVariableInfos(ImageDescriptor imageDescriptor)
+        {
+            yield return new EnvironmentVariableInfo("COMPLUS_NGenProtectedProcess_FeatureEnabled", "0");
+
+            if ((imageDescriptor.Version == "3.5" || imageDescriptor.Version == "4.8") &&
+                imageDescriptor.OsVariant != OsVersion.WSC_LTSC2016 &&
+                imageDescriptor.OsVariant != OsVersion.WSC_LTSC2019 &&
+                imageDescriptor.OsVariant != OsVersion.WSC_1903)
+            {
+                yield return new EnvironmentVariableInfo("DOTNET_RUNNING_IN_CONTAINER", "true");
+            }
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         /// <summary>
         /// Verifies the SDK images contain the expected targeting packs.
         /// </summary>
+        [SkippableTheory("4.6.2", "4.7", "4.7.1", "4.7.2")]
         [Trait("Category", "sdk")]
         [MemberData(nameof(GetImageData))]
         public void VerifyTargetingPacks(ImageDescriptor imageDescriptor)
@@ -75,6 +76,27 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             }
 
             Assert.Equal(expectedVersions, actualVersions);
+        }
+
+        [SkippableTheory("4.6.2", "4.7", "4.7.1", "4.7.2")]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyEnvironmentVariables(ImageDescriptor imageDescriptor)
+        {
+            List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
+
+            variables.AddRange(RuntimeOnlyImageTests.GetRuntimeEnvironmentVariableInfos(imageDescriptor));
+
+            variables.Add(new EnvironmentVariableInfo("ROSLYN_COMPILER_LOCATION",
+                @"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"));
+
+            if (imageDescriptor.OsVariant != OsVersion.WSC_LTSC2016 &&
+                imageDescriptor.OsVariant != OsVersion.WSC_LTSC2019 &&
+                imageDescriptor.OsVariant != OsVersion.WSC_1903)
+            {
+                variables.Add(new EnvironmentVariableInfo("DOTNET_USE_POLLING_FILE_WATCHER", "true"));
+            }
+
+            EnvironmentVariableInfo.Validate(variables, "sdk", imageDescriptor, imageTestHelper);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         }
 
         [SkippableTheory("4.6.2", "4.7", "4.7.1", "4.7.2")]
+        [Trait("Category", "sdk")]
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(ImageDescriptor imageDescriptor)
         {


### PR DESCRIPTION
Fixes the incorrect syntax of environment variables in Dockerfiles for Windows 1909.  Adds unit tests to verify environment variables are set correctly for runtime and SDK images across all versions.

Fixes #452 