### PR TITLE
Add dotnet-eng feed for VersionTools package

### DIFF
--- a/eng/update-dependencies/NuGet.config
+++ b/eng/update-dependencies/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
My changes for https://github.com/microsoft/dotnet-framework-docker/pull/747 were incomplete.  I don't know what happened when testing locally but the `Microsoft.DotNet.VersionTools` package is stored in the `dotnet-eng` feed, not the `dotnet-public`.  Fixed the nuget.config file.