### PR TITLE
Include NuGet 5.8 in SDK as additional version

### DIFF
--- a/eng/models/NuGetInfo.cs
+++ b/eng/models/NuGetInfo.cs
@@ -14,5 +14,8 @@ namespace Microsoft.DotNet.Framework.Models
 
         [JsonProperty(Required = Required.Always)]
         public string NuGetClientVersion { get; set; } = String.Empty;
+
+        [JsonProperty(Required = Required.Always)]
+        public string NuGetClientLatestVersion { get; set; } = String.Empty;
     }
 }

--- a/eng/nuget-info.json
+++ b/eng/nuget-info.json
@@ -1,6 +1,7 @@
 [
   {
     "nugetClientVersion": "4.9.4",
+    "nugetClientLatestVersion": "5.8.0",
     "osVersions": [
       "windowsservercore-ltsc2016",
       "windowsservercore-ltsc2019"
@@ -8,18 +9,21 @@
   },
   {
     "nugetClientVersion": "5.3.1",
+    "nugetClientLatestVersion": "5.8.0",
     "osVersions": [
       "windowsservercore-1909"
     ]
   },
   {
     "nugetClientVersion": "5.5.1",
+    "nugetClientLatestVersion": "5.8.0",
     "osVersions": [
       "windowsservercore-2004"
     ]
   },
   {
     "nugetClientVersion": "5.7.0",
+    "nugetClientLatestVersion": "5.8.0",
     "osVersions": [
       "windowsservercore-20H2"
     ]

--- a/eng/update-dependencies/DependencyUpdater.cs
+++ b/eng/update-dependencies/DependencyUpdater.cs
@@ -210,7 +210,7 @@ namespace Microsoft.DotNet.Framework.UpdateDependencies
 
             return dockerfiles.Value
                 .Where(dockerfile => dockerfile.ImageVariant == SdkImageVariant)
-                .Select(dockerfile =>
+                .SelectMany(dockerfile =>
                 {
                     // Find the NuGetInfo that matches the OS version of this Dockerfile
                     NuGetInfo nuGetInfo = nuGetVersions.FirstOrDefault(ver => ver.OsVersions.Contains(dockerfile.OsVersion));
@@ -219,11 +219,20 @@ namespace Microsoft.DotNet.Framework.UpdateDependencies
                         throw new InvalidOperationException($"No NuGet info is specified in '{this.options.NuGetInfoPath}' for OS version '{dockerfile.OsVersion}'.");
                     }
 
-                    return new CustomFileRegexUpdater(nuGetInfo.NuGetClientVersion, dockerfile.ImageVariant)
+                    return new IDependencyUpdater[]
                     {
-                        Path = dockerfile.Path,
-                        VersionGroupName = NuGetVersionGroupName,
-                        Regex = new Regex(@$"ENV NUGET_VERSION (?<{NuGetVersionGroupName}>\d+\.\d+\.\d+)")
+                        new CustomFileRegexUpdater(nuGetInfo.NuGetClientVersion, dockerfile.ImageVariant)
+                        {
+                            Path = dockerfile.Path,
+                            VersionGroupName = NuGetVersionGroupName,
+                            Regex = new Regex(@$"ENV NUGET_VERSION (?<{NuGetVersionGroupName}>\d+\.\d+\.\d+)")
+                        },
+                        new CustomFileRegexUpdater(nuGetInfo.NuGetClientLatestVersion, dockerfile.ImageVariant)
+                        {
+                            Path = dockerfile.Path,
+                            VersionGroupName = NuGetVersionGroupName,
+                            Regex = new Regex(@$"https://dist.nuget.org/win-x86-commandline/v(?<{NuGetVersionGroupName}>\d+\.\d+\.\d+)/nuget.exe")
+                        }
                     };
                 });
         }

--- a/src/sdk/3.5/windowsservercore-1909/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-1909/Dockerfile
@@ -5,8 +5,9 @@ FROM $REPO:3.5-windowsservercore-1909
 
 # Install NuGet CLI
 ENV NUGET_VERSION 5.3.1
-RUN mkdir "%ProgramFiles%\NuGet" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-2004/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-2004/Dockerfile
@@ -5,8 +5,9 @@ FROM $REPO:3.5-windowsservercore-2004
 
 # Install NuGet CLI
 ENV NUGET_VERSION 5.5.1
-RUN mkdir "%ProgramFiles%\NuGet" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-20H2/Dockerfile
@@ -5,8 +5,9 @@ FROM $REPO:3.5-windowsservercore-20H2
 
 # Install NuGet CLI
 ENV NUGET_VERSION 5.7.0
-RUN mkdir "%ProgramFiles%\NuGet" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -22,14 +22,18 @@ RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.
 
 # Install NuGet CLI
 ENV NUGET_VERSION 4.9.4
-RUN mkdir "%ProgramFiles%\NuGet" `
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe `
+            -OutFile $Env:ProgramFiles\NuGet\latest\nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -15,8 +15,9 @@ RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
 
 # Install NuGet CLI
 ENV NUGET_VERSION 4.9.4
-RUN mkdir "%ProgramFiles%\NuGet" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-1909/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-1909/Dockerfile
@@ -5,8 +5,9 @@ FROM $REPO:4.8-windowsservercore-1909
 
 # Install NuGet CLI
 ENV NUGET_VERSION 5.3.1
-RUN mkdir "%ProgramFiles%\NuGet" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-2004/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-2004/Dockerfile
@@ -5,8 +5,9 @@ FROM $REPO:4.8-windowsservercore-2004
 
 # Install NuGet CLI
 ENV NUGET_VERSION 5.5.1
-RUN mkdir "%ProgramFiles%\NuGet" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-20H2/Dockerfile
@@ -5,8 +5,9 @@ FROM $REPO:4.8-windowsservercore-20H2
 
 # Install NuGet CLI
 ENV NUGET_VERSION 5.7.0
-RUN mkdir "%ProgramFiles%\NuGet" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -5,14 +5,18 @@ FROM $REPO:4.8-windowsservercore-ltsc2016
 
 # Install NuGet CLI
 ENV NUGET_VERSION 4.9.4
-RUN mkdir "%ProgramFiles%\NuGet" `
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\nuget.exe
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe; `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe `
+            -OutFile $Env:ProgramFiles\NuGet\latest\nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -5,8 +5,9 @@ FROM $REPO:4.8-windowsservercore-ltsc2019
 
 # Install NuGet CLI
 ENV NUGET_VERSION 4.9.4
-RUN mkdir "%ProgramFiles%\NuGet" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
 
 # Install VS components
 RUN `


### PR DESCRIPTION
Fixes #678

These changes include NuGet 5.8 in the SDK in order to address the incompatibilities introduced by VS 16.8 build tools with older versions of NuGet.  NuGet 5.8 is included as an additional installation that developers can optionally use in order to workaround this incompatibility.  The existing versions of NuGet in the SDK is not being changed at this time in order to avoid potential breaking changes associated with such an upgrade.