### PR TITLE
Remove usage of deprecated syntax for ENV instruction

### DIFF
--- a/eng/update-dependencies/DependencyUpdater.cs
+++ b/eng/update-dependencies/DependencyUpdater.cs
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.Framework.UpdateDependencies
                         {
                             Path = dockerfile.Path,
                             VersionGroupName = NuGetVersionGroupName,
-                            Regex = new Regex(@$"ENV NUGET_VERSION (?<{NuGetVersionGroupName}>\d+\.\d+\.\d+)")
+                            Regex = new Regex(@$"ENV NUGET_VERSION=(?<{NuGetVersionGroupName}>\d+\.\d+\.\d+)")
                         },
                         new CustomFileRegexUpdater(nuGetInfo.NuGetClientLatestVersion, dockerfile.ImageVariant)
                         {

--- a/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile
@@ -26,7 +26,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe  /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/aspnet/4.7.1/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7.1/windowsservercore-ltsc2016/Dockerfile
@@ -26,7 +26,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe  /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/aspnet/4.7.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7.2/windowsservercore-ltsc2016/Dockerfile
@@ -26,7 +26,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe  /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile
@@ -24,7 +24,7 @@ RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe  /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile
@@ -26,7 +26,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe  /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/aspnet/4.8/windowsservercore-1909/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-1909/Dockerfile
@@ -24,7 +24,7 @@ RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe  /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/aspnet/4.8/windowsservercore-2004/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-2004/Dockerfile
@@ -21,7 +21,7 @@ RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe    
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/aspnet/4.8/windowsservercore-20H2/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-20H2/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -fSLo microsoft.net.compilers.2.9.0.zip https://api.nuget.org/packages/
     && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe `
     && C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -26,7 +26,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe  /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -24,7 +24,7 @@ RUN Invoke-WebRequest https://api.nuget.org/packages/microsoft.net.compilers.2.9
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\vbc.exe /ExeConfig:c:\RoslynCompilers\tools\vbc.exe | `
     &C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe install c:\RoslynCompilers\tools\VBCSCompiler.exe  /ExeConfig:c:\RoslynCompilers\tools\VBCSCompiler.exe
 
-ENV ROSLYN_COMPILER_LOCATION c:\RoslynCompilers\tools
+ENV ROSLYN_COMPILER_LOCATION=c:\RoslynCompilers\tools
 
 EXPOSE 80
 

--- a/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -32,7 +32,7 @@ RUN powershell -Command `
     && rmdir /S /Q patch
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `

--- a/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/s
     && rmdir /S /Q patch
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen update `
     && \Windows\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/src/runtime/4.6.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.6.2/windowsservercore-ltsc2016/Dockerfile
@@ -3,6 +3,6 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.7.1/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.7.1/windowsservercore-ltsc2016/Dockerfile
@@ -29,6 +29,6 @@ RUN powershell -Command `
     && rmdir /S /Q patch
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
@@ -29,6 +29,6 @@ RUN powershell -Command `
     && rmdir /S /Q patch
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.7.2/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/4.7.2/windowsservercore-ltsc2019/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/s
     && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4580422-x64.cab `
     && rmdir /S /Q patch
 
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `

--- a/src/runtime/4.7/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.7/windowsservercore-ltsc2016/Dockerfile
@@ -29,6 +29,6 @@ RUN powershell -Command `
     && rmdir /S /Q patch
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -29,6 +29,6 @@ RUN powershell -Command `
     && rmdir /S /Q patch
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -fSLo patch.msu http://download.windowsupdate.com/c/msdownload/update/s
     && rmdir /S /Q patch
 
 # ngen .NET Fx
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
     && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/sdk/3.5/windowsservercore-1909/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-1909/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-1909
 
 # Install NuGet CLI
-ENV NUGET_VERSION 5.3.1
+ENV NUGET_VERSION=5.3.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
     && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe

--- a/src/sdk/3.5/windowsservercore-2004/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-2004/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-2004
 
 # Install NuGet CLI
-ENV NUGET_VERSION 5.5.1
+ENV NUGET_VERSION=5.5.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
     && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe

--- a/src/sdk/3.5/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-20H2/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-20H2
 
 # Install NuGet CLI
-ENV NUGET_VERSION 5.7.0
+ENV NUGET_VERSION=5.7.0
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
     && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -21,7 +21,7 @@ RUN \Windows\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.9.4
+ENV NUGET_VERSION=4.9.4
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -87,7 +87,7 @@ RUN powershell -Command `
         Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\" `
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
 RUN `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -14,7 +14,7 @@ RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.9.4
+ENV NUGET_VERSION=4.9.4
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
     && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
@@ -53,7 +53,7 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
     && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
 RUN `

--- a/src/sdk/4.8/windowsservercore-1909/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-1909/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-1909
 
 # Install NuGet CLI
-ENV NUGET_VERSION 5.3.1
+ENV NUGET_VERSION=5.3.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
     && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe

--- a/src/sdk/4.8/windowsservercore-2004/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-2004/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-2004
 
 # Install NuGet CLI
-ENV NUGET_VERSION 5.5.1
+ENV NUGET_VERSION=5.5.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
     && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe

--- a/src/sdk/4.8/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-20H2/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-20H2
 
 # Install NuGet CLI
-ENV NUGET_VERSION 5.7.0
+ENV NUGET_VERSION=5.7.0
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
     && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-ltsc2016
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.9.4
+ENV NUGET_VERSION=4.9.4
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -71,7 +71,7 @@ RUN powershell -Command `
         Expand-Archive MSBuild.Microsoft.VisualStudio.Web.targets.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0\" `
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
 RUN `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-ltsc2019
 
 # Install NuGet CLI
-ENV NUGET_VERSION 4.9.4
+ENV NUGET_VERSION=4.9.4
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
     && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
@@ -43,7 +43,7 @@ RUN curl -fSLo MSBuild.Microsoft.VisualStudio.Web.targets.zip https://dotnetbina
     && tar -zxf MSBuild.Microsoft.VisualStudio.Web.targets.zip -C "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft\VisualStudio\v16.0" `
     && del MSBuild.Microsoft.VisualStudio.Web.targets.zip
 
-ENV ROSLYN_COMPILER_LOCATION "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
+ENV ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\Roslyn"
 
 # ngen assemblies queued by VS installers - must be done in cmd shell to avoid access issues
 RUN `


### PR DESCRIPTION
Updates the usage of `ENV name value` syntax to `ENV name=value`.

Fixes #695