### PR TITLE
Refactor Dockerfiles to reduce image sizes

### DIFF
--- a/src/aspnet/3.5/windowsservercore-1909/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-1909/Dockerfile
@@ -10,10 +10,9 @@ RUN powershell -Command `
         Add-WindowsFeature Web-Asp-Net; `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
         Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
-    && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0
-
-RUN C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `
-    &C:\Windows\Microsoft.NET\Framework\v2.0.50727\ngen.exe update
+    && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
+    && C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `
+    && C:\Windows\Microsoft.NET\Framework\v2.0.50727\ngen.exe update
 
 EXPOSE 80
 

--- a/src/aspnet/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -11,10 +11,9 @@ RUN powershell -Command `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
-    && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0
-
-RUN C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `
-    &C:\Windows\Microsoft.NET\Framework\v2.0.50727\ngen.exe update
+    && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
+    && C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `
+    && C:\Windows\Microsoft.NET\Framework\v2.0.50727\ngen.exe update
 
 EXPOSE 80
 

--- a/src/aspnet/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -10,10 +10,9 @@ RUN powershell -Command `
         Add-WindowsFeature Web-Asp-Net; `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
         Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
-    && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0
-
-RUN C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `
-    &C:\Windows\Microsoft.NET\Framework\v2.0.50727\ngen.exe update
+    && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
+    && C:\Windows\Microsoft.NET\Framework64\v2.0.50727\ngen.exe update `
+    && C:\Windows\Microsoft.NET\Framework\v2.0.50727\ngen.exe update
 
 EXPOSE 80
 

--- a/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile
@@ -14,7 +14,7 @@ RUN Add-WindowsFeature Web-Server; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `

--- a/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile
@@ -10,15 +10,15 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
+    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
 # Install Roslyn compilers and ngen binaries
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
-    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe | `

--- a/src/aspnet/4.7.1/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7.1/windowsservercore-ltsc2016/Dockerfile
@@ -14,7 +14,7 @@ RUN Add-WindowsFeature Web-Server; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `

--- a/src/aspnet/4.7.1/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7.1/windowsservercore-ltsc2016/Dockerfile
@@ -10,15 +10,15 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
+    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
 # Install Roslyn compilers and ngen binaries
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
-    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe | `

--- a/src/aspnet/4.7.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7.2/windowsservercore-ltsc2016/Dockerfile
@@ -14,7 +14,7 @@ RUN Add-WindowsFeature Web-Server; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `

--- a/src/aspnet/4.7.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7.2/windowsservercore-ltsc2016/Dockerfile
@@ -10,15 +10,15 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
+    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
 # Install Roslyn compilers and ngen binaries
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
-    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe | `

--- a/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile
@@ -13,7 +13,7 @@ RUN Add-WindowsFeature Web-Server; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `

--- a/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile
@@ -9,14 +9,14 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
+    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
-    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe | `

--- a/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile
@@ -14,7 +14,7 @@ RUN Add-WindowsFeature Web-Server; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `

--- a/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile
@@ -10,15 +10,15 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
+    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
 # Install Roslyn compilers and ngen binaries
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
-    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe | `

--- a/src/aspnet/4.8/windowsservercore-1909/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-1909/Dockerfile
@@ -13,7 +13,7 @@ RUN Add-WindowsFeature Web-Server; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `

--- a/src/aspnet/4.8/windowsservercore-1909/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-1909/Dockerfile
@@ -9,14 +9,14 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
+    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
-    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe | `

--- a/src/aspnet/4.8/windowsservercore-2004/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-2004/Dockerfile
@@ -13,7 +13,7 @@ RUN Add-WindowsFeature Web-Server; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `

--- a/src/aspnet/4.8/windowsservercore-20H2/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-20H2/Dockerfile
@@ -11,7 +11,7 @@ RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /Fea
     && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update `
     && C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN curl -fSLo microsoft.net.compilers.2.9.0.zip https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg `
     && mkdir c:\RoslynCompilers `
     && tar -C c:\RoslynCompilers -zxf microsoft.net.compilers.2.9.0.zip `

--- a/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -14,7 +14,7 @@ RUN Add-WindowsFeature Web-Server; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `

--- a/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -10,15 +10,15 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
+    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
 # Install Roslyn compilers and ngen binaries
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
-    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe | `

--- a/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -13,7 +13,7 @@ RUN Add-WindowsFeature Web-Server; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
-# Install Roslyn compilers and ngen binaries
+# Install Roslyn compilers
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `

--- a/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -9,14 +9,14 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe
+    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
+    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update;
 
 # Install Roslyn compilers and ngen binaries
 RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg -OutFile c:\microsoft.net.compilers.2.9.0.zip; `
     Expand-Archive -Path c:\microsoft.net.compilers.2.9.0.zip -DestinationPath c:\RoslynCompilers; `
     Remove-Item c:\microsoft.net.compilers.2.9.0.zip -Force; `
-    &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update; `
-    &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe update; `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\csc.exe /ExeConfig:c:\RoslynCompilers\tools\csc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe | `

--- a/src/runtime/3.5/windowsservercore-1909/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-1909/Dockerfile
@@ -24,7 +24,7 @@ RUN `
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580980-x64-ndp48.cab `
     && rmdir /S /Q patch `
     `
-    # ngen .NET 3.5 Fx
+    # ngen .NET Fx
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/3.5/windowsservercore-1909/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-1909/Dockerfile
@@ -7,23 +7,24 @@ ENV DOTNET_RUNNING_IN_CONTAINER=true `
     # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
     COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
-# Install .NET Fx 3.5
-RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1909.zip `
+RUN `
+    # Install .NET Fx 3.5
+    curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1909.zip `
     && tar -zxf microsoft-windows-netfx3.zip `
     && del /F /Q microsoft-windows-netfx3.zip `
     && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580980-x64-ndp48_cc3c6bced8c5238bd7767f5abf419d5a3a1847fa.msu `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Apply latest patch
+    && curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580980-x64-ndp48_cc3c6bced8c5238bd7767f5abf419d5a3a1847fa.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580980-x64-ndp48.cab `
-    && rmdir /S /Q patch
-
-# ngen .NET 3.5 Fx
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET 3.5 Fx
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/3.5/windowsservercore-2004/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-2004/Dockerfile
@@ -7,25 +7,25 @@ ENV DOTNET_RUNNING_IN_CONTAINER=true `
     # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
     COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
-# Install .NET Fx 3.5
-RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2004.zip `
+RUN `
+    # Install .NET Fx 3.5
+    curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2004.zip `
     && tar -zxf microsoft-windows-netfx3.zip `
     && del /F /Q microsoft-windows-netfx3.zip `
     && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Apply latest patch
+    && curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580419-x64-ndp48.cab `
-    && rmdir /S /Q patch
-
-RUN `
+    && rmdir /S /Q patch `
+    `
     # Ngen top of assembly graph to optimize a set of frequently used assemblies
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     # To optimize 32-bit assemblies, uncomment the next line and add an escape character (`) to the end of the previous line
     # && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update `

--- a/src/runtime/3.5/windowsservercore-20H2/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-20H2/Dockerfile
@@ -7,25 +7,25 @@ ENV DOTNET_RUNNING_IN_CONTAINER=true `
     # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
     COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
-# Install .NET Fx 3.5
-RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2009.zip `
+RUN `
+    # Install .NET Fx 3.5
+    curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-2009.zip `
     && tar -zxf microsoft-windows-netfx3.zip `
     && del /F /Q microsoft-windows-netfx3.zip `
     && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+`
+    # Apply latest patch
+    && curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580419-x64-ndp48.cab `
-    && rmdir /S /Q patch
-
-RUN `
+    && rmdir /S /Q patch `
+    `
     # Ngen top of assembly graph to optimize a set of frequently used assemblies
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     # To optimize 32-bit assemblies, uncomment the next line and add an escape character (`) to the end of the previous line
     # && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe update `

--- a/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
-# Install .NET Fx 3.5
-RUN powershell -Command `
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN `
+    # Install .NET Fx 3.5
+    powershell -Command `
         $ErrorActionPreference = 'Stop'; `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
@@ -15,10 +18,10 @@ RUN powershell -Command `
     && del microsoft-windows-netfx3.zip `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package.cab `
     && rmdir /S /Q microsoft-windows-netfx3 `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN powershell -Command `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Apply latest patch
+    && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
@@ -29,11 +32,10 @@ RUN powershell -Command `
     && expand patch.msu patch -F:* `
     && del patch.msu `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4593226-x64.cab `
-    && rmdir /S /Q patch
-
-# ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET Fx
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
     && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -2,24 +2,26 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
-# Install .NET Fx 3.5
-RUN curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1809.zip `
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN `
+    # Install .NET Fx 3.5
+    curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-1809.zip `
     && tar -zxf microsoft-windows-netfx3.zip `
     && del /F /Q microsoft-windows-netfx3.zip `
     && DISM /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580422-x64_86829f308772f33bab3ada0190346dab8e15d084.msu `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Apply latest patch
+    && curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580422-x64_86829f308772f33bab3ada0190346dab8e15d084.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580422-x64.cab `
-    && rmdir /S /Q patch
-
-# ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET Fx
+    && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
     && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/src/runtime/4.7.1/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.7.1/windowsservercore-ltsc2016/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
-# Install .NET 4.7.1
-RUN powershell -Command `
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN `
+    # Install .NET 4.7.1
+    powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
@@ -12,10 +15,10 @@ RUN powershell -Command `
             -OutFile dotnet-framework-installer.exe `
     && start /w .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN powershell -Command `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Apply latest patch
+    && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
@@ -26,9 +29,8 @@ RUN powershell -Command `
     && expand patch.msu patch -F:* `
     && del patch.msu `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4593226-x64.cab `
-    && rmdir /S /Q patch
-
-# ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET Fx
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
-# Install .NET 4.7.2
-RUN powershell -Command `
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN `
+    # Install .NET 4.7.2
+    powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
@@ -12,10 +15,10 @@ RUN powershell -Command `
             -OutFile dotnet-framework-installer.exe `
     && start /w .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN powershell -Command `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Apply latest patch
+    && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
@@ -26,9 +29,8 @@ RUN powershell -Command `
     && expand patch.msu patch -F:* `
     && del patch.msu `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4593226-x64.cab `
-    && rmdir /S /Q patch
-
-# ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET Fx
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.7.2/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/4.7.2/windowsservercore-ltsc2019/Dockerfile
@@ -2,16 +2,18 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580422-x64_86829f308772f33bab3ada0190346dab8e15d084.msu `
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN `
+    # Apply latest patch
+    curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580422-x64_86829f308772f33bab3ada0190346dab8e15d084.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580422-x64.cab `
-    && rmdir /S /Q patch
-
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET Fx
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.7/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.7/windowsservercore-ltsc2016/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
-# Install .NET 4.7
-RUN powershell -Command `
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN `
+    # Install .NET 4.7
+    powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
@@ -12,10 +15,10 @@ RUN powershell -Command `
             -OutFile dotnet-framework-installer.exe `
     && start /w .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN powershell -Command `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Apply latest patch
+    && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
@@ -26,9 +29,8 @@ RUN powershell -Command `
     && expand patch.msu patch -F:* `
     && del patch.msu `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4593226-x64.cab `
-    && rmdir /S /Q patch
-
-# ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET Fx
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.8/windowsservercore-1909/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-1909/Dockerfile
@@ -2,19 +2,22 @@
 
 FROM mcr.microsoft.com/windows/servercore:1909-amd64
 
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580980-x64-ndp48_cc3c6bced8c5238bd7767f5abf419d5a3a1847fa.msu `
+ENV `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
+    COMPLUS_NGenProtectedProcess_FeatureEnabled=0
+
+RUN `
+    # Apply latest patch
+    curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580980-x64-ndp48_cc3c6bced8c5238bd7767f5abf419d5a3a1847fa.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580980-x64-ndp48.cab `
-    && rmdir /S /Q patch
-
-# Enable detection of running in a container
-ENV DOTNET_RUNNING_IN_CONTAINER=true `
-    # Ngen workaround: https://github.com/microsoft/dotnet-framework-docker/issues/231
-    COMPLUS_NGenProtectedProcess_FeatureEnabled=0
-
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET Fx
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.8/windowsservercore-2004/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-2004/Dockerfile
@@ -2,14 +2,6 @@
 
 FROM mcr.microsoft.com/windows/servercore:2004-amd64
 
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu `
-    && mkdir patch `
-    && expand patch.msu patch -F:* `
-    && del /F /Q patch.msu `
-    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580419-x64-ndp48.cab `
-    && rmdir /S /Q patch
-
 ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
@@ -17,8 +9,16 @@ ENV `
     COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
+    # Apply latest patch
+    curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580419-x64-ndp48.cab `
+    && rmdir /S /Q patch `
+    `
     # Ngen top of assembly graph to optimize a set of frequently used assemblies
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     # To optimize 32-bit assemblies, uncomment the next line
     # && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `

--- a/src/runtime/4.8/windowsservercore-20H2/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-20H2/Dockerfile
@@ -2,14 +2,6 @@
 
 FROM mcr.microsoft.com/windows/servercore:20H2-amd64
 
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu `
-    && mkdir patch `
-    && expand patch.msu patch -F:* `
-    && del /F /Q patch.msu `
-    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580419-x64-ndp48.cab `
-    && rmdir /S /Q patch
-
 ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
@@ -17,8 +9,16 @@ ENV `
     COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
+    # Apply latest patch
+    curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580419-x64-ndp48_197efbd77177abe76a587359cea77bda5398c594.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580419-x64-ndp48.cab `
+    && rmdir /S /Q patch `
+    `
     # Ngen top of assembly graph to optimize a set of frequently used assemblies
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     # To optimize 32-bit assemblies, uncomment the next line
     # && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `

--- a/src/runtime/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
-# Install .NET 4.8
-RUN powershell -Command `
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN `
+    # Install .NET 4.8
+    powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
@@ -12,10 +15,10 @@ RUN powershell -Command `
             -OutFile dotnet-framework-installer.exe `
     && .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN powershell -Command `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Apply latest patch
+    && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
@@ -26,9 +29,8 @@ RUN powershell -Command `
     && expand patch.msu patch -F:* `
     && del patch.msu `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4585207-x64-ndp48.cab `
-    && rmdir /S /Q patch
-
-# ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET Fx
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -2,22 +2,24 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
-# Install .NET 4.8
-RUN curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+
+RUN `
+    # Install .NET 4.8
+    curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
     && .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
-
-# Apply latest patch
-RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580979-x64-ndp48_24793c7b24af666026c2e60b7870a1034834c8e3.msu `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Apply latest patch
+    && curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/software/updt/2020/10/windows10.0-kb4580979-x64-ndp48_24793c7b24af666026c2e60b7870a1034834c8e3.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580979-x64-ndp48.cab `
-    && rmdir /S /Q patch
-
-# ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
-RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && rmdir /S /Q patch `
+    `
+    # ngen .NET Fx
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/sdk/3.5/windowsservercore-1909/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-1909/Dockerfile
@@ -31,7 +31,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers

--- a/src/sdk/3.5/windowsservercore-1909/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-1909/Dockerfile
@@ -30,6 +30,14 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -43,15 +51,6 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
 
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
     ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/3.5/windowsservercore-2004/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-2004/Dockerfile
@@ -31,7 +31,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers

--- a/src/sdk/3.5/windowsservercore-2004/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-2004/Dockerfile
@@ -30,6 +30,13 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -43,14 +50,6 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
 
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
     ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/3.5/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-20H2/Dockerfile
@@ -31,7 +31,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers

--- a/src/sdk/3.5/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-20H2/Dockerfile
@@ -30,6 +30,13 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -43,14 +50,6 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
 
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
     ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -64,6 +64,14 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -83,15 +91,6 @@ RUN powershell -Command `
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issue with 32 bit assemblies from .NET Framework 4.8 SDK being 64 bit ngen'ed
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -65,7 +65,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -40,6 +40,14 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -52,15 +60,6 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -41,7 +41,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers

--- a/src/sdk/4.8/windowsservercore-1909/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-1909/Dockerfile
@@ -31,7 +31,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers

--- a/src/sdk/4.8/windowsservercore-1909/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-1909/Dockerfile
@@ -30,6 +30,14 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -43,15 +51,6 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
 
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
     ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/4.8/windowsservercore-2004/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-2004/Dockerfile
@@ -31,7 +31,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers

--- a/src/sdk/4.8/windowsservercore-2004/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-2004/Dockerfile
@@ -30,6 +30,13 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -43,14 +50,6 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
 
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
     ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/4.8/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-20H2/Dockerfile
@@ -31,7 +31,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers

--- a/src/sdk/4.8/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-20H2/Dockerfile
@@ -30,6 +30,13 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -43,14 +50,6 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
 
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true `
     ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -48,6 +48,14 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -67,15 +75,6 @@ RUN powershell -Command `
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -49,7 +49,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -30,6 +30,14 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_BuildTools.exe `
     `
+    # Workaround for issues with 64-bit ngen
+    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update `
+    `
     # Cleanup
     && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
     && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
@@ -42,15 +50,6 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
 ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
-
-# ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
-RUN `
-    # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
-    `
-    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
-    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Set PATH in one layer to keep image size down.
 RUN powershell setx /M PATH $(${Env:PATH} `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -31,7 +31,7 @@ RUN `
     && del vs_BuildTools.exe `
     `
     # Workaround for issues with 64-bit ngen
-    \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers


### PR DESCRIPTION
Fixes #696

Some of the Dockerfiles end up executing operations that result in overwritten files from a separate layer. This results in image bloat because the original version of each file is still carried in the other layer.  The two cases where this happens are the following:
* ngen is run in a separate layer from the layer that installed the assemblies
* Patched frameworks are installed in a separate layer from the base installation of the framework.

These changes address both of these cases by combining the affected statements into a single `RUN` instruction so that only a single layer is produced and thus avoiding cross-layer file overwrites.

This can result in substantial savings in some cases.  For example, the `runtime:3.5-windowsservercore-20H2` image was reduced by 350 MB.