### PR TITLE
Define NuGet.config with <clear> element

### DIFF
--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/NuGet.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7.1/.nuget/NuGet.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7.1/.nuget/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-  </packageSources>
-</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7.2/.nuget/NuGet.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7.2/.nuget/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-  </packageSources>
-</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7/.nuget/NuGet.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.7/.nuget/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-  </packageSources>
-</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8/.nuget/NuGet.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8/.nuget/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
Consolidates all the NuGet.config files used by test projects into one file which conforms to NuGet config policy.