### PR TITLE
Fix paths in dotnetapp sample

### DIFF
--- a/samples/dotnetapp/Dockerfile
+++ b/samples/dotnetapp/Dockerfile
@@ -2,16 +2,16 @@ FROM mcr.microsoft.com/dotnet/framework/sdk:4.8 AS build
 WORKDIR /app
 
 # copy csproj and restore as distinct layers
-COPY dotnetapp/*.csproj .
+COPY *.csproj .
 RUN dotnet restore
 
 # copy and build everything else
 COPY . .
-WORKDIR /app/dotnetapp
+WORKDIR /app
 RUN dotnet publish -c Release -o out --no-restore
 
 
 FROM mcr.microsoft.com/dotnet/framework/runtime:4.8 AS runtime
 WORKDIR /app
-COPY --from=build /app/dotnetapp/out ./
+COPY --from=build /app/out ./
 ENTRYPOINT ["dotnetapp.exe"]


### PR DESCRIPTION
The dotnetapp sample Dockerfile was incorrectly updated from https://github.com/microsoft/dotnet-framework-docker/pull/821.  This fixes the path references.