### PR TITLE
Fix build issues

### DIFF
--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1568600
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1548981
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/dockerfile-templates/runtime/Dockerfile
+++ b/eng/dockerfile-templates/runtime/Dockerfile
@@ -30,7 +30,7 @@ RUN `
     `
 }}{{if VARIABLES[cat("kb|", OS_VERSION_NUMBER)] != void && !((OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.7.2") || (PRODUCT_VERSION = "4.8" && OS_VERSION_NUMBER != "ltsc2019" &&VARIABLES["4.8-is-security-release"] = "true"))
 :    # Apply latest patch
-    {{if PRODUCT_VERSION = "3.5" || (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8"):&& }}curl -fSLo patch.msu {{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5":{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}}^else:{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER)]}}}} `
+    {{if PRODUCT_VERSION = "3.5" || (OS_VERSION_NUMBER != "ltsc2016" && OS_VERSION_NUMBER != "20H2" && PRODUCT_VERSION = "4.8"):&& }}curl -fSLo patch.msu {{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5":{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}}^else:{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER)]}}}} `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/eng/dockerfile-templates/runtime/Dockerfile
+++ b/eng/dockerfile-templates/runtime/Dockerfile
@@ -30,7 +30,7 @@ RUN `
     `
 }}{{if VARIABLES[cat("kb|", OS_VERSION_NUMBER)] != void && !((OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.7.2") || (PRODUCT_VERSION = "4.8" && OS_VERSION_NUMBER != "ltsc2019" &&VARIABLES["4.8-is-security-release"] = "true"))
 :    # Apply latest patch
-    {{if PRODUCT_VERSION = "3.5" || (OS_VERSION_NUMBER != "ltsc2016" && OS_VERSION_NUMBER != "20H2" && PRODUCT_VERSION = "4.8"):&& }}curl -fSLo patch.msu {{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5":{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}}^else:{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER)]}}}} `
+    {{if PRODUCT_VERSION = "3.5" || (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8"):&& }}curl -fSLo patch.msu {{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5":{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}}^else:{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER)]}}}} `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
@@ -41,7 +41,7 @@ RUN `
     OS_VERSION_NUMBER != "ltsc2016" && OS_VERSION_NUMBER != "20H2" &&
     (PRODUCT_VERSION = "4.8" || (PRODUCT_VERSION = "3.5" && OS_VERSION_NUMBER != "ltsc2019"))
 :    # Apply patch to provide support for container limits
-    {{if PRODUCT_VERSION = "3.5" || OS_VERSION_NUMBER = "ltsc2019":&& }}curl -fSLo patch.msu {{VARIABLES[cat("limits-patch|url|", OS_VERSION_NUMBER)]}} `
+    {{if PRODUCT_VERSION = "3.5" || (OS_VERSION_NUMBER != "ltsc2016" && OS_VERSION_NUMBER != "20H2"):&& }}curl -fSLo patch.msu {{VARIABLES[cat("limits-patch|url|", OS_VERSION_NUMBER)]}} `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/src/runtime/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -10,7 +10,7 @@ ENV `
 
 RUN `
     # Apply latest patch
-    && curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/12/windows10.0-kb5009470-x64-ndp48_bb024317f391de318cc42f12641da9b3253011cf.msu `
+    curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/12/windows10.0-kb5009470-x64-ndp48_bb024317f391de318cc42f12641da9b3253011cf.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
@@ -18,7 +18,7 @@ RUN `
     && rmdir /S /Q patch `
     `
     # Apply patch to provide support for container limits
-    curl -fSLo patch.msu https://download.microsoft.com/download/5/a/4/5a4425d3-eb10-47a8-afe0-b07a19b20b1c/Windows10.0-KB9008395-x64-NDP48.msu `
+    && curl -fSLo patch.msu https://download.microsoft.com/download/5/a/4/5a4425d3-eb10-47a8-afe0-b07a19b20b1c/Windows10.0-KB9008395-x64-NDP48.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `

--- a/src/runtime/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -10,7 +10,7 @@ ENV `
 
 RUN `
     # Apply latest patch
-    curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/12/windows10.0-kb5009470-x64-ndp48_bb024317f391de318cc42f12641da9b3253011cf.msu `
+    && curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/12/windows10.0-kb5009470-x64-ndp48_bb024317f391de318cc42f12641da9b3253011cf.msu `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `


### PR DESCRIPTION
Needing to revert back the version of Image Builder because some of the changes to support arch "variant" aren't working on the 2016 machines.

Also fixing the Dockerfile generation for 2022.