### PR TITLE
Generate readmes for MCR portal

### DIFF
--- a/.mcr/portal/README.aspnet.portal.md
+++ b/.mcr/portal/README.aspnet.portal.md
@@ -1,0 +1,85 @@
+## About
+
+ASP.NET is a high productivity framework for building Web Applications using Web Forms, MVC, Web API and SignalR.
+
+This image contains:
+
+* Windows Server Core as the base OS
+* IIS 10 as Web Server
+* .NET Framework (multiple versions available)
+* .NET Extensibility for IIS
+
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `4.8`
+  * `docker pull mcr.microsoft.com/dotnet/framework/aspnet:4.8`
+* `3.5`
+  * `docker pull mcr.microsoft.com/dotnet/framework/aspnet:3.5`
+
+## Related Repos
+
+.NET Framework:
+
+* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
+* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
+* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+
+## Usage
+
+The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
+
+## Container sample: Run an ASP.NET application
+You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [ASP.NET Docker sample].
+
+Type the following [Docker](https://www.docker.com/products/docker) command:
+
+```console
+docker run --name aspnet_sample --rm -it -p 8000:80 mcr.microsoft.com/dotnet/framework/samples:aspnetapp
+```
+
+After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).
+
+### Version Compatibility
+
+Version Tag | OS Version | Supported .NET Versions
+-- | -- | --
+4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
+4.7.1 | windowsservercore-ltsc2016 | 4.7.1
+4.7 | windowsservercore-ltsc2016 | 4.7
+4.6.2 | windowsservercore-ltsc2016 | 4.6.2
+3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
+
+## Support
+
+### Lifecycle
+
+* [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
+* [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:20H2, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)

--- a/.mcr/portal/README.aspnet.portal.md
+++ b/.mcr/portal/README.aspnet.portal.md
@@ -37,7 +37,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Container sample: Run an ASP.NET application
+### Container sample: Run an ASP.NET application
 You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [ASP.NET Docker sample].
 
 Type the following [Docker](https://www.docker.com/products/docker) command:

--- a/.mcr/portal/README.runtime.portal.md
+++ b/.mcr/portal/README.runtime.portal.md
@@ -1,0 +1,77 @@
+## About
+
+This image contains the .NET Framework runtimes and libraries and is optimized for running .NET Framework apps in production.
+
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `4.8`
+  * `docker pull mcr.microsoft.com/dotnet/framework/runtime:4.8`
+* `3.5`
+  * `docker pull mcr.microsoft.com/dotnet/framework/runtime:3.5`
+
+## Related Repos
+
+.NET Framework:
+
+* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
+* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
+* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+
+## Usage
+
+The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
+
+## Container sample: Run a simple application
+
+You can quickly run a container with a pre-built [.NET Framework Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [.NET Framework console sample](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/README.md).
+
+Type the following command to run a sample console application:
+
+```console
+docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
+```
+
+### Version Compatibility
+
+Version Tag | OS Version | Supported .NET Versions
+-- | -- | --
+4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
+4.7.1 | windowsservercore-ltsc2016 | 4.7.1
+4.7 | windowsservercore-ltsc2016 | 4.7
+4.6.2 | windowsservercore-ltsc2016 | 4.6.2
+3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
+
+## Support
+
+### Lifecycle
+
+* [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
+* [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:20H2, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)

--- a/.mcr/portal/README.runtime.portal.md
+++ b/.mcr/portal/README.runtime.portal.md
@@ -30,7 +30,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Container sample: Run a simple application
+### Container sample: Run a simple application
 
 You can quickly run a container with a pre-built [.NET Framework Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [.NET Framework console sample](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/README.md).
 

--- a/.mcr/portal/README.samples.portal.md
+++ b/.mcr/portal/README.samples.portal.md
@@ -1,0 +1,97 @@
+## About
+
+These images contain sample .NET Framework, ASP.NET and WCF applications.
+
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `dotnetapp`
+  * `docker pull mcr.microsoft.com/dotnet/framework/samples:dotnetapp`
+* `aspnetapp`
+  * `docker pull mcr.microsoft.com/dotnet/framework/samples:aspnetapp`
+* `wcfservice`
+  * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfservice`
+* `wcfclient`
+  * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfclient`
+
+## Related Repos
+
+.NET Framework:
+
+* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
+* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
+* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
+* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+
+## Usage
+
+The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
+
+## Container sample: Run a simple application
+
+Type the following command to run a sample console application with Docker:
+
+```console
+docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
+```
+
+## Container sample: Run a web application
+
+Type the following command to run a sample web application with Docker:
+
+```console
+docker run -it --rm -p 8000:80 --name aspnet_sample mcr.microsoft.com/dotnet/framework/samples:aspnetapp
+```
+
+After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).
+
+## Container sample: Run WCF service and client applications
+
+Type the following command to run a sample WCF service application with Docker:
+
+```console
+docker run -it --rm --name wcfservice_sample mcr.microsoft.com/dotnet/framework/samples:wcfservice
+```
+
+After the container starts, find the IP address of the container instance:
+
+```console
+docker inspect --format="{{.NetworkSettings.Networks.nat.IPAddress}}" wcfservice_sample
+172.26.236.119
+```
+
+Type the following Docker command to start a WCF client container, set environment variable HOST to the IP address of the wcfservice_sample container:
+
+```console
+docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 mcr.microsoft.com/dotnet/framework/samples:wcfclient
+```
+
+## Support
+
+### Lifecycle
+
+* [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
+* [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:20H2, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)

--- a/.mcr/portal/README.samples.portal.md
+++ b/.mcr/portal/README.samples.portal.md
@@ -34,7 +34,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Container sample: Run a simple application
+### Container sample: Run a simple application
 
 Type the following command to run a sample console application with Docker:
 
@@ -42,7 +42,7 @@ Type the following command to run a sample console application with Docker:
 docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ```
 
-## Container sample: Run a web application
+### Container sample: Run a web application
 
 Type the following command to run a sample web application with Docker:
 
@@ -52,7 +52,7 @@ docker run -it --rm -p 8000:80 --name aspnet_sample mcr.microsoft.com/dotnet/fra
 
 After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).
 
-## Container sample: Run WCF service and client applications
+### Container sample: Run WCF service and client applications
 
 Type the following command to run a sample WCF service application with Docker:
 

--- a/.mcr/portal/README.sdk.portal.md
+++ b/.mcr/portal/README.sdk.portal.md
@@ -1,0 +1,85 @@
+## About
+
+This image contains the .NET Framework SDK which is comprised of the following parts:
+
+1. .NET Framework Runtime
+1. Visual Studio Build Tools
+1. Visual Studio Test Agent
+1. NuGet CLI
+1. .NET Framework Targeting Packs
+1. ASP.NET Web Targets
+
+Use this image for your development process (developing, building and testing applications).
+
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `4.8`
+  * `docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8`
+* `3.5`
+  * `docker pull mcr.microsoft.com/dotnet/framework/sdk:3.5`
+
+## Related Repos
+
+.NET Framework:
+
+* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
+* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
+* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+
+## Usage
+
+The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
+
+## Building .NET Framework Apps with Docker
+
+* [.NET Framework Console Docker Sample](dotnetapp/README.md) - This [sample](dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.
+* [ASP.NET Web Forms Docker Sample](aspnetapp/README.md) - This [sample](aspnetapp/Dockerfile) demonstrates using Docker with an ASP.NET Web Forms app.
+* [ASP.NET MVC Docker Sample](aspnetmvcapp/README.md) - This [sample](aspnetmvcapp/Dockerfile) demonstrates using Docker with an ASP.NET MVC app.
+* [WCF Docker Sample](wcfapp/README.md) - This [sample](wcfapp/) demonstrates using Docker with a WCF app.
+
+### Version Compatibility
+
+Version Tag | OS Version | Supported .NET Versions
+-- | -- | --
+4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8*
+4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
+4.7.1 | windowsservercore-ltsc2016 | 4.7.1
+4.7 | windowsservercore-ltsc2016 | 4.7
+4.6.2 | windowsservercore-ltsc2016 | 4.6.2
+3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
+
+\* The 4.8 SDK is also capable of building 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.
+
+## Support
+
+### Lifecycle
+
+* [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
+* [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:20H2, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)

--- a/.mcr/portal/README.sdk.portal.md
+++ b/.mcr/portal/README.sdk.portal.md
@@ -39,7 +39,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Building .NET Framework Apps with Docker
+### Building .NET Framework Apps with Docker
 
 * [.NET Framework Console Docker Sample](dotnetapp/README.md) - This [sample](dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.
 * [ASP.NET Web Forms Docker Sample](aspnetapp/README.md) - This [sample](aspnetapp/Dockerfile) demonstrates using Docker with an ASP.NET Web Forms app.

--- a/.mcr/portal/README.wcf.portal.md
+++ b/.mcr/portal/README.wcf.portal.md
@@ -1,0 +1,84 @@
+## About
+
+The Windows Communication Foundation (WCF) is a framework for building service-oriented applications. Using WCF, you can send data as asynchronous messages from one service endpoint to another. A service endpoint can be part of a continuously available service hosted by IIS, or it can be a service hosted in an application.
+
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
+
+## Featured Tags
+
+* `4.8`
+  * `docker pull mcr.microsoft.com/dotnet/framework/wcf:4.8`
+
+## Related Repos
+
+.NET Framework:
+
+* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
+* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
+* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
+* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+
+.NET:
+
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+
+## Usage
+
+The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
+
+## Container sample: Run a WCF application
+You can quickly run a container with a pre-built [sample WCF Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the WCF Docker sample.
+
+Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:
+
+```console
+docker run --name wcfservicesample --rm -it mcr.microsoft.com/dotnet/framework/samples:wcfservice
+```
+
+Find the IP address of the container instance.
+
+```console
+docker inspect --format="{{.NetworkSettings.Networks.nat.IPAddress}}" wcfservicesample
+172.26.236.119
+```
+
+Type the following Docker command to start a WCF client container, set environment variable HOST to the IP address of the wcfservicesample container:
+
+```console
+docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.com/dotnet/framework/samples:wcfclient
+```
+
+### Version Compatibility
+
+Version Tag | OS Version | Supported .NET Versions
+-- | -- | --
+4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
+4.7.1 | windowsservercore-ltsc2016 | 4.7.1
+4.7 | windowsservercore-ltsc2016 | 4.7
+4.6.2 | windowsservercore-ltsc2016 | 4.6.2
+
+## Support
+
+### Lifecycle
+
+* [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
+* [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
+
+### Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:20H2, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
+
+### Feedback
+
+* [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+## License
+
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)

--- a/.mcr/portal/README.wcf.portal.md
+++ b/.mcr/portal/README.wcf.portal.md
@@ -28,7 +28,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Container sample: Run a WCF application
+### Container sample: Run a WCF application
 You can quickly run a container with a pre-built [sample WCF Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -5,7 +5,7 @@
 * `3.5`
   * `docker pull mcr.microsoft.com/dotnet/framework/aspnet:3.5`
 
-# About This Image
+# About
 
 ASP.NET is a high productivity framework for building Web Applications using Web Forms, MVC, Web API and SignalR.
 
@@ -16,9 +16,9 @@ This image contains:
 * .NET Framework (multiple versions available)
 * .NET Extensibility for IIS
 
-Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
@@ -32,6 +32,19 @@ docker run --name aspnet_sample --rm -it -p 8000:80 mcr.microsoft.com/dotnet/fra
 ```
 
 After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).
+
+## Version Compatibility
+
+Version Tag | OS Version | Supported .NET Versions
+-- | -- | --
+4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
+4.7.1 | windowsservercore-ltsc2016 | 4.7.1
+4.7 | windowsservercore-ltsc2016 | 4.7
+4.6.2 | windowsservercore-ltsc2016 | 4.6.2
+3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
 
 # Related Repos
 
@@ -80,22 +93,8 @@ Tag | Dockerfile
 3.5-20220510-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/3.5/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/aspnet at https://mcr.microsoft.com/v2/dotnet/framework/aspnet/tags/list.
-<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
-
-# Version Compatibility
-
-Version Tag | OS Version | Supported .NET Versions
--- | -- | --
-4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
-4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
-4.7.1 | windowsservercore-ltsc2016 | 4.7.1
-4.7 | windowsservercore-ltsc2016 | 4.7
-4.6.2 | windowsservercore-ltsc2016 | 4.6.2
-3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
-3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
-3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
 
 # Support
 

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -93,6 +93,7 @@ Tag | Dockerfile
 3.5-20220510-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/3.5/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/aspnet at https://mcr.microsoft.com/v2/dotnet/framework/aspnet/tags/list.
+<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
 * [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
 
-# About .NET Framework
+# About
 
 The [.NET Framework](https://www.microsoft.com/net/framework) is a general purpose development platform maintained by Microsoft. It is the most popular way to build client and server applications for Windows and Windows Server. It is included with Windows, Windows Server and Windows Server Core. It includes server technologies such as ASP.NET Web Forms, ASP.NET MVC and Windows Communication Foundation (WCF) applications, which you can run in Docker containers.
 
@@ -18,9 +18,9 @@ The .NET Framework was first released by Microsoft in 2001. The latest version i
 
 > https://docs.microsoft.com/dotnet/framework/
 
-Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Images
+# Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -85,6 +85,7 @@ Tag | Dockerfile
 3.5-20220510-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/runtime at https://mcr.microsoft.com/v2/dotnet/framework/runtime/tags/list.
+<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -5,13 +5,13 @@
 * `3.5`
   * `docker pull mcr.microsoft.com/dotnet/framework/runtime:3.5`
 
-# About This Image
+# About
 
 This image contains the .NET Framework runtimes and libraries and is optimized for running .NET Framework apps in production.
 
-Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
@@ -24,6 +24,19 @@ Type the following command to run a sample console application:
 ```console
 docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ```
+
+## Version Compatibility
+
+Version Tag | OS Version | Supported .NET Versions
+-- | -- | --
+4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
+4.7.1 | windowsservercore-ltsc2016 | 4.7.1
+4.7 | windowsservercore-ltsc2016 | 4.7
+4.6.2 | windowsservercore-ltsc2016 | 4.6.2
+3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
 
 # Related Repos
 
@@ -72,22 +85,8 @@ Tag | Dockerfile
 3.5-20220510-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/runtime at https://mcr.microsoft.com/v2/dotnet/framework/runtime/tags/list.
-<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
-
-# Version Compatibility
-
-Version Tag | OS Version | Supported .NET Versions
--- | -- | --
-4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
-4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
-4.7.1 | windowsservercore-ltsc2016 | 4.7.1
-4.7 | windowsservercore-ltsc2016 | 4.7
-4.6.2 | windowsservercore-ltsc2016 | 4.6.2
-3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
-3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
-3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
 
 # Support
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -108,6 +108,7 @@ wcfservice-windowsservercore-ltsc2016, wcfservice | [Dockerfile](https://github.
 wcfclient-windowsservercore-ltsc2016, wcfclient | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/wcfapp/Dockerfile.client)
 
 You can retrieve a list of all available tags for dotnet/framework/samples at https://mcr.microsoft.com/v2/dotnet/framework/samples/tags/list.
+<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -9,13 +9,14 @@
 * `wcfclient`
   * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfclient`
 
-# About This Image
+
+# About
 
 These images contain sample .NET Framework, ASP.NET and WCF applications.
 
-Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
@@ -108,7 +109,6 @@ wcfservice-windowsservercore-ltsc2016, wcfservice | [Dockerfile](https://github.
 wcfclient-windowsservercore-ltsc2016, wcfclient | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/wcfapp/Dockerfile.client)
 
 You can retrieve a list of all available tags for dotnet/framework/samples at https://mcr.microsoft.com/v2/dotnet/framework/samples/tags/list.
-<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
 

--- a/README.samples.md
+++ b/README.samples.md
@@ -9,7 +9,6 @@
 * `wcfclient`
   * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfclient`
 
-
 # About
 
 These images contain sample .NET Framework, ASP.NET and WCF applications.

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -5,7 +5,7 @@
 * `3.5`
   * `docker pull mcr.microsoft.com/dotnet/framework/sdk:3.5`
 
-# About This Image
+# About
 
 This image contains the .NET Framework SDK which is comprised of the following parts:
 
@@ -18,9 +18,9 @@ This image contains the .NET Framework SDK which is comprised of the following p
 
 Use this image for your development process (developing, building and testing applications).
 
-Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
@@ -30,6 +30,21 @@ The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framewor
 * [ASP.NET Web Forms Docker Sample](aspnetapp/README.md) - This [sample](aspnetapp/Dockerfile) demonstrates using Docker with an ASP.NET Web Forms app.
 * [ASP.NET MVC Docker Sample](aspnetmvcapp/README.md) - This [sample](aspnetmvcapp/Dockerfile) demonstrates using Docker with an ASP.NET MVC app.
 * [WCF Docker Sample](wcfapp/README.md) - This [sample](wcfapp/) demonstrates using Docker with a WCF app.
+
+## Version Compatibility
+
+Version Tag | OS Version | Supported .NET Versions
+-- | -- | --
+4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8*
+4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
+4.7.1 | windowsservercore-ltsc2016 | 4.7.1
+4.7 | windowsservercore-ltsc2016 | 4.7
+4.6.2 | windowsservercore-ltsc2016 | 4.6.2
+3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
+
+\* The 4.8 SDK is also capable of building 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.
 
 # Related Repos
 
@@ -73,24 +88,8 @@ Tag | Dockerfile
 3.5-20220510-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/sdk at https://mcr.microsoft.com/v2/dotnet/framework/sdk/tags/list.
-<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
-
-# Version Compatibility
-
-Version Tag | OS Version | Supported .NET Versions
--- | -- | --
-4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8*
-4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
-4.7.1 | windowsservercore-ltsc2016 | 4.7.1
-4.7 | windowsservercore-ltsc2016 | 4.7
-4.6.2 | windowsservercore-ltsc2016 | 4.6.2
-3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
-3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
-3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
-
-\* The 4.8 SDK is also capable of building 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.
 
 # Support
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -88,6 +88,7 @@ Tag | Dockerfile
 3.5-20220510-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/sdk at https://mcr.microsoft.com/v2/dotnet/framework/sdk/tags/list.
+<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
 

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -3,13 +3,13 @@
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/wcf:4.8`
 
-# About This Image
+# About
 
 The Windows Communication Foundation (WCF) is a framework for building service-oriented applications. Using WCF, you can send data as asynchronous messages from one service endpoint to another. A service endpoint can be part of a continuously available service hosted by IIS, or it can be a service hosted in an application.
 
-Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# How to Use the Image
+# Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
@@ -34,6 +34,16 @@ Type the following Docker command to start a WCF client container, set environme
 ```console
 docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.com/dotnet/framework/samples:wcfclient
 ```
+
+## Version Compatibility
+
+Version Tag | OS Version | Supported .NET Versions
+-- | -- | --
+4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
+4.7.1 | windowsservercore-ltsc2016 | 4.7.1
+4.7 | windowsservercore-ltsc2016 | 4.7
+4.6.2 | windowsservercore-ltsc2016 | 4.6.2
 
 # Related Repos
 
@@ -78,19 +88,8 @@ Tag | Dockerfile
 4.6.2-20220510-windowsservercore-ltsc2016, 4.6.2-windowsservercore-ltsc2016, 4.6.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.6.2/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/wcf at https://mcr.microsoft.com/v2/dotnet/framework/wcf/tags/list.
-<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
-
-# Version Compatibility
-
-Version Tag | OS Version | Supported .NET Versions
--- | -- | --
-4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
-4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
-4.7.1 | windowsservercore-ltsc2016 | 4.7.1
-4.7 | windowsservercore-ltsc2016 | 4.7
-4.6.2 | windowsservercore-ltsc2016 | 4.6.2
 
 # Support
 

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -88,6 +88,7 @@ Tag | Dockerfile
 4.6.2-20220510-windowsservercore-ltsc2016, 4.6.2-windowsservercore-ltsc2016, 4.6.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.6.2/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/wcf at https://mcr.microsoft.com/v2/dotnet/framework/wcf/tags/list.
+<!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
 

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1773385
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1778213
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1714271
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1773385
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1778213
+  imageNames.imageBuilder: mcr.microsoft.com/dotnet-buildtools/image-builder:1779652
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165
   imageNames.testRunner.withrepo: testrunner-withrepo:$(Build.BuildId)-$(System.JobId)

--- a/eng/readme-templates/About.md
+++ b/eng/readme-templates/About.md
@@ -1,9 +1,8 @@
-The [.NET Framework](https://www.microsoft.com/net/framework) is a general purpose development platform maintained by Microsoft. It is the most popular way to build client and server applications for Windows and Windows Server. It is included with Windows, Windows Server and Windows Server Core. It includes server technologies such as ASP.NET Web Forms, ASP.NET MVC and Windows Communication Foundation (WCF) applications, which you can run in Docker containers.
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}} About
 
-.NET has several capabilities that make development easier, including automatic memory management, (runtime) generic types, reflection, asynchrony, concurrency, and native interop. Millions of developers take advantage of these capabilities to efficiently build high-quality web and client applications.
+{{InsertTemplate(join(filter(["About", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], len), "."))}}
 
-You can use C#, F# and VB to write .NET Framework apps. C# is simple, powerful, type-safe, and object-oriented while retaining the expressiveness and elegance of C-style languages. F# is a multi-paradigm programming language, enabling both functional and object-oriented patterns and practices. VB is a rapid development programming language with the deepest integration between the language and Visual Studio, providing the fastest path to a working app.
-
-The .NET Framework was first released by Microsoft in 2001. The latest version is [.NET Framework 4.8](https://www.microsoft.com/net/framework).
-
-> https://docs.microsoft.com/dotnet/framework/
+Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.

--- a/eng/readme-templates/About.product-family.md
+++ b/eng/readme-templates/About.product-family.md
@@ -1,0 +1,9 @@
+The [.NET Framework](https://www.microsoft.com/net/framework) is a general purpose development platform maintained by Microsoft. It is the most popular way to build client and server applications for Windows and Windows Server. It is included with Windows, Windows Server and Windows Server Core. It includes server technologies such as ASP.NET Web Forms, ASP.NET MVC and Windows Communication Foundation (WCF) applications, which you can run in Docker containers.
+
+.NET has several capabilities that make development easier, including automatic memory management, (runtime) generic types, reflection, asynchrony, concurrency, and native interop. Millions of developers take advantage of these capabilities to efficiently build high-quality web and client applications.
+
+You can use C#, F# and VB to write .NET Framework apps. C# is simple, powerful, type-safe, and object-oriented while retaining the expressiveness and elegance of C-style languages. F# is a multi-paradigm programming language, enabling both functional and object-oriented patterns and practices. VB is a rapid development programming language with the deepest integration between the language and Visual Studio, providing the fastest path to a working app.
+
+The .NET Framework was first released by Microsoft in 2001. The latest version is [.NET Framework 4.8](https://www.microsoft.com/net/framework).
+
+> https://docs.microsoft.com/dotnet/framework/

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -1,0 +1,18 @@
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}} Featured Tags
+
+{{if SHORT_REPO = "samples"
+:* `dotnetapp`
+  * `docker pull mcr.microsoft.com/dotnet/framework/samples:dotnetapp`
+* `aspnetapp`
+  * `docker pull mcr.microsoft.com/dotnet/framework/samples:aspnetapp`
+* `wcfservice`
+  * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfservice`
+* `wcfclient`
+  * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfclient`^else
+:* `4.8`
+  * `docker pull mcr.microsoft.com/dotnet/framework/{{SHORT_REPO}}:4.8`{{if SHORT_REPO != "wcf":
+* `3.5`
+  * `docker pull mcr.microsoft.com/dotnet/framework/{{SHORT_REPO}}:3.5`}}}}

--- a/eng/readme-templates/Get-GeneratedReadmes.ps1
+++ b/eng/readme-templates/Get-GeneratedReadmes.ps1
@@ -11,16 +11,27 @@ if ($Validate) {
 
 $repoRoot = (Get-Item "$PSScriptRoot").Parent.Parent.FullName
 
+function CopyReadme([string]$containerName, [string]$readmeRelativePath) {
+    $readmeDir = Split-Path $readmeRelativePath -Parent
+    Exec "docker cp ${containerName}:/repo/$readmeRelativePath $repoRoot/$readmeDir"
+}
+
 $onDockerfilesGenerated = {
     param($ContainerName)
 
     if (-Not $Validate) {
-        Exec "docker cp ${ContainerName}:/repo/README.aspnet.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.runtime.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.samples.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.sdk.md $repoRoot"
-        Exec "docker cp ${ContainerName}:/repo/README.wcf.md $repoRoot"
+        CopyReadme $ContainerName "README.aspnet.md"
+        CopyReadme $ContainerName "README.md"
+        CopyReadme $ContainerName "README.runtime.md"
+        CopyReadme $ContainerName "README.samples.md"
+        CopyReadme $ContainerName "README.sdk.md"
+        CopyReadme $ContainerName "README.wcf.md"
+
+        CopyReadme $ContainerName ".mcr/portal/README.aspnet.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.runtime.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.samples.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.sdk.portal.md"
+        CopyReadme $ContainerName ".mcr/portal/README.wcf.portal.md"
     }
 }
 

--- a/eng/readme-templates/README.mcr.md
+++ b/eng/readme-templates/README.mcr.md
@@ -1,0 +1,11 @@
+{{
+  set headerArgs to [ "top-header": "##" ]
+}}{{InsertTemplate("About.md", headerArgs)}}
+
+{{InsertTemplate("FeaturedTags.md", headerArgs)}}
+
+{{InsertTemplate("RelatedRepos.md", headerArgs)}}
+
+{{InsertTemplate("Use.md", headerArgs)}}
+
+{{InsertTemplate("Support.md", headerArgs)}}

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -16,6 +16,7 @@
 {{InsertTemplate("RelatedRepos.md", headerArgs)}}
 {{if !IS_PRODUCT_FAMILY:
 # Full Tag Listing
+<!--End of generated tags-->
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
 }}
 {{InsertTemplate("Support.md", headerArgs)}}

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -1,101 +1,21 @@
-{{if IS_PRODUCT_FAMILY
-:# Featured Repos
+{{
+  set headerArgs to [ "top-header": "#" ]
+}}{{if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", headerArgs)}}
+^else:# Featured Repos
 
 * [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
 * [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
 * [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
-^else:# Featured Tags
+}}
+{{InsertTemplate("About.md", headerArgs)}}
 
-{{if SHORT_REPO = "samples"
-:* `dotnetapp`
-  * `docker pull mcr.microsoft.com/dotnet/framework/samples:dotnetapp`
-* `aspnetapp`
-  * `docker pull mcr.microsoft.com/dotnet/framework/samples:aspnetapp`
-* `wcfservice`
-  * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfservice`
-* `wcfclient`
-  * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfclient`
-^else
-:* `4.8`
-  * `docker pull mcr.microsoft.com/dotnet/framework/{{SHORT_REPO}}:4.8`
-{{if SHORT_REPO != "wcf"
-:* `3.5`
-  * `docker pull mcr.microsoft.com/dotnet/framework/{{SHORT_REPO}}:3.5`
-}}}}}}
-# About {{if IS_PRODUCT_FAMILY:.NET Framework^else:This Image}}
+{{InsertTemplate("Use.md", headerArgs)}}
 
-{{InsertTemplate(join(filter(["About", SHORT_REPO, "md"], len), "."))}}
-
-Watch [dotnet/announcements](https://github.com/dotnet/announcements/labels/Docker) for Docker-related .NET announcements.
-
-# How to Use the Image{{if IS_PRODUCT_FAMILY:s}}
-
-The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
-
-{{InsertTemplate(join(filter(["Use", SHORT_REPO, "md"], len), "."))}}
-
-# Related Repos
+{{InsertTemplate("RelatedRepos.md", headerArgs)}}
 {{if !IS_PRODUCT_FAMILY:
-.NET Framework:
-
-{{if SHORT_REPO != "sdk"
-    :* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
-}}{{if SHORT_REPO != "aspnet"
-    :* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
-}}{{if SHORT_REPO != "runtime"
-    :* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
-}}{{if SHORT_REPO != "wcf"
-    :* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
-}}{{if SHORT_REPO != "samples"
-    :* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
-}}
-.NET:
-}}
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
-
-{{if !IS_PRODUCT_FAMILY:# Full Tag Listing
-<!--End of generated tags-->
-
+# Full Tag Listing
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
-
-{{if SHORT_REPO != "samples":# Version Compatibility
-
-Version Tag | OS Version | Supported .NET Versions
--- | -- | --
-4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8{{if SHORT_REPO = "sdk":*}}
-4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
-4.7.1 | windowsservercore-ltsc2016 | 4.7.1
-4.7 | windowsservercore-ltsc2016 | 4.7
-4.6.2 | windowsservercore-ltsc2016 | 4.6.2{{if SHORT_REPO != "wcf":
-3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
-3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
-3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5}}{{if SHORT_REPO = "sdk":
-
-\* The 4.8 SDK is also capable of building 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.}}
-
-}}}}# Support
-
-## Lifecycle
-
-* [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
-* [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
-
-## Image Update Policy
-
-* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:20H2, windows/servercore:ltsc2019, etc.).
-* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
-
-## Feedback
-
-* [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
-* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
-
-# License
-
-* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)
+}}
+{{InsertTemplate("Support.md", headerArgs)}}

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -1,0 +1,23 @@
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}} Related Repos
+{{if !IS_PRODUCT_FAMILY:
+.NET Framework:
+
+{{if SHORT_REPO != "sdk"
+    :* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
+}}{{if SHORT_REPO != "aspnet"
+    :* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
+}}{{if SHORT_REPO != "runtime"
+    :* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
+}}{{if SHORT_REPO != "wcf"
+    :* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
+}}{{if SHORT_REPO != "samples"
+    :* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+}}
+.NET:
+}}
+* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
+* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
+* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples

--- a/eng/readme-templates/Support.md
+++ b/eng/readme-templates/Support.md
@@ -1,0 +1,22 @@
+{{ARGS["top-header"]}} Support
+
+{{ARGS["top-header"]}}# Lifecycle
+
+* [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
+* [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
+
+{{ARGS["top-header"]}}# Image Update Policy
+
+* We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:20H2, windows/servercore:ltsc2019, etc.).
+* We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
+
+{{ARGS["top-header"]}}# Feedback
+
+* [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
+* [Contact Microsoft Support](https://support.microsoft.com/contactus/)
+
+{{ARGS["top-header"]}} License
+
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)

--- a/eng/readme-templates/Use.aspnet.md
+++ b/eng/readme-templates/Use.aspnet.md
@@ -1,4 +1,7 @@
-## Container sample: Run an ASP.NET application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run an ASP.NET application
 You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [ASP.NET Docker sample].
 
 Type the following [Docker](https://www.docker.com/products/docker) command:

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -1,17 +1,24 @@
-## Container sample: Run a simple application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}} Usage
 
-Type the following command to run a sample console application:
+The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-```console
-docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
-```
+{{InsertTemplate(join(filter(["Use", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], len), "."))}}{{
+if !IS_PRODUCT_FAMILY && SHORT_REPO != "samples":
 
-## Container sample: Run a web application
+{{ARGS["top-header"]}}# Version Compatibility
 
-Type the following command to run a sample web application:
+Version Tag | OS Version | Supported .NET Versions
+-- | -- | --
+4.8 | windowsservercore-20H2, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8{{if SHORT_REPO = "sdk":*}}
+4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
+4.7.1 | windowsservercore-ltsc2016 | 4.7.1
+4.7 | windowsservercore-ltsc2016 | 4.7
+4.6.2 | windowsservercore-ltsc2016 | 4.6.2{{if SHORT_REPO != "wcf":
+3.5 | windowsservercore-20H2 | 4.8, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
+3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5}}{{if SHORT_REPO = "sdk":
 
-```console
-docker run -it --rm -p 8000:80 --name aspnet_sample mcr.microsoft.com/dotnet/framework/samples:aspnetapp
-```
-
-After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).
+\* The 4.8 SDK is also capable of building 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.}}}}

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -5,7 +5,8 @@
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-{{InsertTemplate(join(filter(["Use", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], len), "."))}}{{
+{{InsertTemplate(join(filter(["Use", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], len), "."),
+    [ "top-header": ARGS["top-header"] ])}}{{
 if !IS_PRODUCT_FAMILY && SHORT_REPO != "samples":
 
 {{ARGS["top-header"]}}# Version Compatibility

--- a/eng/readme-templates/Use.product-family.md
+++ b/eng/readme-templates/Use.product-family.md
@@ -1,4 +1,7 @@
-## Container sample: Run a simple application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
 Type the following command to run a sample console application:
 
@@ -6,7 +9,7 @@ Type the following command to run a sample console application:
 docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ```
 
-## Container sample: Run a web application
+{{ARGS["top-header"]}}# Container sample: Run a web application
 
 Type the following command to run a sample web application:
 

--- a/eng/readme-templates/Use.product-family.md
+++ b/eng/readme-templates/Use.product-family.md
@@ -1,0 +1,17 @@
+## Container sample: Run a simple application
+
+Type the following command to run a sample console application:
+
+```console
+docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
+```
+
+## Container sample: Run a web application
+
+Type the following command to run a sample web application:
+
+```console
+docker run -it --rm -p 8000:80 --name aspnet_sample mcr.microsoft.com/dotnet/framework/samples:aspnetapp
+```
+
+After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).

--- a/eng/readme-templates/Use.runtime.md
+++ b/eng/readme-templates/Use.runtime.md
@@ -1,4 +1,7 @@
-## Container sample: Run a simple application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
 You can quickly run a container with a pre-built [.NET Framework Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [.NET Framework console sample](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/README.md).
 

--- a/eng/readme-templates/Use.samples.md
+++ b/eng/readme-templates/Use.samples.md
@@ -1,4 +1,7 @@
-## Container sample: Run a simple application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
 Type the following command to run a sample console application with Docker:
 
@@ -6,7 +9,7 @@ Type the following command to run a sample console application with Docker:
 docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ```
 
-## Container sample: Run a web application
+{{ARGS["top-header"]}}# Container sample: Run a web application
 
 Type the following command to run a sample web application with Docker:
 
@@ -16,7 +19,7 @@ docker run -it --rm -p 8000:80 --name aspnet_sample mcr.microsoft.com/dotnet/fra
 
 After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).
 
-## Container sample: Run WCF service and client applications
+{{ARGS["top-header"]}}# Container sample: Run WCF service and client applications
 
 Type the following command to run a sample WCF service application with Docker:
 

--- a/eng/readme-templates/Use.sdk.md
+++ b/eng/readme-templates/Use.sdk.md
@@ -1,4 +1,7 @@
-## Building .NET Framework Apps with Docker
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Building .NET Framework Apps with Docker
 
 * [.NET Framework Console Docker Sample](dotnetapp/README.md) - This [sample](dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.
 * [ASP.NET Web Forms Docker Sample](aspnetapp/README.md) - This [sample](aspnetapp/Dockerfile) demonstrates using Docker with an ASP.NET Web Forms app.

--- a/eng/readme-templates/Use.wcf.md
+++ b/eng/readme-templates/Use.wcf.md
@@ -1,4 +1,7 @@
-## Container sample: Run a WCF application
+{{
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+}}{{ARGS["top-header"]}}# Container sample: Run a WCF application
 You can quickly run a container with a pre-built [sample WCF Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,8 @@
 {
-  "readme": "README.md",
-  "readmeTemplate": "eng/readme-templates/README.md",
+  "readme": {
+    "path": "README.md",
+    "templatePath": "eng/readme-templates/README.md"
+  },
   "registry": "mcr.microsoft.com",
   "includes": [
     "manifest.datestamps.json",
@@ -10,8 +12,16 @@
     {
       "id": "runtime",
       "name": "dotnet/framework/runtime",
-      "readme": "README.runtime.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.runtime.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.runtime.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/runtime-tags.yml",
       "images": [
         {
@@ -257,8 +267,16 @@
     {
       "id": "sdk",
       "name": "dotnet/framework/sdk",
-      "readme": "README.sdk.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.sdk.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.sdk.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/sdk-tags.yml",
       "images": [
         {
@@ -396,8 +414,16 @@
     {
       "id": "aspnet",
       "name": "dotnet/framework/aspnet",
-      "readme": "README.aspnet.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.aspnet.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.aspnet.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/aspnet-tags.yml",
       "images": [
         {
@@ -632,8 +658,16 @@
     {
       "id": "wcf",
       "name": "dotnet/framework/wcf",
-      "readme": "README.wcf.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.wcf.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.wcf.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/wcf-tags.yml",
       "images": [
         {

--- a/manifest.samples.json
+++ b/manifest.samples.json
@@ -4,8 +4,16 @@
     {
       "id": "samples",
       "name": "dotnet/framework/samples",
-      "readme": "README.samples.md",
-      "readmeTemplate": "eng/readme-templates/README.md",
+      "readmes": [
+        {
+          "path": "README.samples.md",
+          "templatePath": "eng/readme-templates/README.md"
+        },
+        {
+          "path": ".mcr/portal/README.samples.portal.md",
+          "templatePath": "eng/readme-templates/README.mcr.md"
+        }
+      ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/samples-tags.yml",
       "images": [
         {


### PR DESCRIPTION
* Updates the manifest to conform to the new schema defined by https://github.com/dotnet/docker-tools/pull/1001.
* Defines new readme files to be used for the MCR portal.
* Refactors the readme templates to enable more common content between the GH and MCR readmes.

I've moved the Version Compatibility section out of the Tags section and into the Usage section. This was done because the MCR readmes don't have a Tags section.