### PR TITLE
Remove ExcludeArchitecture parameter

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -42,8 +42,7 @@ if ($build) {
         -VersionFilter $VersionFilter `
         -OSFilter $OSFilter `
         -PathFilters $PathFilters `
-        -OptionalImageBuilderArgs $OptionalImageBuilderArgs `
-        -ExcludeArchitecture
+        -OptionalImageBuilderArgs $OptionalImageBuilderArgs
 }
 if ($test) {
     & ./tests/run-tests.ps1 `


### PR DESCRIPTION
Removing the `ExcludeArchitecture` parameter because it had been removed from the common build script in https://github.com/dotnet/docker-tools/pull/416.  It was replaced by the presence of the `ArchitectureFilter` parameter.  