### PR TITLE
Apply patch for supporting container limits

### DIFF
--- a/build-and-test.ps1
+++ b/build-and-test.ps1
@@ -19,12 +19,13 @@ param(
 )
 
 if ($Repos.Count -eq 0) {
-    $Path = $null
+    $Paths = $null
 }
 else {
-    $Path = @()
+    $Paths = @()
     $Repos | foreach {
-        $Path += "src/$_/$Version/$OS"
+        
+        $Paths += "src/$_/$Version/$OS"
     }
     $testCategories = $Repos
 }
@@ -33,7 +34,7 @@ if ($Mode -eq "BuildAndTest" -or $Mode -eq "Build") {
     & ./eng/common/build.ps1 `
         -Version $Version `
         -OS $OS `
-        -Path $Path `
+        -Paths $Paths `
         -OptionalImageBuilderArgs $OptionalImageBuilderArgs
 }
 

--- a/eng/dockerfile-templates/runtime/Dockerfile
+++ b/eng/dockerfile-templates/runtime/Dockerfile
@@ -3,10 +3,12 @@
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
 ENV {{
-if OS_VERSION_NUMBER != "ltsc2019"
+if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8"
 :`
     # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true `
+    }}{{ if OS_VERSION_NUMBER != "ltsc2019"
+:DOTNET_RUNNING_IN_CONTAINER=true `
+    }}{{ if PRODUCT_VERSION = "4.8" && OS_VERSION_NUMBER != "2004" && OS_VERSION_NUMBER != "20H2":COMPLUS_RUNNING_IN_CONTAINER=1 `
     }}COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
@@ -33,6 +35,15 @@ RUN `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5":{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}}^else:{{VARIABLES[cat("kb|", OS_VERSION_NUMBER)]}}}}-x64{{if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8":-ndp48}}.cab `
+    && rmdir /S /Q patch `
+    `
+}}{{if PRODUCT_VERSION = "4.8" && (OS_VERSION_NUMBER = "ltsc2019" || OS_VERSION_NUMBER = "ltsc2022")
+:    # Apply patch to provide support for container limits
+    && curl -fSLo patch.msu {{VARIABLES[cat("limits-patch|url|", OS_VERSION_NUMBER)]}} `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("limits-patch|kb|", OS_VERSION_NUMBER)]}}-x64-ndp48.cab `
     && rmdir /S /Q patch `
     `
 }}{{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5"

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -17,6 +17,11 @@
       "kb|ltsc2022": "kb5005538",
       "lcu|ltsc2022": "http://download.windowsupdate.com/c/msdownload/update/software/updt/2021/08/windows10.0-kb5005538-x64-ndp48_451a4214d51de628ef2c3c8a69c87826b2ab43c8.msu",
 
+      "limits-patch|kb|ltsc2022": "kb9008395",
+      "limits-patch|url|ltsc2022": "https://download.microsoft.com/download/5/a/4/5a4425d3-eb10-47a8-afe0-b07a19b20b1c/Windows10.0-KB9008395-x64-NDP48.msu",
+      "limits-patch|kb|ltsc2019": "kb9008392",
+      "limits-patch|url|ltsc2019": "https://download.microsoft.com/download/5/a/4/5a4425d3-eb10-47a8-afe0-b07a19b20b1c/Windows10.0-KB9008392-x64-NDP48.msu",
+
       "nuget|version": "5.11.0",
   
       "vs|version": "16.11",

--- a/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -2,7 +2,10 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 
-ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
+ENV `
+    # Enable detection of running in a container
+    COMPLUS_RUNNING_IN_CONTAINER=1 `
+    COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
     # Install .NET Fx 4.8
@@ -17,6 +20,14 @@ RUN `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb5005540-x64-ndp48.cab `
+    && rmdir /S /Q patch `
+    `
+    # Apply patch to provide support for container limits
+    && curl -fSLo patch.msu https://download.microsoft.com/download/5/a/4/5a4425d3-eb10-47a8-afe0-b07a19b20b1c/Windows10.0-KB9008392-x64-NDP48.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb9008392-x64-ndp48.cab `
     && rmdir /S /Q patch `
     `
     # ngen .NET Fx

--- a/src/runtime/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -5,6 +5,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64
 ENV `
     # Enable detection of running in a container
     DOTNET_RUNNING_IN_CONTAINER=true `
+    COMPLUS_RUNNING_IN_CONTAINER=1 `
     COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
@@ -14,6 +15,14 @@ RUN `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb5005538-x64-ndp48.cab `
+    && rmdir /S /Q patch `
+    `
+    # Apply patch to provide support for container limits
+    && curl -fSLo patch.msu https://download.microsoft.com/download/5/a/4/5a4425d3-eb10-47a8-afe0-b07a19b20b1c/Windows10.0-KB9008395-x64-NDP48.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb9008395-x64-ndp48.cab `
     && rmdir /S /Q patch `
     `
     # Ngen top of assembly graph to optimize a set of frequently used assemblies

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTestHelper.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTestHelper.cs
@@ -65,7 +65,8 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             IEnumerable<string> buildArgs,
             string appDescriptor,
             string runCommand,
-            string testUrl)
+            string testUrl,
+            string optionalRunArgs = null)
         {
             string appId = $"{appDescriptor}-{DateTime.Now.ToFileTime()}";
             string workDir = Path.Combine(
@@ -83,7 +84,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                     contextDir: workDir,
                     buildArgs: buildArgs.ToArray());
 
-                output = DockerHelper.Run(image: appId, name: appId, command: runCommand, detach: !string.IsNullOrEmpty(testUrl));
+                output = DockerHelper.Run(image: appId, name: appId, command: runCommand, optionalRunArgs: optionalRunArgs, detach: !string.IsNullOrEmpty(testUrl));
                 if (!string.IsNullOrEmpty(testUrl))
                 {
                     VerifyHttpResponseFromContainer(appId, testUrl);

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
@@ -89,18 +89,12 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                     contextDir: workDir,
                     buildArgs: appBuildArgs.ToArray());
 
-                // Get the actual number of processors that exist in the container by default
-                int actualProcessorCount = int.Parse(_imageTestHelper.DockerHelper.Run(image: appId, name: appId, command: runCommand));
-
-                // Run the container to use half the available processors
-                int expectedProcessorCount = actualProcessorCount / 2;
                 string output = _imageTestHelper.DockerHelper.Run(image: appId, name: appId, command: runCommand, optionalRunArgs: "--cpus 0.5");
-                Assert.Equal(expectedProcessorCount.ToString(), output);
+                Assert.Equal("1", output);
 
-                // Run the container with an override to specify the number of processors
-                string overridenProcessorCount = "20";
-                output = _imageTestHelper.DockerHelper.Run(image: appId, name: appId, command: runCommand, optionalRunArgs: $"--cpus 0.5 -e COMPLUS_PROCESSOR_COUNT={overridenProcessorCount}");
-                Assert.Equal(overridenProcessorCount, output);
+                string processorCount = "20";
+                output = _imageTestHelper.DockerHelper.Run(image: appId, name: appId, command: runCommand, optionalRunArgs: $"--cpus 0.5 -e COMPLUS_PROCESSOR_COUNT={processorCount}");
+                Assert.Equal(processorCount, output);
             }
             finally
             {

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SkippableTheoryAttribute.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SkippableTheoryAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -9,21 +10,34 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
 {
     public class SkippableTheoryAttribute : TheoryAttribute
     {
+        public string[] SkipOnOsVersions { get; set; } = Array.Empty<string>();
+
         public SkippableTheoryAttribute(params string[] skipOnRuntimeVersions)
         {
-            if (!string.IsNullOrEmpty(Config.Version) && Config.Version != "*")
+            bool skipped = CheckForSkip(Config.Version, skipOnRuntimeVersions);
+            if (!skipped)
+            {
+                CheckForSkip(Config.OS, SkipOnOsVersions);
+            }
+        }
+
+        private bool CheckForSkip(string configuredVersion, string[] skipOnVersions)
+        {
+            if (!string.IsNullOrEmpty(configuredVersion) && configuredVersion != "*")
             {
                 string versionPattern =
-                    Config.Version != null ? Config.GetFilterRegexPattern(Config.Version) : null;
-                foreach (string skipOnRuntimeVersion in skipOnRuntimeVersions)
+                    configuredVersion != null ? Config.GetFilterRegexPattern(configuredVersion) : null;
+                foreach (string skipOnVersion in skipOnVersions)
                 {
-                    if (Regex.IsMatch(skipOnRuntimeVersion, versionPattern, RegexOptions.IgnoreCase))
+                    if (Regex.IsMatch(skipOnVersion, versionPattern, RegexOptions.IgnoreCase))
                     {
-                        Skip = $"{skipOnRuntimeVersion} is unsupported";
-                        break;
+                        Skip = $"{skipOnVersion} is unsupported";
+                        return true;
                     }
                 }
             }
+
+            return false;
         }
     }
 }

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8/Program.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8/Program.cs
@@ -8,7 +8,7 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        bool getProcessorCount = args[0] == "getProcessorCount";
+        bool getProcessorCount = args.Length > 0 && args[0] == "getProcessorCount";
 
         if (getProcessorCount)
         {

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8/Program.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8/Program.cs
@@ -8,6 +8,15 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        Console.WriteLine("Hello Docker World from .NET 4.8!");
+        bool getProcessorCount = args[0] == "getProcessorCount";
+
+        if (getProcessorCount)
+        {
+            Console.WriteLine(Environment.ProcessorCount);
+        }
+        else
+        {
+            Console.WriteLine("Hello Docker World from .NET 4.8!");
+        }
     }
 }

--- a/tests/tests.sln
+++ b/tests/tests.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29505.145
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31815.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Framework.Docker.Tests", "Microsoft.DotNet.Framework.Docker.Tests\Microsoft.DotNet.Framework.Docker.Tests.csproj", "{4C892951-C119-4879-9EE9-EC48E56C5204}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Framework.Models", "..\eng\models\Microsoft.DotNet.Framework.Models.csproj", "{D2524819-960D-41B4-AD9B-AF3FBAAE1951}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +15,6 @@ Global
 		{4C892951-C119-4879-9EE9-EC48E56C5204}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4C892951-C119-4879-9EE9-EC48E56C5204}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4C892951-C119-4879-9EE9-EC48E56C5204}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D2524819-960D-41B4-AD9B-AF3FBAAE1951}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D2524819-960D-41B4-AD9B-AF3FBAAE1951}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D2524819-960D-41B4-AD9B-AF3FBAAE1951}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D2524819-960D-41B4-AD9B-AF3FBAAE1951}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Applies the patch for 4.8's support of container limits (i.e. Docker's `--cpus` and `--memory` options).