### PR TITLE
Refactor Dockerfile templates to use .NET Fx URL variables

### DIFF
--- a/eng/dockerfile-templates/runtime/Dockerfile
+++ b/eng/dockerfile-templates/runtime/Dockerfile
@@ -37,7 +37,7 @@ RUN `
     `
 ^elif OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8"
 :    # Install .NET Fx 4.8
-    curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
+    curl -fSLo dotnet-framework-installer.exe {{VARIABLES[cat(PRODUCT_VERSION, "|url")]}} `
     && .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `

--- a/eng/dockerfile-templates/runtime/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/runtime/Dockerfile.ltsc2016
@@ -21,16 +21,9 @@ RUN `
     && del microsoft-windows-netfx3.zip `
     && dism /Online /Quiet /Add-Package /PackagePath:C:\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package.cab `
     && rmdir /S /Q microsoft-windows-netfx3 `
-^else:{{
-    if PRODUCT_VERSION = "4.7"
-:            -Uri https://download.visualstudio.microsoft.com/download/pr/2dfcc711-bb60-421a-a17b-76c63f8d1907/e5c0231bd5d51fffe65f8ed7516de46a/ndp47-kb3186497-x86-x64-allos-enu.exe `
-^   elif PRODUCT_VERSION = "4.7.1"
-:            -Uri https://download.visualstudio.microsoft.com/download/pr/4312fa21-59b0-4451-9482-a1376f7f3ba4/9947fce13c11105b48cba170494e787f/ndp471-kb4033342-x86-x64-allos-enu.exe `
-^   elif PRODUCT_VERSION = "4.7.2"
-:            -Uri https://download.visualstudio.microsoft.com/download/pr/1f5af042-d0e4-4002-9c59-9ba66bcf15f6/089f837de42708daacaae7c04b7494db/ndp472-kb4054530-x86-x64-allos-enu.exe `
-^   elif PRODUCT_VERSION = "4.8"
-:            -Uri https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe `
-}}            -OutFile dotnet-framework-installer.exe `
+^else
+:            -Uri {{VARIABLES[cat(PRODUCT_VERSION, "|url")]}} `
+            -OutFile dotnet-framework-installer.exe `
     && start /w .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
 }}    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -22,6 +22,11 @@
   
       "vs|version": "17.3",
       "vs|testAgentUrl": "https://aka.ms/vs/17/release/vs_TestAgent.exe",
-      "vs|buildToolsUrl": "https://aka.ms/vs/17/release/vs_BuildTools.exe"
+      "vs|buildToolsUrl": "https://aka.ms/vs/17/release/vs_BuildTools.exe",
+
+      "4.7|url": "https://download.visualstudio.microsoft.com/download/pr/2dfcc711-bb60-421a-a17b-76c63f8d1907/e5c0231bd5d51fffe65f8ed7516de46a/ndp47-kb3186497-x86-x64-allos-enu.exe",
+      "4.7.1|url": "https://download.visualstudio.microsoft.com/download/pr/4312fa21-59b0-4451-9482-a1376f7f3ba4/9947fce13c11105b48cba170494e787f/ndp471-kb4033342-x86-x64-allos-enu.exe",
+      "4.7.2|url": "https://download.visualstudio.microsoft.com/download/pr/1f5af042-d0e4-4002-9c59-9ba66bcf15f6/089f837de42708daacaae7c04b7494db/ndp472-kb4054530-x86-x64-allos-enu.exe",
+      "4.8|url": "https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe"
     }
   }

--- a/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -9,7 +9,7 @@ ENV `
 
 RUN `
     # Install .NET Fx 4.8
-    curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
+    curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe `
     && .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `


### PR DESCRIPTION
This simplifies the runtime Dockerfile templates, allowing them to make use of variables that define the URLs to install the various versions of .NET Fx.

There was an inconsistency discovered for 4.8. The URL used for 4.8 was different between WSC 2019 and WSC 2016 Dockerfiles. The WSC 2016 Dockerfile was using a more current URL of that file. This different didn't have a functional difference since the patch was still being applied on top of the base installer. But at least now this makes things current and consistent.