### PR TITLE
Fix container limits tests failing on local run

### DIFF
--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTestHelper.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/ImageTestHelper.cs
@@ -21,11 +21,11 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         private static readonly Lazy<JObject> s_imageInfoData;
 
         public DockerHelper DockerHelper { get; }
-        private readonly ITestOutputHelper _outputHelper;
+        public ITestOutputHelper OutputHelper { get; }
 
         public ImageTestHelper(ITestOutputHelper outputHelper)
         {
-            _outputHelper = outputHelper;
+            OutputHelper = outputHelper;
             DockerHelper = new DockerHelper(outputHelper);
         }
 
@@ -168,12 +168,12 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                             result.EnsureSuccessStatusCode();
                         }
 
-                        _outputHelper.WriteLine($"Successfully accessed {url}");
+                        OutputHelper.WriteLine($"Successfully accessed {url}");
                         return;
                     }
                     catch (Exception ex)
                     {
-                        _outputHelper.WriteLine($"Request to {url} failed - retrying: {ex}");
+                        OutputHelper.WriteLine($"Request to {url} failed - retrying: {ex}");
                     }
                 }
             }

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
@@ -54,17 +54,19 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             VerifyFxImages(imageDescriptor, "webapp", "powershell -command \"dir ./bin/SimpleWebApplication.dll\"", false);
         }
 
-        [SkippableTheory(
-            "3.5", "4.6.2", "4.7", "4.7.1", "4.7.2",
-            SkipOnOsVersions = new string[]
-            {
-                OsVersion.WSC_LTSC2016,
-                OsVersion.WSC_2004,
-                OsVersion.WSC_20H2
-            })]
+        [Theory]
         [MemberData(nameof(GetImageData))]
         public void ContainerLimits(RuntimeImageDescriptor imageDescriptor)
         {
+            // Container limits are only supported on 4.8 for Server 2019 and 2022.
+            if (imageDescriptor.Version != "4.8" &&
+                (imageDescriptor.OsVariant != OsVersion.WSC_LTSC2019 ||
+                imageDescriptor.OsVariant != OsVersion.WSC_LTSC2022))
+            {
+                _imageTestHelper.OutputHelper.WriteLine("Test skipped due to unsupported version.");
+                return;
+            }
+
             string appId = $"container-limits-{DateTime.Now.ToFileTime()}";
             string workDir = Path.Combine(
                 Directory.GetCurrentDirectory(),

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
@@ -59,8 +59,8 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         public void ContainerLimits(RuntimeImageDescriptor imageDescriptor)
         {
             // Container limits are only supported on 4.8 for Server 2019 and 2022.
-            if (imageDescriptor.Version != "4.8" &&
-                (imageDescriptor.OsVariant != OsVersion.WSC_LTSC2019 ||
+            if (imageDescriptor.Version != "4.8" ||
+                (imageDescriptor.OsVariant != OsVersion.WSC_LTSC2019 &&
                 imageDescriptor.OsVariant != OsVersion.WSC_LTSC2022))
             {
                 _imageTestHelper.OutputHelper.WriteLine("Test skipped due to unsupported version.");

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SkippableTheoryAttribute.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SkippableTheoryAttribute.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -10,45 +9,23 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
 {
     public class SkippableTheoryAttribute : TheoryAttribute
     {
-        private readonly Lazy<string> _skip;
-        public string[] SkipOnOsVersions { get; set; } = Array.Empty<string>();
         public string[] SkipOnRuntimeVersions { get; }
 
         public SkippableTheoryAttribute(params string[] skipOnRuntimeVersions)
         {
-            SkipOnRuntimeVersions = skipOnRuntimeVersions;
-            _skip = new Lazy<string>(() => LoadSkip());
-        }
-
-        public override string Skip { get => _skip.Value; set => throw new NotSupportedException(); }
-
-        private string LoadSkip()
-        {
-            string skip = CheckForSkip(Config.Version, SkipOnRuntimeVersions);
-            if (skip is null)
-            {
-                skip = CheckForSkip(Config.OS, SkipOnOsVersions);
-            }
-
-            return skip;
-        }
-
-        private string CheckForSkip(string configuredVersion, string[] skipOnVersions)
-        {
-            if (!string.IsNullOrEmpty(configuredVersion) && configuredVersion != "*")
+            if (!string.IsNullOrEmpty(Config.Version) && Config.Version != "*")
             {
                 string versionPattern =
-                    configuredVersion != null ? Config.GetFilterRegexPattern(configuredVersion) : null;
-                foreach (string skipOnVersion in skipOnVersions)
+                    Config.Version != null ? Config.GetFilterRegexPattern(Config.Version) : null;
+                foreach (string skipOnRuntimeVersion in skipOnRuntimeVersions)
                 {
-                    if (Regex.IsMatch(skipOnVersion, versionPattern, RegexOptions.IgnoreCase))
+                    if (Regex.IsMatch(skipOnRuntimeVersion, versionPattern, RegexOptions.IgnoreCase))
                     {
-                        return $"{skipOnVersion} is unsupported";
+                        Skip = $"{skipOnRuntimeVersion} is unsupported";
+                        break;
                     }
                 }
             }
-
-            return null;
         }
     }
 }


### PR DESCRIPTION
When running tests locally and not specifying the `-Version` filter to the `build-and-test.ps1` script, it will cause the ContainerLimits test to be run for unsupported versions, causing failures.

The test is not skipped because the logic in the `SkippableTestAttribute` accounts for the wildcard scenario, which this scenario is when the Version value is set to `*` by default. The tests are designed to run the scenarios defined by the version matrix as defined by: https://github.com/microsoft/dotnet-framework-docker/blob/98002c0d20a95c84a790dab8d07783728a24edbe/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs#L17-L34

The purpose of the `SkippableTestAttribute` is to reflect this same version matrix, not to further refine it. This is to workaround the limitation of xUnit throwing an error if `MemberData` were to ever return an empty result, which in test job scenarios which are configured to run tests for specific versions which may not have any associated tests. The attribute allows those tests to be skipped gracefully without causing an error.

For further refinement of the configured version matrix, the test itself should be run but no-op if it's not a supported scenario for that version.

For these changes, I've updated the test to no-op for non-supported versions and also reverted the change to `SkippableTheoryAttribute` from https://github.com/microsoft/dotnet-framework-docker/pull/842 since that code path is no longer used.