### PR TITLE
Add ASP.NET and WCF environment variable tests

### DIFF
--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/AspnetImageTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "4.7.2", OsVariant = OsVersion.WSC_LTSC2019 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2019 },
-            new ImageDescriptor { Version = "4.8",  OsVariant = OsVersion.WSC_1903 },
-            new ImageDescriptor { Version = "4.8",  OsVariant = OsVersion.WSC_1909 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1903 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1909 },
         };
 
         public AspnetImageTests(ITestOutputHelper outputHelper)
@@ -33,6 +33,27 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         }
 
         protected override string ImageType => "aspnet";
+
+        [Theory]
+        [Trait("Category", "aspnet")]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyEnvironmentVariables(ImageDescriptor imageDescriptor)
+        {
+            VerifyCommonEnvironmentVariables(GetEnvironmentVariables(imageDescriptor), imageDescriptor);
+        }
+
+        public static IEnumerable<EnvironmentVariableInfo> GetEnvironmentVariables(ImageDescriptor imageDescriptor)
+        {
+            List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
+            variables.AddRange(RuntimeOnlyImageTests.GetEnvironmentVariables(imageDescriptor));
+
+            if (imageDescriptor.Version != "3.5")
+            {
+                variables.Add(new EnvironmentVariableInfo("ROSLYN_COMPILER_LOCATION", "c:\\\\RoslynCompilers\\\\tools"));
+            }
+
+            return variables;
+        }
 
         [Theory]
         [Trait("Category", "aspnet")]

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTests.cs
@@ -30,29 +30,14 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         protected void VerifyCommonEnvironmentVariables(IEnumerable<EnvironmentVariableInfo> variables, ImageDescriptor imageDescriptor)
         {
             const char delimiter = '|';
-            IEnumerable<string> echoParts;
-            string invokeCommand;
-            char delimiterEscape;
-
-            if (DockerHelper.IsLinuxContainerModeEnabled)
-            {
-                echoParts = variables.Select(envVar => $"${envVar.Name}");
-                invokeCommand = $"/bin/sh -c";
-                delimiterEscape = '\\';
-            }
-            else
-            {
-                echoParts = variables.Select(envVar => $"%{envVar.Name}%");
-                invokeCommand = $"CMD /S /C";
-                delimiterEscape = '^';
-            }
-
             string appId = $"envvar-{DateTime.Now.ToFileTime()}";
+            IEnumerable<string> echoParts= variables.Select(envVar => $"%{envVar.Name}%");
 
             string combinedValues = ImageTestHelper.DockerHelper.Run(
                 image: ImageTestHelper.GetImage(ImageType, imageDescriptor.Version, imageDescriptor.OsVariant),
                 name: appId,
-                command: $"{invokeCommand} \"echo {String.Join($"{delimiterEscape}{delimiter}", echoParts)}\"");
+                entrypointOverride: "cmd",
+                command: $"CMD /S /C \"echo {String.Join($"^{delimiter}", echoParts)}\"");
 
             string[] values = combinedValues.Split(delimiter);
             Assert.Equal(variables.Count(), values.Count());

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyEnvironmentVariables(ImageDescriptor imageDescriptor)
         {
-            VerifyCommonEnvironmentVariables(GetRuntimeEnvironmentVariableInfos(imageDescriptor), imageDescriptor);
+            VerifyCommonEnvironmentVariables(GetEnvironmentVariables(imageDescriptor), imageDescriptor);
         }
 
         [Theory]
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             VerifyCommmonNgenQueuesAreEmpty(imageDescriptor);
         }
 
-        public static IEnumerable<EnvironmentVariableInfo> GetRuntimeEnvironmentVariableInfos(ImageDescriptor imageDescriptor)
+        public static IEnumerable<EnvironmentVariableInfo> GetEnvironmentVariables(ImageDescriptor imageDescriptor)
         {
             yield return new EnvironmentVariableInfo("COMPLUS_NGenProtectedProcess_FeatureEnabled", "0");
 

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         {
             List<EnvironmentVariableInfo> variables = new List<EnvironmentVariableInfo>();
 
-            variables.AddRange(RuntimeOnlyImageTests.GetRuntimeEnvironmentVariableInfos(imageDescriptor));
+            variables.AddRange(RuntimeOnlyImageTests.GetEnvironmentVariables(imageDescriptor));
 
             variables.Add(new EnvironmentVariableInfo("ROSLYN_COMPILER_LOCATION",
                 @"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"));

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SkippableTheoryAttribute.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SkippableTheoryAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
     {
         public SkippableTheoryAttribute(params string[] skipOnRuntimeVersions)
         {
-            if (Config.VersionFilter != "*")
+            if (!string.IsNullOrEmpty(Config.VersionFilter) && Config.VersionFilter != "*")
             {
                 string versionFilterPattern =
                     Config.VersionFilter != null ? Config.GetFilterRegexPattern(Config.VersionFilter) : null;

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/WcfImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/WcfImageTests.cs
@@ -30,6 +30,14 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
 
         protected override string ImageType => "wcf";
 
+        [SkippableTheory("3.5")]
+        [Trait("Category", "wcf")]
+        [MemberData(nameof(GetImageData))]
+        public void VerifyEnvironmentVariables(ImageDescriptor imageDescriptor)
+        {
+            VerifyCommonEnvironmentVariables(AspnetImageTests.GetEnvironmentVariables(imageDescriptor), imageDescriptor);
+        }
+
         // Skip the test if it's for 3.5 to avoid empty MemberData (see https://github.com/xunit/xunit/issues/1113)
         [SkippableTheory("3.5")]
         [Trait("Category", "wcf")]


### PR DESCRIPTION
Fixes #455 
Fixes #456 

This uncovered an [issue ](https://github.com/microsoft/dotnet-framework-docker/issues/474)with the ROSLYN_COMPILER_LOCATION variable being defined incorrectly.
