### PR TITLE
Fix update-readmes pipeline pool

### DIFF
--- a/eng/pipelines/update-readmes.yml
+++ b/eng/pipelines/update-readmes.yml
@@ -7,7 +7,7 @@ variables:
   value: manifest.json
 jobs:
 - job: UpdateReadmes
-  pool: Hosted Ubuntu 1604
+  pool: $(defaultLinuxAmd64PoolImage)
   steps:
   - template: ../common/templates/steps/init-docker-linux.yml
   - template: ../common/templates/steps/publish-readmes.yml

--- a/eng/pipelines/update-readmes.yml
+++ b/eng/pipelines/update-readmes.yml
@@ -7,7 +7,8 @@ variables:
   value: manifest.json
 jobs:
 - job: UpdateReadmes
-  pool: $(defaultLinuxAmd64PoolImage)
+  pool:
+    vmImage: $(defaultLinuxAmd64PoolImage)
   steps:
   - template: ../common/templates/steps/init-docker-linux.yml
   - template: ../common/templates/steps/publish-readmes.yml


### PR DESCRIPTION
`Hosted Ubuntu 1604` is no longer a supported pool. Updating to built-in variable for the default pool.