### PR TITLE
Add Dockerfiles for Windows, version 2009 

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -50,6 +50,12 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 # Full Tag Listing
 
+## Windows Server, version 2009 amd64 Tags
+Tag | Dockerfile
+---------| ---------------
+4.8-20200908-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/4.8/windowsservercore-2009/Dockerfile)
+3.5-20200908-windowsservercore-2009, 4.8-3.5-20200908-windowsservercore-2009, 3.5-windowsservercore-2009, 4.8-3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/3.5/windowsservercore-2009/Dockerfile)
+
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -53,8 +53,8 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 ## Windows Server, version 2009 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20200908-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/4.8/windowsservercore-2009/Dockerfile)
-3.5-20200908-windowsservercore-2009, 4.8-3.5-20200908-windowsservercore-2009, 3.5-windowsservercore-2009, 4.8-3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/3.5/windowsservercore-2009/Dockerfile)
+4.8-20201013-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/4.8/windowsservercore-2009/Dockerfile)
+3.5-20201013-windowsservercore-2009, 3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/3.5/windowsservercore-2009/Dockerfile)
 
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -53,8 +53,8 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 ## Windows Server, version 2009 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20201013-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/4.8/windowsservercore-2009/Dockerfile)
-3.5-20201013-windowsservercore-2009, 3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/3.5/windowsservercore-2009/Dockerfile)
+4.8-20201020-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/4.8/windowsservercore-2009/Dockerfile)
+3.5-20201020-windowsservercore-2009, 3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/aspnet/3.5/windowsservercore-2009/Dockerfile)
 
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -45,8 +45,8 @@ docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ## Windows Server, version 2009 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20201013-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.8/windowsservercore-2009/Dockerfile)
-3.5-20201013-windowsservercore-2009, 3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/3.5/windowsservercore-2009/Dockerfile)
+4.8-20201020-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.8/windowsservercore-2009/Dockerfile)
+3.5-20201020-windowsservercore-2009, 3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/3.5/windowsservercore-2009/Dockerfile)
 
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -45,8 +45,8 @@ docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ## Windows Server, version 2009 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20200908-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.8/windowsservercore-2009/Dockerfile)
-3.5-20200908-windowsservercore-2009, 4.8-3.5-20200908-windowsservercore-2009, 3.5-windowsservercore-2009, 4.8-3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/3.5/windowsservercore-2009/Dockerfile)
+4.8-20201013-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.8/windowsservercore-2009/Dockerfile)
+3.5-20201013-windowsservercore-2009, 3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/3.5/windowsservercore-2009/Dockerfile)
 
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -42,6 +42,12 @@ docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 
 # Full Tag Listing
 
+## Windows Server, version 2009 amd64 Tags
+Tag | Dockerfile
+---------| ---------------
+4.8-20200908-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.8/windowsservercore-2009/Dockerfile)
+3.5-20200908-windowsservercore-2009, 4.8-3.5-20200908-windowsservercore-2009, 3.5-windowsservercore-2009, 4.8-3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/3.5/windowsservercore-2009/Dockerfile)
+
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------

--- a/README.samples.md
+++ b/README.samples.md
@@ -75,6 +75,14 @@ docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 mcr.microsoft
 
 # Full Tag Listing
 
+## Windows Server, version 2009 amd64 Tags
+Tag | Dockerfile
+---------| ---------------
+dotnetapp-windowsservercore-2009, dotnetapp, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/samples/dotnetapp/Dockerfile)
+aspnetapp-windowsservercore-2009, aspnetapp | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/samples/aspnetapp/Dockerfile)
+wcfservice-windowsservercore-2009, wcfservice | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.web)
+wcfclient-windowsservercore-2009, wcfclient | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/samples/wcfapp/Dockerfile.client)
+
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -51,8 +51,8 @@ The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framewor
 ## Windows Server, version 2009 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20200908-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/4.8/windowsservercore-2009/Dockerfile)
-3.5-20200908-windowsservercore-2009, 4.8-3.5-20200908-windowsservercore-2009, 3.5-windowsservercore-2009, 4.8-3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/3.5/windowsservercore-2009/Dockerfile)
+4.8-20201013-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/4.8/windowsservercore-2009/Dockerfile)
+3.5-20201013-windowsservercore-2009, 3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/3.5/windowsservercore-2009/Dockerfile)
 
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -51,8 +51,8 @@ The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framewor
 ## Windows Server, version 2009 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20201013-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/4.8/windowsservercore-2009/Dockerfile)
-3.5-20201013-windowsservercore-2009, 3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/3.5/windowsservercore-2009/Dockerfile)
+4.8-20201020-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/4.8/windowsservercore-2009/Dockerfile)
+3.5-20201020-windowsservercore-2009, 3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/3.5/windowsservercore-2009/Dockerfile)
 
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -48,6 +48,12 @@ The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framewor
 
 # Full Tag Listing
 
+## Windows Server, version 2009 amd64 Tags
+Tag | Dockerfile
+---------| ---------------
+4.8-20200908-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/4.8/windowsservercore-2009/Dockerfile)
+3.5-20200908-windowsservercore-2009, 4.8-3.5-20200908-windowsservercore-2009, 3.5-windowsservercore-2009, 4.8-3.5-windowsservercore-2009, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/sdk/3.5/windowsservercore-2009/Dockerfile)
+
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -55,7 +55,7 @@ docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.
 ## Windows Server, version 2009 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20200908-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/wcf/4.8/windowsservercore-2009/Dockerfile)
+4.8-20201013-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/wcf/4.8/windowsservercore-2009/Dockerfile)
 
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -52,6 +52,11 @@ docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.
 
 # Full Tag Listing
 
+## Windows Server, version 2009 amd64 Tags
+Tag | Dockerfile
+---------| ---------------
+4.8-20200908-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/wcf/4.8/windowsservercore-2009/Dockerfile)
+
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -55,7 +55,7 @@ docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.
 ## Windows Server, version 2009 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20201013-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/wcf/4.8/windowsservercore-2009/Dockerfile)
+4.8-20201020-windowsservercore-2009, 4.8-windowsservercore-2009, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/master/src/wcf/4.8/windowsservercore-2009/Dockerfile)
 
 ## Windows Server, version 2004 amd64 Tags
 Tag | Dockerfile

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -1,4 +1,6 @@
 $(McrTagsYmlRepo:aspnet)
+$(McrTagsYmlTagGroup:4.8-windowsservercore-2009)
+$(McrTagsYmlTagGroup:3.5-windowsservercore-2009)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-2004)
 $(McrTagsYmlTagGroup:3.5-windowsservercore-2004)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-1909)

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -1,4 +1,6 @@
 $(McrTagsYmlRepo:runtime)
+$(McrTagsYmlTagGroup:4.8-windowsservercore-2009)
+$(McrTagsYmlTagGroup:3.5-windowsservercore-2009)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-2004)
 $(McrTagsYmlTagGroup:3.5-windowsservercore-2004)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-1909)

--- a/eng/mcr-tags-metadata-templates/samples-tags.yml
+++ b/eng/mcr-tags-metadata-templates/samples-tags.yml
@@ -1,4 +1,8 @@
 $(McrTagsYmlRepo:samples)
+$(McrTagsYmlTagGroup:dotnetapp-windowsservercore-2009)
+$(McrTagsYmlTagGroup:aspnetapp-windowsservercore-2009)
+$(McrTagsYmlTagGroup:wcfservice-windowsservercore-2009)
+$(McrTagsYmlTagGroup:wcfclient-windowsservercore-2009)
 $(McrTagsYmlTagGroup:dotnetapp-windowsservercore-2004)
 $(McrTagsYmlTagGroup:aspnetapp-windowsservercore-2004)
 $(McrTagsYmlTagGroup:wcfservice-windowsservercore-2004)

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -1,4 +1,6 @@
 $(McrTagsYmlRepo:sdk)
+$(McrTagsYmlTagGroup:4.8-windowsservercore-2009)
+$(McrTagsYmlTagGroup:3.5-windowsservercore-2009)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-2004)
 $(McrTagsYmlTagGroup:3.5-windowsservercore-2004)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-1909)

--- a/eng/mcr-tags-metadata-templates/wcf-tags.yml
+++ b/eng/mcr-tags-metadata-templates/wcf-tags.yml
@@ -1,4 +1,5 @@
 $(McrTagsYmlRepo:wcf)
+$(McrTagsYmlTagGroup:4.8-windowsservercore-2009)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-2004)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-1909)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-1903)

--- a/eng/nuget-info.json
+++ b/eng/nuget-info.json
@@ -18,5 +18,11 @@
     "osVersions": [
       "windowsservercore-2004"
     ]
+  },
+  {
+    "nugetClientVersion": "5.7.0",
+    "osVersions": [
+      "windowsservercore-2009"
+    ]
   }
 ]

--- a/manifest.json
+++ b/manifest.json
@@ -67,6 +67,15 @@
                 "4.8-$(RuntimeReleaseDateStamp)-windowsservercore-2004": {},
                 "4.8-windowsservercore-2004": {}
               }
+            },
+            {
+              "dockerfile": "src/runtime/4.8/windowsservercore-2009",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "4.8-$(RuntimeReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-windowsservercore-2009": {}
+              }
             }
           ]
         },
@@ -252,6 +261,17 @@
                 "3.5-windowsservercore-2004": {},
                 "4.8-3.5-windowsservercore-2004": {}
               }
+            },
+            {
+              "dockerfile": "src/runtime/3.5/windowsservercore-2009",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "3.5-$(RuntimeReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-3.5-$(RuntimeReleaseDateStamp)-windowsservercore-2009": {},
+                "3.5-windowsservercore-2009": {},
+                "4.8-3.5-windowsservercore-2009": {}
+              }
             }
           ]
         }
@@ -330,6 +350,18 @@
                 "4.8-$(SdkReleaseDateStamp)-windowsservercore-2004": {},
                 "4.8-windowsservercore-2004": {}
               }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/sdk/4.8/windowsservercore-2009",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "4.8-$(SdkReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-windowsservercore-2009": {}
+              }
             }
           ]
         },
@@ -402,6 +434,20 @@
                 "4.8-3.5-$(SdkReleaseDateStamp)-windowsservercore-2004": {},
                 "3.5-windowsservercore-2004": {},
                 "4.8-3.5-windowsservercore-2004": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/sdk/3.5/windowsservercore-2009",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "3.5-$(SdkReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-3.5-$(SdkReleaseDateStamp)-windowsservercore-2009": {},
+                "3.5-windowsservercore-2009": {},
+                "4.8-3.5-windowsservercore-2009": {}
               }
             }
           ]
@@ -480,6 +526,18 @@
               "tags": {
                 "4.8-$(AspnetReleaseDateStamp)-windowsservercore-2004": {},
                 "4.8-windowsservercore-2004": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/4.8/windowsservercore-2009",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "4.8-$(AspnetReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-windowsservercore-2009": {}
               }
             }
           ]
@@ -646,6 +704,20 @@
                 "3.5-windowsservercore-2004": {},
                 "4.8-3.5-windowsservercore-2004": {}
               }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/3.5/windowsservercore-2009",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "3.5-$(AspnetReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-3.5-$(AspnetReleaseDateStamp)-windowsservercore-2009": {},
+                "3.5-windowsservercore-2009": {},
+                "4.8-3.5-windowsservercore-2009": {}
+              }
             }
           ]
         }
@@ -723,6 +795,18 @@
               "tags": {
                 "4.8-$(WcfReleaseDateStamp)-windowsservercore-2004": {},
                 "4.8-windowsservercore-2004": {}
+              }
+            },
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/wcf/4.8/windowsservercore-2009",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "4.8-$(WcfReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-windowsservercore-2009": {}
               }
             }
           ]

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,11 @@
     "RuntimeReleaseDateStamp": "20201013",
     "SdkReleaseDateStamp": "20201013",
     "AspnetReleaseDateStamp": "20201013",
-    "WcfReleaseDateStamp": "20201013"
+    "WcfReleaseDateStamp": "20201013",
+    "2009-RuntimeReleaseDateStamp": "20201020",
+    "2009-SdkReleaseDateStamp": "20201020",
+    "2009-AspnetReleaseDateStamp": "20201020",
+    "2009-WcfReleaseDateStamp": "20201020"
   },
   "repos": [
     {
@@ -73,7 +77,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-2009",
               "tags": {
-                "4.8-$(RuntimeReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-$(2009-RuntimeReleaseDateStamp)-windowsservercore-2009": {},
                 "4.8-windowsservercore-2009": {}
               }
             }
@@ -267,7 +271,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-2009",
               "tags": {
-                "3.5-$(RuntimeReleaseDateStamp)-windowsservercore-2009": {},
+                "3.5-$(2009-RuntimeReleaseDateStamp)-windowsservercore-2009": {},
                 "3.5-windowsservercore-2009": {}
               }
             }
@@ -357,7 +361,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-2009",
               "tags": {
-                "4.8-$(SdkReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-$(2009-SdkReleaseDateStamp)-windowsservercore-2009": {},
                 "4.8-windowsservercore-2009": {}
               }
             }
@@ -442,7 +446,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-2009",
               "tags": {
-                "3.5-$(SdkReleaseDateStamp)-windowsservercore-2009": {},
+                "3.5-$(2009-SdkReleaseDateStamp)-windowsservercore-2009": {},
                 "3.5-windowsservercore-2009": {}
               }
             }
@@ -532,7 +536,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-2009",
               "tags": {
-                "4.8-$(AspnetReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-$(2009-AspnetReleaseDateStamp)-windowsservercore-2009": {},
                 "4.8-windowsservercore-2009": {}
               }
             }
@@ -709,7 +713,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-2009",
               "tags": {
-                "3.5-$(AspnetReleaseDateStamp)-windowsservercore-2009": {},
+                "3.5-$(2009-AspnetReleaseDateStamp)-windowsservercore-2009": {},
                 "3.5-windowsservercore-2009": {}
               }
             }
@@ -799,7 +803,7 @@
               "os": "windows",
               "osVersion": "windowsservercore-2009",
               "tags": {
-                "4.8-$(WcfReleaseDateStamp)-windowsservercore-2009": {},
+                "4.8-$(2009-WcfReleaseDateStamp)-windowsservercore-2009": {},
                 "4.8-windowsservercore-2009": {}
               }
             }

--- a/manifest.json
+++ b/manifest.json
@@ -268,9 +268,7 @@
               "osVersion": "windowsservercore-2009",
               "tags": {
                 "3.5-$(RuntimeReleaseDateStamp)-windowsservercore-2009": {},
-                "4.8-3.5-$(RuntimeReleaseDateStamp)-windowsservercore-2009": {},
-                "3.5-windowsservercore-2009": {},
-                "4.8-3.5-windowsservercore-2009": {}
+                "3.5-windowsservercore-2009": {}
               }
             }
           ]
@@ -445,9 +443,7 @@
               "osVersion": "windowsservercore-2009",
               "tags": {
                 "3.5-$(SdkReleaseDateStamp)-windowsservercore-2009": {},
-                "4.8-3.5-$(SdkReleaseDateStamp)-windowsservercore-2009": {},
-                "3.5-windowsservercore-2009": {},
-                "4.8-3.5-windowsservercore-2009": {}
+                "3.5-windowsservercore-2009": {}
               }
             }
           ]
@@ -714,9 +710,7 @@
               "osVersion": "windowsservercore-2009",
               "tags": {
                 "3.5-$(AspnetReleaseDateStamp)-windowsservercore-2009": {},
-                "4.8-3.5-$(AspnetReleaseDateStamp)-windowsservercore-2009": {},
-                "3.5-windowsservercore-2009": {},
-                "4.8-3.5-windowsservercore-2009": {}
+                "3.5-windowsservercore-2009": {}
               }
             }
           ]

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -53,6 +53,14 @@
               "tags": {
                 "dotnetapp-windowsservercore-2004": {}
               }
+            },
+            {
+              "dockerfile": "samples/dotnetapp",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "dotnetapp-windowsservercore-2009": {}
+              }
             }
           ]
         },
@@ -99,6 +107,14 @@
               "osVersion": "windowsservercore-2004",
               "tags": {
                 "aspnetapp-windowsservercore-2004": {}
+              }
+            },
+            {
+              "dockerfile": "samples/aspnetapp",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "aspnetapp-windowsservercore-2009": {}
               }
             }
           ]
@@ -147,6 +163,14 @@
               "tags": {
                 "wcfservice-windowsservercore-2004": {}
               }
+            },
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.web",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "wcfservice-windowsservercore-2009": {}
+              }
             }
           ]
         },
@@ -193,6 +217,14 @@
               "osVersion": "windowsservercore-2004",
               "tags": {
                 "wcfclient-windowsservercore-2004": {}
+              }
+            },
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.client",
+              "os": "windows",
+              "osVersion": "windowsservercore-2009",
+              "tags": {
+                "wcfclient-windowsservercore-2009": {}
               }
             }
           ]

--- a/src/aspnet/3.5/windowsservercore-2009/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-2009/Dockerfile
@@ -6,7 +6,7 @@ FROM $REPO:3.5-windowsservercore-2009
 RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /FeatureName:IIS-ASPNET `
     && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
     && del /q "C:\inetpub\wwwroot\*" `
-    && FOR /D %p IN ("C:\inetpub\wwwroot\*.*") DO rmdir "%p" /s /q `
+    && FOR /D %p IN ("C:\inetpub\wwwroot\*") DO rmdir "%p" /s /q `
     && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
     && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update `

--- a/src/aspnet/3.5/windowsservercore-2009/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-2009/Dockerfile
@@ -3,13 +3,11 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-2009
 
-RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        Add-WindowsFeature Web-Server; `
-        Add-WindowsFeature Web-Asp-Net; `
-        Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
+RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /FeatureName:IIS-ASPNET `
+    && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
+    && del /q "C:\inetpub\wwwroot\*" `
+    && FOR /D %p IN ("C:\inetpub\wwwroot\*.*") DO rmdir "%p" /s /q `
+    && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
     && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update `
     && C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update

--- a/src/aspnet/3.5/windowsservercore-2009/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-2009/Dockerfile
@@ -1,0 +1,19 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
+FROM $REPO:3.5-windowsservercore-2009
+
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        Add-WindowsFeature Web-Server; `
+        Add-WindowsFeature Web-Asp-Net; `
+        Remove-Item -Recurse C:\inetpub\wwwroot\*; `
+        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
+    && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
+    && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update `
+    && C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update
+
+EXPOSE 80
+
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc"]

--- a/src/aspnet/4.8/windowsservercore-2009/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-2009/Dockerfile
@@ -6,7 +6,7 @@ FROM $REPO:4.8-windowsservercore-2009
 RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /FeatureName:NetFx4Extended-ASPNET45 /FeatureName:IIS-ASPNET45 `
     && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
     && del /q "C:\inetpub\wwwroot\*" `
-    && FOR /D %p IN ("C:\inetpub\wwwroot\*.*") DO rmdir "%p" /s /q `
+    && FOR /D %p IN ("C:\inetpub\wwwroot\*") DO rmdir "%p" /s /q `
     && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
     && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update `
     && C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update

--- a/src/aspnet/4.8/windowsservercore-2009/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-2009/Dockerfile
@@ -1,0 +1,34 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
+FROM $REPO:4.8-windowsservercore-2009
+
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        Add-WindowsFeature Web-Server; `
+        Add-WindowsFeature NET-Framework-45-ASPNET; `
+        Add-WindowsFeature Web-Asp-Net45; `
+        Remove-Item -Recurse C:\inetpub\wwwroot\*; `
+        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
+        &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update
+
+# Install Roslyn compilers and ngen binaries
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
+        Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
+        Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
+        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
+        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
+        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe    
+
+ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+
+EXPOSE 80
+
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc"]

--- a/src/aspnet/4.8/windowsservercore-2009/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-2009/Dockerfile
@@ -3,29 +3,22 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-2009
 
-RUN powershell -Command "`
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        `
-        Add-WindowsFeature Web-Server; `
-        Add-WindowsFeature NET-Framework-45-ASPNET; `
-        Add-WindowsFeature Web-Asp-Net45; `
-        Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
-        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-        &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update"
+RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /FeatureName:NetFx4Extended-ASPNET45 /FeatureName:IIS-ASPNET45 `
+    && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
+    && del /q "C:\inetpub\wwwroot\*" `
+    && FOR /D %p IN ("C:\inetpub\wwwroot\*.*") DO rmdir "%p" /s /q `
+    && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
+    && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update `
+    && C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update
 
 # Install Roslyn compilers and ngen binaries
-RUN powershell -Command "`
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        `
-        Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
-        Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
-        Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
-        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
-        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
-        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe"
+RUN curl -fSLo microsoft.net.compilers.2.9.0.zip https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg `
+    && mkdir c:\RoslynCompilers `
+    && tar -C c:\RoslynCompilers -zxf microsoft.net.compilers.2.9.0.zip `
+    && del microsoft.net.compilers.2.9.0.zip `
+    && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe `
+    && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe `
+    && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
 ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
 

--- a/src/aspnet/4.8/windowsservercore-2009/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-2009/Dockerfile
@@ -3,7 +3,7 @@
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-2009
 
-RUN powershell -Command `
+RUN powershell -Command "`
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
@@ -13,10 +13,10 @@ RUN powershell -Command `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
         Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
         &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-        &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update
+        &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update"
 
 # Install Roslyn compilers and ngen binaries
-RUN powershell -Command `
+RUN powershell -Command "`
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         `
@@ -25,7 +25,7 @@ RUN powershell -Command `
         Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
         &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
         &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
-        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe    
+        &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe"
 
 ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
 

--- a/src/runtime/3.5/windowsservercore-2009/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-2009/Dockerfile
@@ -1,0 +1,30 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:2009-amd64
+
+# Enable detection of running in a container
+ENV DOTNET_RUNNING_IN_CONTAINER=true `
+    # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
+    COMPLUS_NGenProtectedProcess_FeatureEnabled=0
+
+# Install .NET Fx 3.5
+# RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2009.zip `
+#     && tar -zxf microsoft-windows-netfx3.zip `
+#     && del /F /Q microsoft-windows-netfx3.zip `
+#     && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+#     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+#     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+# TODO: Temporary for testing
+COPY . .
+RUN DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+    && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+RUN `
+    # Ngen top of assembly graph to optimize a set of frequently used assemblies
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    # To optimize 32-bit assemblies, uncomment the next line and add an escape character (`) to the end of the previous line
+    # && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update `
+    && C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update

--- a/src/runtime/3.5/windowsservercore-2009/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-2009/Dockerfile
@@ -8,16 +8,10 @@ ENV DOTNET_RUNNING_IN_CONTAINER=true `
     COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 # Install .NET Fx 3.5
-# RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2009.zip `
-#     && tar -zxf microsoft-windows-netfx3.zip `
-#     && del /F /Q microsoft-windows-netfx3.zip `
-#     && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-#     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-#     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# TODO: Temporary for testing
-COPY . .
-RUN DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
+RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2009.zip `
+    && tar -zxf microsoft-windows-netfx3.zip `
+    && del /F /Q microsoft-windows-netfx3.zip `
+    && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
 

--- a/src/runtime/4.8/windowsservercore-2009/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-2009/Dockerfile
@@ -1,0 +1,25 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:2009-amd64
+
+# Apply latest patch
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/08/windows10.0-kb4576478-x64-ndp48_83f09dc64c451be104a7a4f737e576c413a51650.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4576478-x64-ndp48.cab `
+    && rmdir /S /Q patch
+
+ENV `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
+    COMPLUS_NGenProtectedProcess_FeatureEnabled=0
+
+RUN `
+    # Ngen top of assembly graph to optimize a set of frequently used assemblies
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    # To optimize 32-bit assemblies, uncomment the next line
+    # && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.8/windowsservercore-2009/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-2009/Dockerfile
@@ -2,14 +2,6 @@
 
 FROM mcr.microsoft.com/windows/servercore:2009-amd64
 
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/08/windows10.0-kb4576478-x64-ndp48_83f09dc64c451be104a7a4f737e576c413a51650.msu `
-    && mkdir patch `
-    && expand patch.msu patch -F:* `
-    && del /F /Q patch.msu `
-    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4576478-x64-ndp48.cab `
-    && rmdir /S /Q patch
-
 ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `

--- a/src/sdk/3.5/windowsservercore-2009/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-2009/Dockerfile
@@ -31,7 +31,8 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Cleanup
-    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
+    && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"
 

--- a/src/sdk/3.5/windowsservercore-2009/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-2009/Dockerfile
@@ -1,0 +1,74 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
+FROM $REPO:3.5-windowsservercore-2009
+
+# Install NuGet CLI
+ENV NUGET_VERSION 5.7.0
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+
+# Install VS components
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/584a5fcf-dd07-4c36-add9-620e858c9a35/cd90750df4950dc9a6130937f4aaf7367f42944dea5fde2c78dbcb4bd8a7fa73/vs_TestAgent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
+    && del vs_TestAgent.exe `
+    `
+    # Install VS Build Tools
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/584a5fcf-dd07-4c36-add9-620e858c9a35/536a649978a0c34a78ca99a0c7b14a7b52e96b5a563d86efe6fdf9559b2886fb/vs_BuildTools.exe `
+    # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Net.Component.4.8.SDK ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --add Microsoft.VisualStudio.Component.WebDeploy ^ `
+        --quiet --norestart --nocache --wait `
+    && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
+    && del vs_BuildTools.exe `
+    `
+    # Cleanup
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
+
+# Install web targets
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2020.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
+
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
+    ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+
+# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
+RUN `
+    # Workaround for issues with 64-bit ngen 
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update
+
+# Set PATH in one layer to keep image size down.
+RUN powershell setx /M PATH $(${Env:PATH} `
+    + \";${Env:ProgramFiles}\NuGet\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
+
+# Install Targeting Packs
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    | %{ `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
+        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
+        Remove-Item -Force referenceassemblies.zip; `
+    }"

--- a/src/sdk/4.8/windowsservercore-2009/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-2009/Dockerfile
@@ -31,7 +31,8 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Cleanup
-    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
+    && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
     && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
     && rmdir /S /Q "%ProgramData%\Package Cache"
 

--- a/src/sdk/4.8/windowsservercore-2009/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-2009/Dockerfile
@@ -1,0 +1,76 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
+FROM $REPO:4.8-windowsservercore-2009
+
+# Install NuGet CLI
+ENV NUGET_VERSION 5.7.0
+RUN mkdir "%ProgramFiles%\NuGet" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+
+# Install VS components
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://download.visualstudio.microsoft.com/download/pr/584a5fcf-dd07-4c36-add9-620e858c9a35/cd90750df4950dc9a6130937f4aaf7367f42944dea5fde2c78dbcb4bd8a7fa73/vs_TestAgent.exe `
+    && start /w vs_TestAgent.exe --quiet --norestart --nocache --wait `
+    && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
+    && del vs_TestAgent.exe `
+    `
+    # Install VS Build Tools
+    && curl -fSLo vs_BuildTools.exe https://download.visualstudio.microsoft.com/download/pr/584a5fcf-dd07-4c36-add9-620e858c9a35/536a649978a0c34a78ca99a0c7b14a7b52e96b5a563d86efe6fdf9559b2886fb/vs_BuildTools.exe `
+    # Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+    && setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1 `
+    && start /w vs_BuildTools.exe ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --add Microsoft.VisualStudio.Workload.NetCoreBuildTools ^ `
+        --add Microsoft.Net.Component.4.8.SDK ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --add Microsoft.VisualStudio.Component.WebDeploy ^ `
+        --quiet --norestart --nocache --wait `
+    && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
+    && del vs_BuildTools.exe `
+    `
+    # Cleanup
+    && rmdir /S /Q "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer" `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
+
+# Install web targets
+RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/MSBuild.Microsoft.VisualStudio.Web.targets.2020.05.zip `
+    && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
+    && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
+
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
+    ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn" `
+    # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
+    COMPLUS_NGenProtectedProcess_FeatureEnabled=0
+
+# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
+RUN `
+    # Workaround for issues with 64-bit ngen 
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update
+
+# Set PATH in one layer to keep image size down.
+RUN powershell setx /M PATH $(${Env:PATH} `
+    + \";${Env:ProgramFiles}\NuGet\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
+
+# Install Targeting Packs
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    | %{ `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
+        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
+        Remove-Item -Force referenceassemblies.zip; `
+    }"

--- a/src/wcf/4.8/windowsservercore-2009/Dockerfile
+++ b/src/wcf/4.8/windowsservercore-2009/Dockerfile
@@ -4,9 +4,13 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/aspnet
 FROM $REPO:4.8-windowsservercore-2009
 
 # Install Windows components required for WCF service hosted on IIS
-RUN Add-WindowsFeature NET-WCF-TCP-Activation45; `
-    Add-WindowsFeature NET-WCF-HTTP-Activation45; `
-    Add-WindowsFeature Web-WebSockets
+RUN powershell -Command `
+        $ErrorActionPreference = 'Stop'; `
+        $ProgressPreference = 'SilentlyContinue'; `
+        `
+        Add-WindowsFeature NET-WCF-TCP-Activation45; `
+        Add-WindowsFeature NET-WCF-HTTP-Activation45; `
+        Add-WindowsFeature Web-WebSockets
 
 # Enable net.tcp protocol for default web site on IIS
 RUN windows\system32\inetsrv\appcmd.exe set app 'Default Web Site/' /enabledProtocols:"http,net.tcp"

--- a/src/wcf/4.8/windowsservercore-2009/Dockerfile
+++ b/src/wcf/4.8/windowsservercore-2009/Dockerfile
@@ -1,0 +1,13 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/framework/aspnet
+FROM $REPO:4.8-windowsservercore-2009
+
+# Install Windows components required for WCF service hosted on IIS
+RUN Add-WindowsFeature NET-WCF-TCP-Activation45; `
+    Add-WindowsFeature NET-WCF-HTTP-Activation45; `
+    Add-WindowsFeature Web-WebSockets
+
+# Enable net.tcp protocol for default web site on IIS
+RUN windows\system32\inetsrv\appcmd.exe set app 'Default Web Site/' /enabledProtocols:"http,net.tcp"
+EXPOSE 808

--- a/src/wcf/4.8/windowsservercore-2009/Dockerfile
+++ b/src/wcf/4.8/windowsservercore-2009/Dockerfile
@@ -13,5 +13,5 @@ RUN powershell -Command `
         Add-WindowsFeature Web-WebSockets
 
 # Enable net.tcp protocol for default web site on IIS
-RUN windows\system32\inetsrv\appcmd.exe set app 'Default Web Site/' /enabledProtocols:"http,net.tcp"
+RUN windows\system32\inetsrv\appcmd.exe set app "Default Web Site/" /enabledProtocols:"http,net.tcp"
 EXPOSE 808

--- a/src/wcf/4.8/windowsservercore-2009/Dockerfile
+++ b/src/wcf/4.8/windowsservercore-2009/Dockerfile
@@ -4,13 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/aspnet
 FROM $REPO:4.8-windowsservercore-2009
 
 # Install Windows components required for WCF service hosted on IIS
-RUN powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        `
-        Add-WindowsFeature NET-WCF-TCP-Activation45; `
-        Add-WindowsFeature NET-WCF-HTTP-Activation45; `
-        Add-WindowsFeature Web-WebSockets
+RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:WCF-HTTP-Activation45 /FeatureName:WCF-TCP-Activation45 /FeatureName:IIS-WebSockets
 
 # Enable net.tcp protocol for default web site on IIS
 RUN windows\system32\inetsrv\appcmd.exe set app "Default Web Site/" /enabledProtocols:"http,net.tcp"

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/AspnetImageTests.cs
@@ -88,8 +88,24 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyShell(ImageDescriptor imageDescriptor)
         {
-            // 3.5 differs from the rest: https://github.com/microsoft/dotnet-framework-docker/issues/483
-            string expectedShellValue = imageDescriptor.Version == "3.5" ? ShellValue_Default : ShellValue_PowerShell;
+            // 3.5 uses cmd: https://github.com/microsoft/dotnet-framework-docker/issues/483
+            // Server Core 2009 and higher also use cmd
+            string expectedShellValue;
+            if (imageDescriptor.Version != "3.5" &&
+                (
+                    imageDescriptor.OsVariant == OsVersion.WSC_LTSC2016 ||
+                    imageDescriptor.OsVariant == OsVersion.WSC_LTSC2019 ||
+                    imageDescriptor.OsVariant == OsVersion.WSC_1903 ||
+                    imageDescriptor.OsVariant == OsVersion.WSC_1909 ||
+                    imageDescriptor.OsVariant == OsVersion.WSC_2004
+                ))
+            {
+                expectedShellValue = ShellValue_PowerShell;
+            }
+            else
+            {
+                expectedShellValue = ShellValue_Default;
+            }
             VerifyCommonShell(imageDescriptor, expectedShellValue);
         }
 

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/AspnetImageTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_1903 },
             new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_1909 },
             new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_2004 },
+            new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_2009 },
             new ImageDescriptor { Version = "4.6.2", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.7", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.7.1", OsVariant = OsVersion.WSC_LTSC2016 },
@@ -28,6 +29,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1903 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1909 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_2004 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_2009 },
         };
 
         public AspnetImageTests(ITestOutputHelper outputHelper)

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/OsVersion.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/OsVersion.cs
@@ -11,5 +11,6 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         public const string WSC_1903 = "windowsservercore-1903";
         public const string WSC_1909 = "windowsservercore-1909";
         public const string WSC_2004 = "windowsservercore-2004";
+        public const string WSC_2009 = "windowsservercore-2009";
     }
 }

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_1903 },
             new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_1909 },
             new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_2004 },
+            new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_2009 },
             new ImageDescriptor { Version = "4.6.2", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.7", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.7.1", OsVariant = OsVersion.WSC_LTSC2016 },
@@ -28,6 +29,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1903 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1909 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_2004 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_2009 },
         };
 
         public RuntimeOnlyImageTests(ITestOutputHelper outputHelper)

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new RuntimeImageDescriptor { Version = "3.5", SdkVersion = "3.5", OsVariant = OsVersion.WSC_1903 },
             new RuntimeImageDescriptor { Version = "3.5", SdkVersion = "3.5", OsVariant = OsVersion.WSC_1909 },
             new RuntimeImageDescriptor { Version = "3.5", SdkVersion = "3.5", OsVariant = OsVersion.WSC_2004 },
+            new RuntimeImageDescriptor { Version = "3.5", SdkVersion = "3.5", OsVariant = OsVersion.WSC_2009 },
             new RuntimeImageDescriptor { Version = "4.6.2", SdkVersion = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
             new RuntimeImageDescriptor { Version = "4.7", SdkVersion = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
             new RuntimeImageDescriptor { Version = "4.7.1", SdkVersion = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
@@ -29,6 +30,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = OsVersion.WSC_1903 },
             new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = OsVersion.WSC_1909 },
             new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = OsVersion.WSC_2004 },
+            new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = OsVersion.WSC_2009 },
         };
 
         private readonly ImageTestHelper _imageTestHelper;

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -204,14 +204,12 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         public void VerifyClickOncePublishing(ImageDescriptor imageDescriptor)
         {
             string baseBuildImage = ImageTestHelper.GetImage("sdk", imageDescriptor.Version, imageDescriptor.OsVariant);
-            const string PublishDir = "publish";
             List<string> buildArgs = new List<string>
             {
                 $"BASE_BUILD_IMAGE={baseBuildImage}",
-                $"PUBLISH_DIR={PublishDir}/"
             };
 
-            string command = $"cmd /s /c dir /b {PublishDir}";
+            string command = $"cmd /s /c dir /b publish";
             string output = ImageTestHelper.BuildAndTestImage(imageDescriptor, buildArgs, "clickonce", command, null);
 
             string[] outputLines = output.Split(Environment.NewLine);

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -227,7 +227,21 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyShell(ImageDescriptor imageDescriptor)
         {
-            VerifyCommonShell(imageDescriptor, ShellValue_PowerShell);
+            string expectedShellValue;
+            if (imageDescriptor.OsVariant == OsVersion.WSC_LTSC2016 ||
+                imageDescriptor.OsVariant == OsVersion.WSC_LTSC2019 ||
+                imageDescriptor.OsVariant == OsVersion.WSC_1903 ||
+                imageDescriptor.OsVariant == OsVersion.WSC_1909 ||
+                imageDescriptor.OsVariant == OsVersion.WSC_2004)
+            {
+                expectedShellValue = ShellValue_PowerShell;
+            }
+            else
+            {
+                expectedShellValue = ShellValue_Default;
+            }
+
+            VerifyCommonShell(imageDescriptor, expectedShellValue);
         }
     }
 }

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -23,11 +23,13 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_1903 },
             new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_1909 },
             new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_2004 },
+            new ImageDescriptor { Version = "3.5", OsVariant = OsVersion.WSC_2009 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2019 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1903 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1909 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_2004 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_2009 },
         };
 
         public SdkOnlyImageTests(ITestOutputHelper outputHelper)

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/WcfImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/WcfImageTests.cs
@@ -71,7 +71,21 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyShell(ImageDescriptor imageDescriptor)
         {
-            VerifyCommonShell(imageDescriptor, ShellValue_PowerShell);
+            string expectedShellValue;
+            if (imageDescriptor.OsVariant == OsVersion.WSC_LTSC2016 ||
+                imageDescriptor.OsVariant == OsVersion.WSC_LTSC2019 ||
+                imageDescriptor.OsVariant == OsVersion.WSC_1903 ||
+                imageDescriptor.OsVariant == OsVersion.WSC_1909 ||
+                imageDescriptor.OsVariant == OsVersion.WSC_2004)
+            {
+                expectedShellValue = ShellValue_PowerShell;
+            }
+            else
+            {
+                expectedShellValue = ShellValue_Default;
+            }
+
+            VerifyCommonShell(imageDescriptor, expectedShellValue);
         }
 
         public static IEnumerable<object[]> GetImageData()

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/WcfImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/WcfImageTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1903 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_1909 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_2004 },
+            new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_2009 },
         };
 
         public WcfImageTests(ITestOutputHelper outputHelper)

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
@@ -2,8 +2,6 @@ ARG BASE_BUILD_IMAGE
 
 FROM $BASE_BUILD_IMAGE as builder
 
-ARG PUBLISH_DIR
-
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="$PUBLISH_DIR"
+RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish"

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
@@ -4,4 +4,4 @@ FROM $BASE_BUILD_IMAGE as builder
 
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish\""
+RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish/"

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
@@ -4,4 +4,4 @@ FROM $BASE_BUILD_IMAGE as builder
 
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish"
+RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish\"

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
@@ -6,4 +6,4 @@ ARG PUBLISH_DIR
 
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="${Env:PUBLISH_DIR}"
+RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="$PUBLISH_DIR"

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-3.5/Dockerfile
@@ -4,4 +4,4 @@ FROM $BASE_BUILD_IMAGE as builder
 
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish\"
+RUN msbuild.exe clickonce-3.5.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish\""

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
@@ -4,4 +4,4 @@ FROM $BASE_BUILD_IMAGE as builder
 
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish\""
+RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish/"

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
@@ -2,8 +2,6 @@ ARG BASE_BUILD_IMAGE
 
 FROM $BASE_BUILD_IMAGE as builder
 
-ARG PUBLISH_DIR
-
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="$PUBLISH_DIR"
+RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish"

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
@@ -4,4 +4,4 @@ FROM $BASE_BUILD_IMAGE as builder
 
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish"
+RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish\"

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
@@ -4,4 +4,4 @@ FROM $BASE_BUILD_IMAGE as builder
 
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish\"
+RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish\""

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8/Dockerfile
@@ -6,4 +6,4 @@ ARG PUBLISH_DIR
 
 WORKDIR /app
 COPY . ./
-RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="${Env:PUBLISH_DIR}"
+RUN msbuild.exe clickonce-4.8.csproj /t:Publish /p:Configuration=Release /p:PublishDir="$PUBLISH_DIR"


### PR DESCRIPTION
Related to https://github.com/microsoft/dotnet-framework-docker/issues/647

Fixes https://github.com/microsoft/dotnet-framework-docker/issues/646 by changing the 2009 Dockerfiles to use the default cmd shell instead of PowerShell.

Related to https://github.com/microsoft/dotnet-framework-docker/issues/650 by not declaring a `4.8-3.5` tagging pattern for the 2009 tags.