### PR TITLE
Reference MAR URLs in readmes for MAR portal

### DIFF
--- a/.mcr/portal/README.aspnet.portal.md
+++ b/.mcr/portal/README.aspnet.portal.md
@@ -22,23 +22,23 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
-* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
-* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
-* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework/sdk](https://mcr.microsoft.com/product/dotnet/framework/sdk): .NET Framework SDK
+* [dotnet/framework/runtime](https://mcr.microsoft.com/product/dotnet/framework/runtime): .NET Framework Runtime
+* [dotnet/framework/wcf](https://mcr.microsoft.com/product/dotnet/framework/wcf): Windows Communication Foundation (WCF)
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples): .NET Framework, ASP.NET and WCF Samples
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
+* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples): .NET Samples
 
 ## Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
 ### Container sample: Run an ASP.NET application
-You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [ASP.NET Docker sample].
+You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://mcr.microsoft.com/product/dotnet/framework/samples), based on the [ASP.NET Docker sample].
 
 Type the following [Docker](https://www.docker.com/products/docker) command:
 
@@ -80,6 +80,6 @@ Version Tag | OS Version | Supported .NET Versions
 
 ## License
 
-* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://mcr.microsoft.com/product/windows/servercore): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://mcr.microsoft.com/product/dotnet/framework/sdk)

--- a/.mcr/portal/README.runtime.portal.md
+++ b/.mcr/portal/README.runtime.portal.md
@@ -15,16 +15,16 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
-* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
-* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
-* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework/sdk](https://mcr.microsoft.com/product/dotnet/framework/sdk): .NET Framework SDK
+* [dotnet/framework/aspnet](https://mcr.microsoft.com/product/dotnet/framework/aspnet): ASP.NET Web Forms and MVC
+* [dotnet/framework/wcf](https://mcr.microsoft.com/product/dotnet/framework/wcf): Windows Communication Foundation (WCF)
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples): .NET Framework, ASP.NET and WCF Samples
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
+* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples): .NET Samples
 
 ## Usage
 
@@ -32,7 +32,7 @@ The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framewor
 
 ### Container sample: Run a simple application
 
-You can quickly run a container with a pre-built [.NET Framework Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [.NET Framework console sample](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Framework Docker image](https://mcr.microsoft.com/product/dotnet/framework/samples), based on the [.NET Framework console sample](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/README.md).
 
 Type the following command to run a sample console application:
 
@@ -72,6 +72,6 @@ Version Tag | OS Version | Supported .NET Versions
 
 ## License
 
-* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://mcr.microsoft.com/product/windows/servercore): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://mcr.microsoft.com/product/dotnet/framework/sdk)

--- a/.mcr/portal/README.samples.portal.md
+++ b/.mcr/portal/README.samples.portal.md
@@ -19,16 +19,16 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
-* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
-* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
-* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
-* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
+* [dotnet/framework/sdk](https://mcr.microsoft.com/product/dotnet/framework/sdk): .NET Framework SDK
+* [dotnet/framework/aspnet](https://mcr.microsoft.com/product/dotnet/framework/aspnet): ASP.NET Web Forms and MVC
+* [dotnet/framework/runtime](https://mcr.microsoft.com/product/dotnet/framework/runtime): .NET Framework Runtime
+* [dotnet/framework/wcf](https://mcr.microsoft.com/product/dotnet/framework/wcf): Windows Communication Foundation (WCF)
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
+* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples): .NET Samples
 
 ## Usage
 
@@ -92,6 +92,6 @@ docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 mcr.microsoft
 
 ## License
 
-* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://mcr.microsoft.com/product/windows/servercore): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://mcr.microsoft.com/product/dotnet/framework/sdk)

--- a/.mcr/portal/README.sdk.portal.md
+++ b/.mcr/portal/README.sdk.portal.md
@@ -24,16 +24,16 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
-* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
-* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
-* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework/aspnet](https://mcr.microsoft.com/product/dotnet/framework/aspnet): ASP.NET Web Forms and MVC
+* [dotnet/framework/runtime](https://mcr.microsoft.com/product/dotnet/framework/runtime): .NET Framework Runtime
+* [dotnet/framework/wcf](https://mcr.microsoft.com/product/dotnet/framework/wcf): Windows Communication Foundation (WCF)
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples): .NET Framework, ASP.NET and WCF Samples
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
+* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples): .NET Samples
 
 ## Usage
 
@@ -80,6 +80,6 @@ Version Tag | OS Version | Supported .NET Versions
 
 ## License
 
-* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://mcr.microsoft.com/product/windows/servercore): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://mcr.microsoft.com/product/dotnet/framework/sdk)

--- a/.mcr/portal/README.wcf.portal.md
+++ b/.mcr/portal/README.wcf.portal.md
@@ -13,23 +13,23 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
-* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
-* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
-* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework/sdk](https://mcr.microsoft.com/product/dotnet/framework/sdk): .NET Framework SDK
+* [dotnet/framework/aspnet](https://mcr.microsoft.com/product/dotnet/framework/aspnet): ASP.NET Web Forms and MVC
+* [dotnet/framework/runtime](https://mcr.microsoft.com/product/dotnet/framework/runtime): .NET Framework Runtime
+* [dotnet/framework/samples](https://mcr.microsoft.com/product/dotnet/framework/samples): .NET Framework, ASP.NET and WCF Samples
 
 .NET:
 
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
+* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
+* [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples): .NET Samples
 
 ## Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
 ### Container sample: Run a WCF application
-You can quickly run a container with a pre-built [sample WCF Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the WCF Docker sample.
+You can quickly run a container with a pre-built [sample WCF Docker image](https://mcr.microsoft.com/product/dotnet/framework/samples), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:
 
@@ -79,6 +79,6 @@ Version Tag | OS Version | Supported .NET Versions
 
 ## License
 
-* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Microsoft Software Supplemental License for Windows Container Base Image](https://mcr.microsoft.com/product/windows/servercore): applies to all [.NET Framework container images](https://mcr.microsoft.com/catalog?search=dotnet/framework/)
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://mcr.microsoft.com/product/dotnet/framework/sdk)

--- a/eng/readme-templates/README.mcr.md
+++ b/eng/readme-templates/README.mcr.md
@@ -1,11 +1,11 @@
 {{
-  set headerArgs to [ "top-header": "##" ]
-}}{{InsertTemplate("About.md", headerArgs)}}
+  set commonArgs to [ "top-header": "##", "readme-host": "mar" ]
+}}{{InsertTemplate("About.md", commonArgs)}}
 
-{{InsertTemplate("FeaturedTags.md", headerArgs)}}
+{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 
-{{InsertTemplate("RelatedRepos.md", headerArgs)}}
+{{InsertTemplate("RelatedRepos.md", commonArgs)}}
 
-{{InsertTemplate("Use.md", headerArgs)}}
+{{InsertTemplate("Use.md", commonArgs)}}
 
-{{InsertTemplate("Support.md", headerArgs)}}
+{{InsertTemplate("Support.md", commonArgs)}}

--- a/eng/readme-templates/README.md
+++ b/eng/readme-templates/README.md
@@ -1,22 +1,22 @@
 {{
-  set headerArgs to [ "top-header": "#" ]
-}}{{if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", headerArgs)}}
+  set commonArgs to [ "top-header": "#", "readme-host": "dockerhub" ]
+}}{{if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 ^else:# Featured Repos
 
-* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
-* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
-* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
-* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
-* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+* [dotnet/framework/sdk]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/framework/sdk" ])}}): .NET Framework SDK
+* [dotnet/framework/aspnet]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/framework/aspnet" ])}}): ASP.NET Web Forms and MVC
+* [dotnet/framework/runtime]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/framework/runtime" ])}}): .NET Framework Runtime
+* [dotnet/framework/wcf]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/framework/wcf" ])}}): Windows Communication Foundation (WCF)
+* [dotnet/framework/samples]({{InsertTemplate("Url.md", [ "readme-host": "dockerhub", "repo": "dotnet/framework/samples" ])}}): .NET Framework, ASP.NET and WCF Samples
 }}
-{{InsertTemplate("About.md", headerArgs)}}
+{{InsertTemplate("About.md", commonArgs)}}
 
-{{InsertTemplate("Use.md", headerArgs)}}
+{{InsertTemplate("Use.md", commonArgs)}}
 
-{{InsertTemplate("RelatedRepos.md", headerArgs)}}
+{{InsertTemplate("RelatedRepos.md", commonArgs)}}
 {{if !IS_PRODUCT_FAMILY:
 # Full Tag Listing
 <!--End of generated tags-->
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
 }}
-{{InsertTemplate("Support.md", headerArgs)}}
+{{InsertTemplate("Support.md", commonArgs)}}

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -1,23 +1,24 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}} Related Repos
 {{if !IS_PRODUCT_FAMILY:
 .NET Framework:
 
 {{if SHORT_REPO != "sdk"
-    :* [dotnet/framework/sdk](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/): .NET Framework SDK
+    :* [dotnet/framework/sdk]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/sdk" ])}}): .NET Framework SDK
 }}{{if SHORT_REPO != "aspnet"
-    :* [dotnet/framework/aspnet](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
+    :* [dotnet/framework/aspnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/aspnet" ])}}): ASP.NET Web Forms and MVC
 }}{{if SHORT_REPO != "runtime"
-    :* [dotnet/framework/runtime](https://hub.docker.com/_/microsoft-dotnet-framework-runtime/): .NET Framework Runtime
+    :* [dotnet/framework/runtime]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/runtime" ])}}): .NET Framework Runtime
 }}{{if SHORT_REPO != "wcf"
-    :* [dotnet/framework/wcf](https://hub.docker.com/_/microsoft-dotnet-framework-wcf/): Windows Communication Foundation (WCF)
+    :* [dotnet/framework/wcf]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/wcf" ])}}): Windows Communication Foundation (WCF)
 }}{{if SHORT_REPO != "samples"
-    :* [dotnet/framework/samples](https://hub.docker.com/_/microsoft-dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
+    :* [dotnet/framework/samples]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/samples" ])}}): .NET Framework, ASP.NET and WCF Samples
 }}
 .NET:
 }}
-* [dotnet](https://hub.docker.com/_/microsoft-dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/_/microsoft-dotnet-nightly/): .NET (Preview)
-* [dotnet/samples](https://hub.docker.com/_/microsoft-dotnet-samples/): .NET Samples
+* [dotnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet", "is-product-family": "true" ])}}): .NET
+* [dotnet-nightly]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly", "is-product-family": "true" ])}}): .NET (Preview)
+* [dotnet/samples]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/samples" ])}}): .NET Samples

--- a/eng/readme-templates/Support.md
+++ b/eng/readme-templates/Support.md
@@ -17,6 +17,6 @@
 
 {{ARGS["top-header"]}} License
 
-* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/_/microsoft-windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/_/microsoft-dotnet-framework/)
-* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images](https://hub.docker.com/_/microsoft-dotnet-framework-sdk/)
+* [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework", "is-product-family": "true" ])}})
+* [Microsoft Software Supplemental License for Windows Container Base Image]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "windows/servercore", ])}}): applies to all [.NET Framework container images]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework", "is-product-family": "true" ])}})
+* [Visual Studio Tools License](https://visualstudio.microsoft.com/license-terms/mlt031519/): applies to all [.NET Framework SDK container images]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/sdk" ])}})

--- a/eng/readme-templates/Url.md
+++ b/eng/readme-templates/Url.md
@@ -1,0 +1,14 @@
+{{
+    _ Generates a URL formatted for the site that will host the readme
+    ARGS:
+      readme-host: Moniker of the site that will host the readme
+      repo: Repo path of the URL to be generated
+      is-product-family: Indicates whether the URL refers to a product family page
+}}{{
+when(ARGS["readme-host"] = "mar",
+    when(ARGS["is-product-family"],
+        cat("https://mcr.microsoft.com/catalog?search=", ARGS["repo"], "/"),
+        cat("https://mcr.microsoft.com/product/", ARGS["repo"])),
+    when(ARGS["readme-host"] = "dockerhub",
+        cat("https://hub.docker.com/_/microsoft-", join(split(ARGS["repo"], "/"), "-"), "/"),
+        cat("UNKNOWN HOST: ", ARGS["readme-host"])))}}

--- a/eng/readme-templates/Use.aspnet.md
+++ b/eng/readme-templates/Use.aspnet.md
@@ -1,8 +1,9 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run an ASP.NET application
-You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [ASP.NET Docker sample].
+You can quickly run a container with a pre-built [sample ASP.NET Docker image]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/samples" ])}}), based on the [ASP.NET Docker sample].
 
 Type the following [Docker](https://www.docker.com/products/docker) command:
 

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -1,12 +1,13 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}} Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
 {{InsertTemplate(join(filter(["Use", when(IS_PRODUCT_FAMILY, "product-family", SHORT_REPO), "md"], len), "."),
-    [ "top-header": ARGS["top-header"] ])}}{{
+    [ "top-header": ARGS["top-header"], "readme-host": ARGS["readme-host"] ])}}{{
 if !IS_PRODUCT_FAMILY && SHORT_REPO != "samples":
 
 {{ARGS["top-header"]}}# Version Compatibility

--- a/eng/readme-templates/Use.product-family.md
+++ b/eng/readme-templates/Use.product-family.md
@@ -1,6 +1,7 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
 Type the following command to run a sample console application:

--- a/eng/readme-templates/Use.runtime.md
+++ b/eng/readme-templates/Use.runtime.md
@@ -1,9 +1,10 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
-You can quickly run a container with a pre-built [.NET Framework Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the [.NET Framework console sample](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/README.md).
+You can quickly run a container with a pre-built [.NET Framework Docker image]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/samples" ])}}), based on the [.NET Framework console sample](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/README.md).
 
 Type the following command to run a sample console application:
 

--- a/eng/readme-templates/Use.samples.md
+++ b/eng/readme-templates/Use.samples.md
@@ -1,6 +1,7 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run a simple application
 
 Type the following command to run a sample console application with Docker:

--- a/eng/readme-templates/Use.sdk.md
+++ b/eng/readme-templates/Use.sdk.md
@@ -1,6 +1,7 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Building .NET Framework Apps with Docker
 
 * [.NET Framework Console Docker Sample](dotnetapp/README.md) - This [sample](dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.

--- a/eng/readme-templates/Use.wcf.md
+++ b/eng/readme-templates/Use.wcf.md
@@ -1,8 +1,9 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run a WCF application
-You can quickly run a container with a pre-built [sample WCF Docker image](https://hub.docker.com/_/microsoft-dotnet-framework-samples/), based on the WCF Docker sample.
+You can quickly run a container with a pre-built [sample WCF Docker image]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/samples" ])}}), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:
 


### PR DESCRIPTION
The two sets of readmes that we have between DH and MAR should have links which are relative to those sites. In other words, readmes hosted in DH should contain links to DH pages while readmes hosted in MAR should contain links to MAR pages.

I've updated the readme templates to use a sub-template which will generate the appropriate URL depending on the context of the readme host site.

Since MAR doesn't have product family pages currently, I resorted to using a sear