### PR TITLE
Use common NuGet CLI version

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -17,7 +17,8 @@ RUN %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
 # Install NuGet CLI
 ENV NUGET_VERSION={{VARIABLES[cat("nuget|version")]}}
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -15,10 +15,9 @@ RUN %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update
 }}
 # Install NuGet CLI
-ENV NUGET_VERSION={{VARIABLES[cat("nuget|", OS_VERSION_NUMBER, "|version")]}}
+ENV NUGET_VERSION={{VARIABLES[cat("nuget|version")]}}
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v{{VARIABLES["nuget|version"]}}/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS components
 RUN `

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -22,7 +22,7 @@ RUN %windir%\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.
     && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update
 }}
 # Install NuGet CLI
-ENV NUGET_VERSION={{VARIABLES[cat("nuget|", OS_VERSION_NUMBER, "|version")]}}
+ENV NUGET_VERSION={{VARIABLES[cat("nuget|version")]}}
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -30,11 +30,7 @@ RUN mkdir "%ProgramFiles%\NuGet\latest" `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\nuget.exe; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dist.nuget.org/win-x86-commandline/v{{VARIABLES["nuget|version"]}}/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\latest\nuget.exe
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe;
 
 # Install VS components
 RUN `

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -30,7 +30,8 @@ RUN mkdir "%ProgramFiles%\NuGet\latest" `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\nuget.exe;
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe; `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -16,12 +16,7 @@
       "kb|20H2":"kb4586876",
       "lcu|20H2":"http://download.windowsupdate.com/d/msdownload/update/software/updt/2020/11/windows10.0-kb4586876-x64-ndp48_ab1407801539dfe4af2423400875a596fc032739.msu",
 
-      "nuget|ltsc2016|version": "4.9.4",
-      "nuget|ltsc2019|version": "4.9.4",
-      "nuget|1909|version": "5.3.1",
-      "nuget|2004|version": "5.5.1",
-      "nuget|20H2|version": "5.7.0",
-      "nuget|version": "5.8.0",
+      "nuget|version": "5.8.1",
   
       "vs|version": "16.8",
       "vs|testAgentUrl": "https://download.visualstudio.microsoft.com/download/pr/5f914955-f6c7-4add-8e47-2e090bdc02fa/8fd51571a9aff13c4381037ccb7559a3bb3e6527cbacf4816068e711dfe824f4/vs_TestAgent.exe",

--- a/src/sdk/3.5/windowsservercore-1909/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-1909/Dockerfile
@@ -4,10 +4,9 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-1909
 
 # Install NuGet CLI
-ENV NUGET_VERSION=5.3.1
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-1909/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-1909/Dockerfile
@@ -6,7 +6,8 @@ FROM $REPO:3.5-windowsservercore-1909
 # Install NuGet CLI
 ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-2004/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-2004/Dockerfile
@@ -6,7 +6,8 @@ FROM $REPO:3.5-windowsservercore-2004
 # Install NuGet CLI
 ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-2004/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-2004/Dockerfile
@@ -4,10 +4,9 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-2004
 
 # Install NuGet CLI
-ENV NUGET_VERSION=5.5.1
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-20H2/Dockerfile
@@ -6,7 +6,8 @@ FROM $REPO:3.5-windowsservercore-20H2
 # Install NuGet CLI
 ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-20H2/Dockerfile
@@ -4,10 +4,9 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:3.5-windowsservercore-20H2
 
 # Install NuGet CLI
-ENV NUGET_VERSION=5.7.0
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -21,7 +21,7 @@ RUN %windir%\Microsoft.NET\Framework64\v2.0.50727\ngen uninstall "Microsoft.Tpm.
     && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Install NuGet CLI
-ENV NUGET_VERSION=4.9.4
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -29,11 +29,7 @@ RUN mkdir "%ProgramFiles%\NuGet\latest" `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\nuget.exe; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\latest\nuget.exe
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe;
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -29,7 +29,8 @@ RUN mkdir "%ProgramFiles%\NuGet\latest" `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\nuget.exe;
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe; `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -16,7 +16,8 @@ RUN %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
 # Install NuGet CLI
 ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -14,10 +14,9 @@ RUN %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update
 
 # Install NuGet CLI
-ENV NUGET_VERSION=4.9.4
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-1909/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-1909/Dockerfile
@@ -6,7 +6,8 @@ FROM $REPO:4.8-windowsservercore-1909
 # Install NuGet CLI
 ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-1909/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-1909/Dockerfile
@@ -4,10 +4,9 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-1909
 
 # Install NuGet CLI
-ENV NUGET_VERSION=5.3.1
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-2004/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-2004/Dockerfile
@@ -6,7 +6,8 @@ FROM $REPO:4.8-windowsservercore-2004
 # Install NuGet CLI
 ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-2004/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-2004/Dockerfile
@@ -4,10 +4,9 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-2004
 
 # Install NuGet CLI
-ENV NUGET_VERSION=5.5.1
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-20H2/Dockerfile
@@ -6,7 +6,8 @@ FROM $REPO:4.8-windowsservercore-20H2
 # Install NuGet CLI
 ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-20H2/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-20H2/Dockerfile
@@ -4,10 +4,9 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-20H2
 
 # Install NuGet CLI
-ENV NUGET_VERSION=5.7.0
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -4,7 +4,7 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-ltsc2016
 
 # Install NuGet CLI
-ENV NUGET_VERSION=4.9.4
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `
@@ -12,11 +12,7 @@ RUN mkdir "%ProgramFiles%\NuGet\latest" `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\nuget.exe; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\latest\nuget.exe
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe;
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -12,7 +12,8 @@ RUN mkdir "%ProgramFiles%\NuGet\latest" `
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe `
-            -OutFile $Env:ProgramFiles\NuGet\nuget.exe;
+            -OutFile $Env:ProgramFiles\NuGet\nuget.exe; `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -4,10 +4,9 @@ ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:4.8-windowsservercore-ltsc2019
 
 # Install NuGet CLI
-ENV NUGET_VERSION=4.9.4
+ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
-    && curl -fSLo "%ProgramFiles%\NuGet\latest\nuget.exe" https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
 
 # Install VS components
 RUN `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -6,7 +6,8 @@ FROM $REPO:4.8-windowsservercore-ltsc2019
 # Install NuGet CLI
 ENV NUGET_VERSION=5.8.1
 RUN mkdir "%ProgramFiles%\NuGet\latest" `
-    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
 
 # Install VS components
 RUN `

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
 
             Assert.StartsWith("NuGet Version:", output);
 
-            command = "%ProgramFiles%\NuGet\latest\nuget.exe help";
+            command = @"%ProgramFiles%\NuGet\latest\nuget.exe help";
             string latestOutput = ImageTestHelper.DockerHelper.Run(image: baseBuildImage, name: appId, command: command);
             Assert.Equal(output, latestOutput);
         }

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
 
             Assert.StartsWith("NuGet Version:", output);
 
-            command = @"%ProgramFiles%\NuGet\latest\nuget.exe help";
+            command = @"cmd /c ""C:\Program Files\NuGet\latest\nuget.exe"" help";
             string latestOutput = ImageTestHelper.DockerHelper.Run(image: baseBuildImage, name: appId, command: command);
             Assert.Equal(output, latestOutput);
         }

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -135,6 +135,10 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             string output = ImageTestHelper.DockerHelper.Run(image: baseBuildImage, name: appId, command: command);
 
             Assert.StartsWith("NuGet Version:", output);
+
+            command = "%ProgramFiles%\NuGet\latest\nuget.exe help";
+            string latestOutput = ImageTestHelper.DockerHelper.Run(image: baseBuildImage, name: appId, command: command);
+            Assert.Equal(output, latestOutput);
         }
 
         [SkippableTheory("4.6.2", "4.7", "4.7.1", "4.7.2")]


### PR DESCRIPTION
Updates all the SDK images to use the latest NuGet CLI version.

This implements the rest of the phased plan for #704.

Fixes https://github.com/microsoft/dotnet-framework-docker/issues/678