### PR TITLE
Add guiding principles documentation

### DIFF
--- a/documentation/guiding-principles.md
+++ b/documentation/guiding-principles.md
@@ -1,0 +1,35 @@
+# Guiding Principles
+
+These are the guiding principles for the content, tagging and production of the official .NET Docker images.  They establish a framework for the behavior customers can expect and the decision-making process when making changes to the images.  They are not hard rules which are stringently enforced as there will be occasions where it is sensible to make special exceptions.
+
+## Image Content
+
+1. Images are intended to satisfy the common usage scenarios.  They are not intended to satisfy every possible usage scenario.  As a result of this, decisions will be made (e.g. components excluded, configurations made, etc.) in order to keep the image size manageable.  It is expected there will be scenarios in which customers will need to create derived images that add their required components/settings.
+
+1. Components installed within the images are required to have the same or longer support lifecycle as [.NET Framework](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework).  Components are expected to be serviced over their lifetime as appropriate.
+
+1. Breaking changes are not allowed within a release.  This includes changes such as adding/removing components, adding/removing ENVs, and major/minor version changes to included components.
+
+1. There should be parity within the supported image matrix.  Examples include:
+    1. If support for a new version of Windows is added for a particular .NET Core version, then support will be added across all `runtime`, `aspnet`, `wcf`, and `sdk` image variants.
+    1. If a new component is added, it should be available across all supported OS versions.
+
+1. Windows Server Core is the only Windows SKU supported by the official .NET Framework images.  Windows Server Core is the best Windows SKU to run .NET Framework apps from a performance perspective.  Windows Server Core doesn't have support for every scenario.  For these cases, it is expected that consumers will need to manage their own custom .NET Framework images based on the [Windows](https://hub.docker.com/_/microsoft-windows) base image.
+
+## Image Tagging
+
+The .NET Core image tags strive to align with the tagging practices utilized by the [Official Images on Docker Hub](https://hub.docker.com/search?q=&type=image&image_filter=official).  The [Tagging Guidelines](tagging-guidelines.md) describe this in detail.
+
+## Engineering
+
+1. Images will be included as part of the .NET release process.  The Docker images will be released at the same time as the core product.
+
+1. Images will be rebuilt within hours of base image changes. For example, suppose a particular version of Windows is patched.  The .NET Core images based on this version of Windows will be rebuilt with this new base image within hours of its release.
+
+1. Images will never be deleted from the [official Docker repositories](https://hub.docker.com/_/microsoft-dotnet-framework/).
+
+1. The [Dockerfiles](https://github.com/microsoft/dotnet-framework-docker/search?q=filename%3ADockerfile) used to produce all of the images will be publicly available. Customers will be able to take the Dockerfiles and build them to produce their own equivalent images.  No special build steps or permissions should be needed to build the Dockerfiles.
+
+1. If a change is ever made to the tagging patterns, all of the old tags will be serviced appropriately through its original lifetime.  All old tags will no longer be documented within the tag details section of the readme.
+
+1. No experimental Docker features will be utilized within the infrastructure used to produce the images.  Utilizing experimental features can negatively affect the reliability of image production and introduces a risk to the integrity of the resulting artifacts.

--- a/documentation/guiding-principles.md
+++ b/documentation/guiding-principles.md
@@ -11,7 +11,7 @@ These are the guiding principles for the content, tagging and production of the 
 1. Breaking changes are not allowed within a release.  This includes changes such as adding/removing components, adding/removing ENVs, and major/minor version changes to included components.
 
 1. There should be parity within the supported image matrix.  Examples include:
-    1. If support for a new version of Windows is added for a particular .NET Core version, then support will be added across all `runtime`, `aspnet`, `wcf`, and `sdk` image variants.
+    1. If support for a new version of Windows is added for a particular .NET Framework version, then support will be added across all `runtime`, `aspnet`, `wcf`, and `sdk` image variants.
     1. If a new component is added, it should be available across all supported OS versions.
 
 1. Windows Server Core is the only Windows SKU supported by the official .NET Framework images.  Windows Server Core is the best Windows SKU to run .NET Framework apps from a performance perspective.  Windows Server Core doesn't have support for every scenario.  For these cases, it is expected that consumers will need to manage their own custom .NET Framework images based on the [Windows](https://hub.docker.com/_/microsoft-windows) base image.

--- a/documentation/guiding-principles.md
+++ b/documentation/guiding-principles.md
@@ -24,7 +24,7 @@ The .NET Core image tags strive to align with the tagging practices utilized by 
 
 1. Images will be included as part of the .NET release process.  The Docker images will be released at the same time as the core product.
 
-1. Images will be rebuilt within hours of base image changes. For example, suppose a particular version of Windows is patched.  The .NET Core images based on this version of Windows will be rebuilt with this new base image within hours of its release.
+1. Images will be rebuilt within hours of base image changes. For example, suppose a particular version of Windows is patched.  The .NET Framework images based on this version of Windows will be rebuilt with this new base image within hours of its release.
 
 1. Images will never be deleted from the [official Docker repositories](https://hub.docker.com/_/microsoft-dotnet-framework/).
 

--- a/documentation/tagging-guidelines.md
+++ b/documentation/tagging-guidelines.md
@@ -1,0 +1,53 @@
+# Image Tagging Guidelines
+
+This document describes the tagging practices used with the official .NET Framework Docker images.
+
+The .NET image tags strive to align with the tagging practices utilized by the [Official Images on Docker Hub](https://hub.docker.com/search?q=&type=image&image_filter=official).
+
+## Simple Tags
+
+1. `<.NET Version>-<TimeStamp>-<OS>`
+
+    **Examples**
+
+    * `4.8-20200310-windowsservercore-1909`
+    * `4.7.2-20200310-windowsservercore-ltsc2019`
+    * `3.5-20200414-windowsservercore-ltsc2016`
+
+1. `<.NET Version>-<OS>`
+
+    **Examples**
+
+    * `4.8-windowsservercore-1909`
+    * `4.7.2-windowsservercore-ltsc2019`
+    * `3.5-windowsservercore-ltsc2016`
+
+## Shared Tags
+
+1. `<.NET Version>`
+
+    **Examples**
+
+    * `4.8`
+    * `4.7.2`
+    * `3.5`
+
+1. `latest`
+
+    * References the most recent .NET version.
+
+All shared tags [support multiple platforms](https://blog.docker.com/2017/09/docker-official-images-now-multi-platform/) and have the following characteristics:
+
+1. Include entries for each supported Windows version.
+
+    1. New entries will be added as new versions of Windows are released.
+
+    1. Entries will be removed as versions of Windows reach EOL.
+
+## Tag Parts
+
+* `<.NET Version>` - The .NET version number included in the image.
+
+* `<TimeStamp>` - The timestamp of when the .NET components of the image were last changed.  The timestamp does not change when only the base OS is updated.
+
+* `<OS>` - The name of the OS release and variant the image is based upon.  The image the tag references is updated whenever a new OS patch is released.  The OS release name does support pinning to specific OS patches.  If OS patch pinning is required then the image digest should be used (e.g. `mcr.microsoft.com/dotnet/framework/runtime@sha256:c2310f61b429d6e9780c56068e4e9d35ab8a36deae03eff0e5b3d276f707e5b8`).


### PR DESCRIPTION
These are similar to the [guiding principles](https://github.com/dotnet/dotnet-docker/blob/master/documentation/guiding-principles.md) we have for the .NET Core Docker repo with a few repo specific adjustments.

The primary piece I wanted to get documented is the tagging strategy.