### PR TITLE
Added 'Image Update Policy' section to the READMEs

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -10,10 +10,11 @@
 ASP.NET is a high productivity framework for building Web Applications using Web Forms, MVC, Web API and SignalR.
 
 This image contains:
-- Windows Server Core as the base OS
-- IIS 10 as Web Server
-- .NET Framework (multiple versions available)
-- .NET Extensibility for IIS
+
+* Windows Server Core as the base OS
+* IIS 10 as Web Server
+* .NET Framework (multiple versions available)
+* .NET Extensibility for IIS
 
 Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
 
@@ -82,7 +83,12 @@ You can retrieve a list of all available tags for dotnet/framework/aspnet at htt
 
 # Support
 
-See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/en-us/help/17455/lifecycle-faq-net-framework)
+See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
+
+# Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:1909, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
 
 # Feedback
 
@@ -95,7 +101,6 @@ See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/en-us/help/
 
 # License
 
-View [license information](https://www.microsoft.com/net/dotnet_library_license.htm) for the software contained in this image. 
+View [license information](https://www.microsoft.com/net/dotnet_library_license.htm) for the software contained in this image.
 
 Windows Container images use the same license as the [Windows Server Core base image](https://hub.docker.com/_/microsoft-windows-servercore/).
-

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/en-us/help/17455/lifecycle-faq-net-framework)
 
+# Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:1909, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
+
 # Feedback
 
 * [File a .NET Framework Docker issue](https://github.com/microsoft/dotnet-framework-docker/issues)

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -77,6 +77,11 @@ You can retrieve a list of all available tags for dotnet/framework/runtime at ht
 
 See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/en-us/help/17455/lifecycle-faq-net-framework)
 
+# Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:1909, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
+
 # Feedback
 
 * [File a .NET Framework Docker issue](https://github.com/microsoft/dotnet-framework-docker/issues)

--- a/README.samples.md
+++ b/README.samples.md
@@ -44,15 +44,20 @@ Type the following command to run a sample WCF service application with Docker:
 ```console
 docker run -it --rm --name wcfservice_sample mcr.microsoft.com/dotnet/framework/samples:wcfservice
 ```
+
 After the container starts, find the IP address of the container instance:
+
 ```console
 docker inspect --format="{{.NetworkSettings.Networks.nat.IPAddress}}" wcfservice_sample
 172.26.236.119
 ```
+
 Type the following Docker command to start a WCF client container, set environment variable HOST to the IP address of the wcfservice_sample container:
+
 ```console
 docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 mcr.microsoft.com/dotnet/framework/samples:wcfclient
 ```
+
 # Related Repos
 
 .NET Framework:
@@ -107,6 +112,11 @@ You can retrieve a list of all available tags for dotnet/framework/samples at ht
 # Support
 
 See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/en-us/help/17455/lifecycle-faq-net-framework)
+
+# Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:1909, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
 
 # Feedback
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -76,7 +76,12 @@ You can retrieve a list of all available tags for dotnet/framework/sdk at https:
 
 # Support
 
-See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/en-us/help/17455/lifecycle-faq-net-framework)
+See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
+
+# Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:1909, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
 
 # Feedback
 

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -16,15 +16,20 @@ The [WCF Docker samples](https://github.com/Microsoft/dotnet-framework-docker/tr
 You can quickly run a container with a pre-built [sample WCF Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:
+
 ```console
 docker run --name wcfservicesample --rm -it mcr.microsoft.com/dotnet/framework/samples:wcfservice
 ```
+
 Find the IP address of the container instance.
+
 ```console
 docker inspect --format="{{.NetworkSettings.Networks.nat.IPAddress}}" wcfservicesample
 172.26.236.119
 ```
+
 Type the following Docker command to start a WCF client container, set environment variable HOST to the IP address of the wcfservicesample container:
+
 ```console
 docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.com/dotnet/framework/samples:wcfclient
 ```
@@ -77,6 +82,11 @@ You can retrieve a list of all available tags for dotnet/framework/wcf at https:
 
 See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/en-us/help/17455/lifecycle-faq-net-framework)
 
+# Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:1909, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
+
 # Feedback
 
 * [File a WCF Docker issue](https://github.com/microsoft/dotnet-framework-docker/issues)
@@ -88,8 +98,6 @@ See the [.NET Framework Lifecycle FAQ](https://support.microsoft.com/en-us/help/
 
 # License
 
-View [license information](https://www.microsoft.com/net/dotnet_library_license.htm) for the software contained in this image. 
+View [license information](https://www.microsoft.com/net/dotnet_library_license.htm) for the software contained in this image.
 
 Windows Container images use the same license as the [Windows Server Core base image](https://hub.docker.com/_/microsoft-windows-servercore/).
-
-


### PR DESCRIPTION
Added an 'Image Update Policy' section to the READMEs to call out when .NET Framework images will be updated. The purpose is to communicate our policy so that customers can know what to expect. The desired outcome is that more customers feel compelled to take a dependency on our images.

I also made a few other README edits to address MD rule violations.