### PR TITLE
Set TLS protocol version to download .NET install script

### DIFF
--- a/tests/run-tests.ps1
+++ b/tests/run-tests.ps1
@@ -44,6 +44,7 @@ $dotnetInstallScript = "dotnet-install.ps1";
 $dotnetInstallScriptPath = "$dotnetInstallDir/$DotnetInstallScript"
 if (!(Test-Path $dotnetInstallScriptPath)) {
     $dotnetInstallScriptUrl = "https://dot.net/v1/$dotnetInstallScript"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
     Invoke-WebRequest $dotnetInstallScriptUrl -OutFile $dotnetInstallScriptPath
 }
 


### PR DESCRIPTION
We've got a new set of Windows Server 2016 build agents that appear to be configured with a minimum TLS version of 1.2.  This causes an error when attempting to download the .NET install script in the tests because the default protocol version of PowerShell is TLS 1.0.  Fixing this by explicitly setting the TLS version to 1.2 for that PowerShell script that does the download.  This is actually the prescribed way of doing this as documented here: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script.