### PR TITLE
Add CG detection pipeline

### DIFF
--- a/eng/pipelines/cg-detection.yml
+++ b/eng/pipelines/cg-detection.yml
@@ -1,0 +1,14 @@
+trigger:
+  branches:
+    include:
+    - main
+    - dev
+pr: none
+
+variables:
+- template: ../common/templates/variables/common.yml
+- name: cgBuildGrepArgs
+  value: -v -e 'samples/' -e 'tests/'
+
+jobs:
+- template: ../common/templates/jobs/cg-detection.yml


### PR DESCRIPTION
Defines a pipeline that runs through component governance whenever a commit is made.  This will cause all projects in the repo to be built and their assets scanned by component governance.