### PR TITLE
Update 4.x NuGet client to 4.9.4

### DIFF
--- a/3.5/sdk/windowsservercore-1903/Dockerfile
+++ b/3.5/sdk/windowsservercore-1903/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-1903
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.4.3
+ENV NUGET_VERSION 4.9.4
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 

--- a/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -20,7 +20,7 @@ RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.4.3
+ENV NUGET_VERSION 4.9.4
 RUN mkdir "%ProgramFiles%\NuGet" `
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `

--- a/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/3.5/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -14,7 +14,7 @@ RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.4.3
+ENV NUGET_VERSION 4.9.4
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 

--- a/4.8/sdk/windowsservercore-1903/Dockerfile
+++ b/4.8/sdk/windowsservercore-1903/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-1903
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.4.3
+ENV NUGET_VERSION 4.9.4
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 

--- a/4.8/sdk/windowsservercore-ltsc2016/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2016/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-ltsc2016
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.4.3
+ENV NUGET_VERSION 4.9.4
 RUN mkdir "%ProgramFiles%\NuGet" `
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `

--- a/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
+++ b/4.8/sdk/windowsservercore-ltsc2019/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-ltsc2019
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.4.3
+ENV NUGET_VERSION 4.9.4
 RUN mkdir "%ProgramFiles%\NuGet" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -64,20 +64,20 @@ Tag | Dockerfile
 ## Windows Server, version 1903 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20200316-windowsservercore-1903, 4.8-windowsservercore-1903, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/sdk/windowsservercore-1903/Dockerfile)
-3.5-20200316-windowsservercore-1903, 3.5-windowsservercore-1903, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1903/Dockerfile)
+4.8-20200318-windowsservercore-1903, 4.8-windowsservercore-1903, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/sdk/windowsservercore-1903/Dockerfile)
+3.5-20200318-windowsservercore-1903, 3.5-windowsservercore-1903, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-1903/Dockerfile)
 
 ## Windows Server 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20200316-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/sdk/windowsservercore-ltsc2019/Dockerfile)
-3.5-20200316-windowsservercore-ltsc2019, 3.5-windowsservercore-ltsc2019, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2019/Dockerfile)
+4.8-20200318-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/sdk/windowsservercore-ltsc2019/Dockerfile)
+3.5-20200318-windowsservercore-ltsc2019, 3.5-windowsservercore-ltsc2019, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2019/Dockerfile)
 
 ## Windows Server 2016 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20200316-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/sdk/windowsservercore-ltsc2016/Dockerfile)
-3.5-20200316-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2016/Dockerfile)
+4.8-20200318-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/sdk/windowsservercore-ltsc2016/Dockerfile)
+3.5-20200318-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/3.5/sdk/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/sdk at https://mcr.microsoft.com/v2/dotnet/framework/sdk/tags/list.
 

--- a/eng/nuget-info.json
+++ b/eng/nuget-info.json
@@ -1,6 +1,6 @@
 [
   {
-    "nugetClientVersion": "4.4.3",
+    "nugetClientVersion": "4.9.4",
     "osVersions": [
       "windowsservercore-1903",
       "windowsservercore-ltsc2016",

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
     "3B-2016-RuntimeReleaseDateStamp": "20200312",
     "3B-2016-SdkReleaseDateStamp": "20200316",
     "3B-2016-AspnetReleaseDateStamp": "20200312",
-    "3B-2016-WcfReleaseDateStamp": "20200312"
+    "3B-2016-WcfReleaseDateStamp": "20200312",
+    "NuGetUpdate-SdkReleaseDateStamp": "20200318"
   },
   "repos": [
     {
@@ -249,7 +250,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "4.8-$(SdkReleaseDateStamp)-windowsservercore-ltsc2016": {},
+                "4.8-$(NuGetUpdate-SdkReleaseDateStamp)-windowsservercore-ltsc2016": {},
                 "4.8-windowsservercore-ltsc2016": {}
               }
             },
@@ -261,7 +262,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "4.8-$(SdkReleaseDateStamp)-windowsservercore-ltsc2019": {},
+                "4.8-$(NuGetUpdate-SdkReleaseDateStamp)-windowsservercore-ltsc2019": {},
                 "4.8-windowsservercore-ltsc2019": {}
               }
             },
@@ -273,7 +274,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1903",
               "tags": {
-                "4.8-$(3B-SdkReleaseDateStamp)-windowsservercore-1903": {},
+                "4.8-$(NuGetUpdate-SdkReleaseDateStamp)-windowsservercore-1903": {},
                 "4.8-windowsservercore-1903": {}
               }
             },
@@ -304,7 +305,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
-                "3.5-$(3B-2016-SdkReleaseDateStamp)-windowsservercore-ltsc2016": {},
+                "3.5-$(NuGetUpdate-SdkReleaseDateStamp)-windowsservercore-ltsc2016": {},
                 "3.5-windowsservercore-ltsc2016": {}
               }
             },
@@ -316,7 +317,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
-                "3.5-$(SdkReleaseDateStamp)-windowsservercore-ltsc2019": {},
+                "3.5-$(NuGetUpdate-SdkReleaseDateStamp)-windowsservercore-ltsc2019": {},
                 "3.5-windowsservercore-ltsc2019": {}
               }
             },
@@ -328,7 +329,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-1903",
               "tags": {
-                "3.5-$(SdkReleaseDateStamp)-windowsservercore-1903": {},
+                "3.5-$(NuGetUpdate-SdkReleaseDateStamp)-windowsservercore-1903": {},
                 "3.5-windowsservercore-1903": {}
               }
             },

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_RUNTIME_IMAGE
 FROM $BASE_BUILD_IMAGE as builder
 WORKDIR /app
 COPY . ./
-RUN dotnet restore
+RUN nuget restore dotnetapp-4.8.sln
 RUN dotnet build -c Release
 
 

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8/dotnetapp-4.8.sln
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8/dotnetapp-4.8.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnetapp-4.8", "dotnetapp-4.8.csproj", "{20033517-2F7F-4B2F-952A-C9B17F6E2284}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{20033517-2F7F-4B2F-952A-C9B17F6E2284}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20033517-2F7F-4B2F-952A-C9B17F6E2284}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20033517-2F7F-4B2F-952A-C9B17F6E2284}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20033517-2F7F-4B2F-952A-C9B17F6E2284}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {307221C7-F18F-4685-9C3B-88EE9A058128}
+	EndGlobalSection
+EndGlobal

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7.2/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7.2/Dockerfile
@@ -5,6 +5,6 @@ FROM $BASE_BUILD_IMAGE
 WORKDIR /app
 COPY . ./
 
-RUN nuget restore SimpleWebApplication.csproj -SolutionDirectory .
+RUN nuget restore SimpleWebApplication.sln -SolutionDirectory .
 
 RUN msbuild SimpleWebApplication.csproj /p:Configuration=Release

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7.2/SimpleWebApplication.sln
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7.2/SimpleWebApplication.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleWebApplication", "SimpleWebApplication.csproj", "{E02160B5-4466-4003-BA3E-C5C62E576C07}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x64.Build.0 = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x86.Build.0 = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x64.ActiveCfg = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x64.Build.0 = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x86.ActiveCfg = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {307221C7-F18F-4685-9C3B-88EE9A058128}
+	EndGlobalSection
+EndGlobal

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8/Dockerfile
@@ -5,6 +5,6 @@ FROM $BASE_BUILD_IMAGE
 WORKDIR /app
 COPY . ./
 
-RUN nuget restore SimpleWebApplication.csproj -SolutionDirectory .
+RUN nuget restore SimpleWebApplication.sln -SolutionDirectory .
 
-RUN msbuild SimpleWebApplication.csproj /p:Configuration=Release
+RUN msbuild SimpleWebApplication.sln /p:Configuration=Release

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8/SimpleWebApplication.sln
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8/SimpleWebApplication.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleWebApplication", "SimpleWebApplication.csproj", "{E02160B5-4466-4003-BA3E-C5C62E576C07}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x64.Build.0 = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x86.Build.0 = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x64.ActiveCfg = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x64.Build.0 = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x86.ActiveCfg = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {307221C7-F18F-4685-9C3B-88EE9A058128}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
An unintended breaking change occurred when including the VS 16.5 tools in the SDK images (https://github.com/microsoft/dotnet-framework-docker/pull/543).  When attempting to run `nuget restore` on a solution file, it would cause the following error:
```
Exception has been thrown by the target of an invocation. The project file could not be loaded. Could not load file or assembly 'Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
```

This issue can be resolved by upgrading the NuGet client to a version >= 4.8.2.  After evaluating the known issues for the NuGet client releases, it was decided to go with the latest 4.x release, 4.9.4, since there appear to be no known issues in that release that should impact consumers of the SDK images.

Fixes #545