### PR TITLE
Add infra to generate wcf Dockerfiles from templates

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:20210108104530
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:943088
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:939194
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:20210108104530
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-slim-docker-testrunner-690072
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
+++ b/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
@@ -1,0 +1,22 @@
+#!/usr/bin/env pwsh
+param(
+    [switch]$Validate
+)
+
+if ($Validate) {
+    $customImageBuilderArgs = " --validate"
+}
+
+$repoRoot = (Get-Item "$PSScriptRoot").Parent.Parent.FullName
+
+$onDockerfilesGenerated = {
+    param($ContainerName)
+
+    if (-Not $Validate) {
+        Exec "docker cp ${ContainerName}:/repo/src $repoRoot"
+    }
+}
+
+& $PSScriptRoot/../common/Invoke-ImageBuilder.ps1 `
+    -ImageBuilderArgs "generateDockerfiles --architecture '*' --os-type '*' --optional-templates $customImageBuilderArgs" `
+    -OnCommandExecuted $onDockerfilesGenerated

--- a/eng/dockerfile-templates/wcf/Dockerfile
+++ b/eng/dockerfile-templates/wcf/Dockerfile
@@ -1,0 +1,19 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/framework/aspnet
+FROM $REPO:{{PRODUCT_VERSION}}-{{OS_VERSION}}
+
+# Install Windows components required for WCF service hosted on IIS
+{{if OS_VERSION_NUMBER = "ltsc2016" || OS_VERSION_NUMBER = "ltsc2019" || OS_VERSION_NUMBER = "1903" || OS_VERSION_NUMBER = "1909" || OS_VERSION_NUMBER = "2004"
+:RUN Add-WindowsFeature NET-WCF-TCP-Activation45; `
+    Add-WindowsFeature NET-WCF-HTTP-Activation45; `
+    Add-WindowsFeature Web-WebSockets
+^else
+:RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:WCF-HTTP-Activation45 /FeatureName:WCF-TCP-Activation45 /FeatureName:IIS-WebSockets
+}}
+# Enable net.tcp protocol for default web site on IIS
+{{if OS_VERSION_NUMBER = "ltsc2016" || OS_VERSION_NUMBER = "ltsc2019" || OS_VERSION_NUMBER = "1903" || OS_VERSION_NUMBER = "1909" || OS_VERSION_NUMBER = "2004"
+:RUN windows\system32\inetsrv\appcmd.exe set app 'Default Web Site/' /enabledProtocols:"http,net.tcp"
+^else
+:RUN windows\system32\inetsrv\appcmd.exe set app "Default Web Site/" /enabledProtocols:"http,net.tcp"
+}}EXPOSE 808

--- a/manifest.json
+++ b/manifest.json
@@ -722,6 +722,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.8/windowsservercore-ltsc2016",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
@@ -734,6 +735,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.8/windowsservercore-ltsc2019",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
@@ -746,6 +748,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.8/windowsservercore-1909",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-1909",
               "tags": {
@@ -758,6 +761,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.8/windowsservercore-2004",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-2004",
               "tags": {
@@ -770,6 +774,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.8/windowsservercore-20H2",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-20H2",
               "tags": {
@@ -796,6 +801,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.7.2/windowsservercore-ltsc2016",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
@@ -808,6 +814,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.7.2/windowsservercore-ltsc2019",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2019",
               "tags": {
@@ -828,6 +835,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.7.1/windowsservercore-ltsc2016",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
@@ -848,6 +856,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.7/windowsservercore-ltsc2016",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {
@@ -868,6 +877,7 @@
                 "REPO": "$(Repo:aspnet)"
               },
               "dockerfile": "src/wcf/4.6.2/windowsservercore-ltsc2016",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
               "os": "windows",
               "osVersion": "windowsservercore-ltsc2016",
               "tags": {

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/GeneratedArtifactTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/GeneratedArtifactTests.cs
@@ -21,6 +21,15 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         }
 
         [Fact]
+        public void VerifyDockerfileTemplates()
+        {
+            string generateDockerfilesScript = Path.Combine(Config.SourceRepoRoot, "eng", "dockerfile-templates", "Get-GeneratedDockerfiles.ps1");
+            ValidateGeneratedArtifacts(
+                generateDockerfilesScript,
+                $"The Dockerfiles are out of sync with the templates.  Update the Dockerfiles by running `{generateDockerfilesScript}`.");
+        }
+
+        [Fact]
         public void VerifyReadmeTemplates()
         {
             string generateTagsDocumentationScript = Path.Combine(Config.SourceRepoRoot, "eng", "readme-templates", "Get-GeneratedReadmes.ps1");


### PR DESCRIPTION
This is the first phase of introducing Dockerfile templates.  The other variants such as aspnet, runtime, and sdk will be added if deemed valuable in subsequent PRs.

Related to #616 