### PR TITLE
Remove .git folder from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,3 @@
 **/.vs
 .dotnet
 .Microsoft.DotNet.ImageBuilder
-.git


### PR DESCRIPTION
Having the `.git` folder listed in `.dockerignore` breaks build pipeline logic when we build an ImageBuilder image that wraps the repo contents.  By not including the `.git` folder, it prevents `git` commands from being used within the resulting container.