### PR TITLE
Remove dependency on dotnet.myget.org NuGet feed

### DIFF
--- a/eng/update-dependencies/Microsoft.DotNet.Framework.UpdateDependencies.csproj
+++ b/eng/update-dependencies/Microsoft.DotNet.Framework.UpdateDependencies.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="2.2.0-prerelease-02431-01" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="5.0.0-beta.19617.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
   </ItemGroup>

--- a/eng/update-dependencies/NuGet.config
+++ b/eng/update-dependencies/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Attempting to restore projects for `Microsoft.DotNet.Framework.UpdateDependencies.csproj` on a machine without cached NuGet packages will result in the following error:

```
/usr/share/dotnet/sdk/5.0.201/NuGet.targets(131,5): error : Unable to load the service index for source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json. [/home/vsts/work/1/s/eng/update-dependencies/Microsoft.DotNet.Framework.UpdateDependencies.csproj]
/usr/share/dotnet/sdk/5.0.201/NuGet.targets(131,5): error :   The SSL connection could not be established, see inner exception. [/home/vsts/work/1/s/eng/update-dependencies/Microsoft.DotNet.Framework.UpdateDependencies.csproj]
/usr/share/dotnet/sdk/5.0.201/NuGet.targets(131,5): error :   The remote certificate is invalid according to the validation procedure: RemoteCertificateNameMismatch [/home/vsts/work/1/s/eng/update-dependencies/Microsoft.DotNet.Framework.UpdateDependencies.csproj]
```

The dotnet.myget.org has been deprecated and should no longer be referenced.  I've removed the reference and updated the package version of `Microsoft.DotNet.VersionTools` which is the available version in the `dotnet-public` feed.