### PR TITLE
Update ServiceMonitor version to 2.0.1.10

### DIFF
--- a/3.5/aspnet/windowsservercore-1903/Dockerfile
+++ b/3.5/aspnet/windowsservercore-1903/Dockerfile
@@ -9,7 +9,7 @@ RUN powershell -Command `
         Add-WindowsFeature Web-Server; `
         Add-WindowsFeature Web-Asp-Net; `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
+        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0
 
 RUN C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `

--- a/3.5/aspnet/windowsservercore-1909/Dockerfile
+++ b/3.5/aspnet/windowsservercore-1909/Dockerfile
@@ -9,7 +9,7 @@ RUN powershell -Command `
         Add-WindowsFeature Web-Server; `
         Add-WindowsFeature Web-Asp-Net; `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
+        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0
 
 RUN C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `

--- a/3.5/aspnet/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/aspnet/windowsservercore-ltsc2016/Dockerfile
@@ -9,7 +9,7 @@ RUN powershell -Command `
         Add-WindowsFeature Web-Server; `
         Add-WindowsFeature Web-Asp-Net; `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
+        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0
 
 RUN C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `

--- a/3.5/aspnet/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/aspnet/windowsservercore-ltsc2019/Dockerfile
@@ -9,7 +9,7 @@ RUN powershell -Command `
         Add-WindowsFeature Web-Server; `
         Add-WindowsFeature Web-Asp-Net; `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
+        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0
     
 RUN C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `

--- a/4.6.2/aspnet/windowsservercore-ltsc2016/Dockerfile
+++ b/4.6.2/aspnet/windowsservercore-ltsc2016/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `

--- a/4.7.1/aspnet/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.1/aspnet/windowsservercore-ltsc2016/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `

--- a/4.7.2/aspnet/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7.2/aspnet/windowsservercore-ltsc2016/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `

--- a/4.7.2/aspnet/windowsservercore-ltsc2019/Dockerfile
+++ b/4.7.2/aspnet/windowsservercore-ltsc2019/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `

--- a/4.7/aspnet/windowsservercore-ltsc2016/Dockerfile
+++ b/4.7/aspnet/windowsservercore-ltsc2016/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `

--- a/4.8/aspnet/windowsservercore-1903/Dockerfile
+++ b/4.8/aspnet/windowsservercore-1903/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `

--- a/4.8/aspnet/windowsservercore-1909/Dockerfile
+++ b/4.8/aspnet/windowsservercore-1909/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `

--- a/4.8/aspnet/windowsservercore-ltsc2016/Dockerfile
+++ b/4.8/aspnet/windowsservercore-ltsc2016/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `

--- a/4.8/aspnet/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/aspnet/windowsservercore-ltsc2019/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `


### PR DESCRIPTION
The latest release of IIS ServiceMonitor contains a fix for [https://github.com/microsoft/IIS.ServiceMonitor/issues/32](https://github.com/microsoft/IIS.ServiceMonitor/issues/32), which is very annoying issue. @gislikonrad even ported ServiceMonitor to .NET to have it fixed: [https://github.com/SOLIDSoftworks/iis-service-monitor](https://github.com/SOLIDSoftworks/iis-service-monitor)