### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: "Bug Report"
+about: Create a report to help us improve
+
+---
+
+## Steps to reproduce the issue
+1.
+2.
+3.
+
+## Expected behavior
+
+
+## Actual behavior
+
+
+## Additional information (e.g. issue happens only occasionally)
+
+
+## Output of `docker version`
+
+```
+(paste your output here)
+```
+
+## Output of `docker info`
+
+```
+(paste your output here)
+```

--- a/.github/ISSUE_TEMPLATE/releases/patch-tuesday-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/patch-tuesday-release.md
@@ -1,0 +1,31 @@
+# Patch Tuesday Release
+
+## Tasks
+
+1. - [ ] Merge any pending PRs or commits from `dev` branch:
+      - [ ] &lt;placeholder link&gt;
+1. - [ ] Look up the latest [NuGet CLI versions](https://www.nuget.org/downloads) and update the [nuget-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/nuget-info.json) file with the latest patch of each major/minor version listed in the file.
+1. - [ ] Wait for latest cumulative updates (LCUs) to be released (typically at 10 AM PST on Patch Tuesday).
+1. - [ ] Gather list of KB numbers for the .NET Framework updates from the .NET Release team.
+1. - [ ] Look up the download URL for each of the KB numbers in [Microsoft Update Catalog](https://www.catalog.update.microsoft.com/) and input them into the [lcu-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/lcu-info.json) file.
+1. - [ ] Run the `update-dependencies` tool to update all the necessary files:
+      - [ ] `dotnet run --project .\eng\update-dependencies\update-dependencies.csproj --datestamp-all <YYYYMMDD>`
+1. - [ ] Inspect generated changes for correctness
+1. - [ ] Commit generated changes
+1. - [ ] Create PR
+1. - [ ] Get PR signoff
+1. - [ ] Merge PR
+1. - [ ] Wait for changes to be mirrored to internal [dotnet-framework-docker repo](https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-framework-docker) (internal MSFT link)
+1. - [ ] Wait for the following Windows images to have been updated as part of the Windows Patch Tuesday release process (this begins at 10 AM PST on Patch Tuesday):
+      - [ ] `mcr.microsoft.com/windows/servercore:1809`
+      - [ ] `mcr.microsoft.com/windows/servercore:1903`
+      - [ ] `mcr.microsoft.com/windows/servercore:1909`
+      - [ ] `mcr.microsoft.com/windows/servercore:ltsc2016`
+      - [ ] `mcr.microsoft.com/windows/servercore:ltsc2019`
+1. - [ ] Queue build of [dotnet-framework-docker pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=372) (internal MSFT link)
+1. - [ ] Confirm images have been ingested by MCR
+1. - [ ] Confirm READMEs have been updated in Docker Hub for [microsoft-dotnet-framework](https://hub.docker.com/_/microsoft-dotnet-framework)
+1. - [ ] Confirm build for [dotnet-docker-framework-samples](https://dev.azure.com/dnceng/internal/_build?definitionId=374) (internal MSFT link) was queued. This will be queued automatically by [dotnet-docker-tools-check-base-image-updates](https://dev.azure.com/dnceng/internal/_build?definitionId=536) when it detects that the product images have been updated (detection runs on a schedule). Alternatively, you can manually queue the samples build.
+1. - [ ] Confirm sample images have been ingested by MCR
+1. - [ ] Confirm `Last Modified` field has been updated in Docker Hub for [microsoft-dotnet-framework-samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/)
+1. - [ ] Reply to .NET Release team with a status update email

--- a/.github/ISSUE_TEMPLATE/releases/vs-tools-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/vs-tools-release.md
@@ -4,18 +4,20 @@ VS Version: &lt;version&gt;
 
 ## Tasks
 
+_There is overlap between the tasks here and those for a [Patch Tuesday release](patch-tuesday-release.md). In the case where a VS release is on the same day as Patch Tuesday, the tasks should be combined into one workflow. Tasks specific to only a VS release have been **bolded**._
+
 1. - [ ] Merge any pending PRs or commits from `dev` branch:
       - [ ] &lt;placeholder link&gt;
-1. - [ ] Update the `vsVersion` in [vs-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/vs-info.json) to be the new VS version being released
 1. - [ ] Look up the latest [NuGet CLI versions](https://www.nuget.org/downloads) and update the [nuget-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/nuget-info.json) file with the latest patch of each major/minor version listed in the file
-1. - [ ] Wait for VS to be released
-1. - [ ] Install or update the new version of VS on your local machine
-1. - [ ] Create a zip file named `MSBuild.Microsoft.VisualStudio.Web.targets.<YYYY>.<MM>.zip` that contains the `MSBuild\Microsoft\VisualStudio\v16.0\Web` and `MSBuild\Microsoft\VisualStudio\v16.0\WebApplications` folders from the VS installation location
-1. - [ ] Upload the zip file to https://dotnetbinaries.blob.core.windows.net/dockerassets
-1. - [ ] Update the `webTargetsUrl` in [vs-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/vs-info.json) to reference the new zip file name
-1. - [ ] Gather the Build Tools and Test Agent download URLs by navigating to https://visualstudio.microsoft.com/downloads. Download links can be found under the `Tools for Visual Studio` section. Prior to clicking the download button, open a network profiler like your browser's dev tools or Fiddler so that you can capture the URL that gets downloaded. For `Build Tools for Visual Studio` look for a file named `vs_BuildTools.exe` being downloaded. For `Agents for Visual Studio`, ensure the radio button is defaulted to `Agent` and look for a file named `vs_TestAgent.exe`. Copy those two URLs and paste them into [vs-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/vs-info.json).
+1. - [ ] **Update the `vsVersion` in [vs-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/vs-info.json) to be the new VS version being released**
+1. - [ ] **Wait for VS to be released**
+1. - [ ] **Install or update the new version of VS on your local machine**
+1. - [ ] **Create a zip file named `MSBuild.Microsoft.VisualStudio.Web.targets.<YYYY>.<MM>.zip` that contains the `MSBuild\Microsoft\VisualStudio\v16.0\Web` and `MSBuild\Microsoft\VisualStudio\v16.0\WebApplications` folders from the VS installation location**
+1. - [ ] **Upload the zip file to https://dotnetbinaries.blob.core.windows.net/dockerassets**
+1. - [ ] **Update the `webTargetsUrl` in [vs-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/vs-info.json) to reference the new zip file name**
+1. - [ ] **Gather the Build Tools and Test Agent download URLs by navigating to https://visualstudio.microsoft.com/downloads. Download links can be found under the `Tools for Visual Studio` section. Prior to clicking the download button, open a network profiler like your browser's dev tools or Fiddler so that you can capture the URL that gets downloaded. For `Build Tools for Visual Studio` look for a file named `vs_BuildTools.exe` being downloaded. For `Agents for Visual Studio`, ensure the radio button is defaulted to `Agent` and look for a file named `vs_TestAgent.exe`. Copy those two URLs and paste them into [vs-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/vs-info.json).**
 1. - [ ] Run the `update-dependencies` tool to update all the necessary files:
-      - [ ] `dotnet run --project .\eng\update-dependencies\update-dependencies.csproj --datestamp-all <YYYYMMDD>`
+      - [ ] **`dotnet run --project .\eng\update-dependencies\update-dependencies.csproj --datestamp-sdk <YYYYMMDD>` _Note that this uses a different option than a [Patch Tuesday release](patch-tuesday-release.md) because only the SDK images should be updated here. If VS and Patch Tuesday releases align, then `--datestamp-all` should be used._**
 1. - [ ] Inspect generated changes for correctness
 1. - [ ] Commit generated changes
 1. - [ ] Create PR

--- a/.github/ISSUE_TEMPLATE/releases/vs-tools-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/vs-tools-release.md
@@ -1,0 +1,30 @@
+# VS Tools Release
+
+VS Version: &lt;version&gt;
+
+## Tasks
+
+1. - [ ] Merge any pending PRs or commits from `dev` branch:
+      - [ ] &lt;placeholder link&gt;
+1. - [ ] Update the `vsVersion` in [vs-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/vs-info.json) to be the new VS version being released
+1. - [ ] Look up the latest [NuGet CLI versions](https://www.nuget.org/downloads) and update the [nuget-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/nuget-info.json) file with the latest patch of each major/minor version listed in the file
+1. - [ ] Wait for VS to be released
+1. - [ ] Install or update the new version of VS on your local machine
+1. - [ ] Create a zip file named `MSBuild.Microsoft.VisualStudio.Web.targets.<YYYY>.<MM>.zip` that contains the `MSBuild\Microsoft\VisualStudio\v16.0\Web` and `MSBuild\Microsoft\VisualStudio\v16.0\WebApplications` folders from the VS installation location
+1. - [ ] Upload the zip file to https://dotnetbinaries.blob.core.windows.net/dockerassets
+1. - [ ] Update the `webTargetsUrl` in [vs-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/vs-info.json) to reference the new zip file name
+1. - [ ] Gather the Build Tools and Test Agent download URLs by navigating to https://visualstudio.microsoft.com/downloads. Download links can be found under the `Tools for Visual Studio` section. Prior to clicking the download button, open a network profiler like your browser's dev tools or Fiddler so that you can capture the URL that gets downloaded. For `Build Tools for Visual Studio` look for a file named `vs_BuildTools.exe` being downloaded. For `Agents for Visual Studio`, ensure the radio button is defaulted to `Agent` and look for a file named `vs_TestAgent.exe`. Copy those two URLs and paste them into [vs-info.json](https://github.com/microsoft/dotnet-framework-docker/blob/master/eng/vs-info.json).
+1. - [ ] Run the `update-dependencies` tool to update all the necessary files:
+      - [ ] `dotnet run --project .\eng\update-dependencies\update-dependencies.csproj --datestamp-all <YYYYMMDD>`
+1. - [ ] Inspect generated changes for correctness
+1. - [ ] Commit generated changes
+1. - [ ] Create PR
+1. - [ ] Get PR signoff
+1. - [ ] Merge PR
+1. - [ ] Wait for changes to be mirrored to internal [dotnet-framework-docker repo](https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet-framework-docker) (internal MSFT link)
+1. - [ ] Queue build of [dotnet-framework-docker pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=372) (internal MSFT link)
+1. - [ ] Confirm images have been ingested by MCR
+1. - [ ] Confirm READMEs have been updated in Docker Hub for [microsoft-dotnet-framework](https://hub.docker.com/_/microsoft-dotnet-framework)
+1. - [ ] Confirm build for [dotnet-docker-framework-samples](https://dev.azure.com/dnceng/internal/_build?definitionId=374) (internal MSFT link) was queued. This will be queued automatically by [dotnet-docker-tools-check-base-image-updates](https://dev.azure.com/dnceng/internal/_build?definitionId=536) when it detects that the product images have been updated (detection runs on a schedule). Alternatively, you can manually queue the samples build.
+1. - [ ] Confirm sample images have been ingested by MCR
+1. - [ ] Confirm `Last Modified` field has been updated in Docker Hub for [microsoft-dotnet-framework-samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/)

--- a/eng/pipelines/dotnet-framework.yml
+++ b/eng/pipelines/dotnet-framework.yml
@@ -6,6 +6,7 @@ pr:
     - dev
   paths:
     exclude:
+    - .github/*
     - README*
     - samples/*
 


### PR DESCRIPTION
Defines two markdown files to be used as templates for creating issues for a release. These are stored in a `releases` subfolder since they are not intended to be available to select when creating a new issue.

Also includes a bug report issue template for the repo.

Related to dotnet/docker-tools#383