### PR TITLE
Use concrete tags for base Windows images

### DIFF
--- a/src/runtime/3.5/windowsservercore-1903/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-1903/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:1903
+FROM mcr.microsoft.com/windows/servercore:1903-amd64
 
 # Install .NET Fx 3.5
 RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1903.zip `

--- a/src/runtime/3.5/windowsservercore-1909/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-1909/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:1909
+FROM mcr.microsoft.com/windows/servercore:1909-amd64
 
 # Enable detection of running in a container
 ENV DOTNET_RUNNING_IN_CONTAINER=true `

--- a/src/runtime/3.5/windowsservercore-2004/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-2004/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:2004
+FROM mcr.microsoft.com/windows/servercore:2004-amd64
 
 # Enable detection of running in a container
 ENV DOTNET_RUNNING_IN_CONTAINER=true `

--- a/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
 # Install .NET Fx 3.5
 RUN powershell -Command `

--- a/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
 # Install .NET Fx 3.5
 RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1809.zip `

--- a/src/runtime/4.6.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.6.2/windowsservercore-ltsc2016/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
 # ngen .NET Fx
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0

--- a/src/runtime/4.7.1/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.7.1/windowsservercore-ltsc2016/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
 # Install .NET 4.7.1
 RUN powershell -Command `

--- a/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
 # Install .NET 4.7.2
 RUN powershell -Command `

--- a/src/runtime/4.7.2/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/4.7.2/windowsservercore-ltsc2019/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
 # Apply latest patch
 RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/secu/2020/07/windows10.0-kb4569776-x64_fb879f26b463abeea05426b15bbaba635b4ab79d.msu `

--- a/src/runtime/4.7/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.7/windowsservercore-ltsc2016/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
 # Install .NET 4.7
 RUN powershell -Command `

--- a/src/runtime/4.8/windowsservercore-1903/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-1903/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:1903
+FROM mcr.microsoft.com/windows/servercore:1903-amd64
 
 # Apply latest patch
 RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/07/windows10.0-kb4569751-x64-ndp48_99e0fedbc8108ac53c27032c7d2fa08e21bcd22f.msu `

--- a/src/runtime/4.8/windowsservercore-1909/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-1909/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:1909
+FROM mcr.microsoft.com/windows/servercore:1909-amd64
 
 # Apply latest patch
 RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/07/windows10.0-kb4569751-x64-ndp48_99e0fedbc8108ac53c27032c7d2fa08e21bcd22f.msu `

--- a/src/runtime/4.8/windowsservercore-2004/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-2004/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:2004
+FROM mcr.microsoft.com/windows/servercore:2004-amd64
 
 # Apply latest patch
 RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/07/windows10.0-kb4569745-x64-ndp48_7f8a54816ac281286046a4b00a79fe1b7ed12fd5.msu `

--- a/src/runtime/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
 # Install .NET 4.8
 RUN powershell -Command `

--- a/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
 # Install .NET 4.8
 RUN curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `


### PR DESCRIPTION
Current references to Windows images are using multi-arch tags like `mcr.microsoft.com/windows/servercore:1903`.  Updating the tags to be concrete, architecture-specific tags by appending `-amd64` to the tag names to be future-proofed and explicit of the desired architecture.