### PR TITLE
Add path exclusions to pipeline

### DIFF
--- a/eng/pipelines/dotnet-framework.yml
+++ b/eng/pipelines/dotnet-framework.yml
@@ -1,7 +1,13 @@
 trigger: none
 pr:
-- master
-- dev
+  branches:
+    include:
+    - master
+    - dev
+  paths:
+    exclude:
+    - README*
+    - samples/*
 
 variables:
 - template: variables/common.yml


### PR DESCRIPTION
Ensures that PR builds will not trigger for commits that only consist of README or sample changes.

Fixes #495