### PR TITLE
Apply 4.8 container limits patch to 3.5 Dockerfile for WS 2022

### DIFF
--- a/eng/dockerfile-templates/runtime/Dockerfile
+++ b/eng/dockerfile-templates/runtime/Dockerfile
@@ -37,9 +37,11 @@ RUN `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5":{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}}^else:{{VARIABLES[cat("kb|", OS_VERSION_NUMBER)]}}}}-x64{{if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8":-ndp48}}.cab `
     && rmdir /S /Q patch `
     `
-}}{{if PRODUCT_VERSION = "4.8" && (OS_VERSION_NUMBER = "ltsc2019" || OS_VERSION_NUMBER = "ltsc2022")
+}}{{if
+    OS_VERSION_NUMBER != "ltsc2016" && OS_VERSION_NUMBER != "20H2" &&
+    (PRODUCT_VERSION = "4.8" || (PRODUCT_VERSION = "3.5" && OS_VERSION_NUMBER != "ltsc2019"))
 :    # Apply patch to provide support for container limits
-    {{if OS_VERSION_NUMBER != "ltsc2022":&& }}curl -fSLo patch.msu {{VARIABLES[cat("limits-patch|url|", OS_VERSION_NUMBER)]}} `
+    {{if PRODUCT_VERSION = "3.5" || OS_VERSION_NUMBER = "ltsc2019":&& }}curl -fSLo patch.msu {{VARIABLES[cat("limits-patch|url|", OS_VERSION_NUMBER)]}} `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/src/runtime/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -24,6 +24,14 @@ RUN `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb5008882-x64-ndp48.cab `
     && rmdir /S /Q patch `
     `
+    # Apply patch to provide support for container limits
+    && curl -fSLo patch.msu https://download.microsoft.com/download/5/a/4/5a4425d3-eb10-47a8-afe0-b07a19b20b1c/Windows10.0-KB9008395-x64-NDP48.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb9008395-x64-ndp48.cab `
+    && rmdir /S /Q patch `
+    `
     # Ngen top of assembly graph to optimize a set of frequently used assemblies
     && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     # To optimize 32-bit assemblies, uncomment the next line


### PR DESCRIPTION
Fixes #866