### PR TITLE
Add default NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Defines a default NuGet.config file at the repo root for a couple reasons:
* An issue was discovered with restoring NuGet packages for the test project on a newly provisioned machine because its %APPDATA%\NuGet\NuGet.config file did not contain any package sources. Since the repo didn't define its own NuGet.config listing any package sources either, NuGet couldn't find any packages to restore from and failed.
* For secure supply chain reasons, we need to be explicit about which NuGet feed is used.