### PR TITLE
Remove unneeded test NuGet.config

### DIFF
--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/NuGet.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/NuGet.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
This NuGet.config file is getting flagged in our builds by the NuGet security analysis because it's referencing nuget.org feed instead of the Azure Artifact Feed. But this file is actually unneeded and not used by the tests so I'm deleting it.