### PR TITLE
Refactor patch variable usage in Dockerfile templates

### DIFF
--- a/eng/dockerfile-templates/runtime/Dockerfile
+++ b/eng/dockerfile-templates/runtime/Dockerfile
@@ -1,7 +1,7 @@
 {{
     set is48SecurityRelease to (VARIABLES[cat("4.8-is-security-release|", OS_VERSION_NUMBER)] = "true") ^
-    set apply35Patch to (VARIABLES[cat("kb|", OS_VERSION_NUMBER)] != void && PRODUCT_VERSION = "3.5" && OS_VERSION_NUMBER != "ltsc2019") ^
-    set applyPatch to VARIABLES[cat("kb|", OS_VERSION_NUMBER)] != void &&
+    set apply35Patch to (VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|", PRODUCT_VERSION)] != void && PRODUCT_VERSION = "3.5" && OS_VERSION_NUMBER != "ltsc2019") ^
+    set applyPatch to VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|", PRODUCT_VERSION)] != void &&
         !(
             (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.7.2") ||
             (
@@ -44,20 +44,20 @@ RUN `
     `
 }}{{if apply35Patch
 :    # Apply latest 3.5 patch
-    && curl -fSLo patch.msu {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}} `
+    && curl -fSLo patch.msu {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|", PRODUCT_VERSION)]}} `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}}-x64.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|", PRODUCT_VERSION)]}}-x64.cab `
     && rmdir /S /Q patch `
     `
 }}{{if applyPatch
 :    # Apply latest patch
-    {{if PRODUCT_VERSION = "3.5" || (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8"):&& }}curl -fSLo patch.msu {{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5":{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}}^else:{{VARIABLES[cat("lcu|", OS_VERSION_NUMBER)]}}}} `
+    {{if PRODUCT_VERSION = "3.5" || (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8"):&& }}curl -fSLo patch.msu {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|", when(PRODUCT_VERSION = "3.5", "default", PRODUCT_VERSION))]}} `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5":{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|3.5-4.7.2")]}}^else:{{VARIABLES[cat("kb|", OS_VERSION_NUMBER)]}}}}-x64{{if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8":-ndp48}}.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|", when(PRODUCT_VERSION = "3.5", "default", PRODUCT_VERSION))]}}-x64{{if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8":-ndp48}}.cab `
     && rmdir /S /Q patch `
     `
 }}{{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5"

--- a/eng/dockerfile-templates/runtime/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/runtime/Dockerfile.ltsc2016
@@ -41,12 +41,12 @@ RUN `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
             -UseBasicParsing `
-            -Uri {{if PRODUCT_VERSION = "4.8":{{VARIABLES["lcu|ltsc2016"]}}^else:{{VARIABLES["lcu|ltsc2016|3.5-4.7.2"]}}}} `
+            -Uri {{VARIABLES[cat("lcu|ltsc2016|", PRODUCT_VERSION)]}} `
             -OutFile patch.msu; `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{if PRODUCT_VERSION = "4.8":{{VARIABLES["kb|ltsc2016"]}}^else:{{VARIABLES["kb|ltsc2016|3.5-4.7.2"]}}}}-x64{{if PRODUCT_VERSION = "4.8":-ndp48}}.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|ltsc2016|", PRODUCT_VERSION)]}}-x64{{if PRODUCT_VERSION = "4.8":-ndp48}}.cab `
     && rmdir /S /Q patch `
     `
 }}    # ngen .NET Fx

--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -22,11 +22,11 @@ RUN `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
     `
     # Apply latest patch
-    && curl -fSLo patch.msu {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER)]}} `
+    && curl -fSLo patch.msu {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|4.8")]}} `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER)]}}-x64-ndp48.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|4.8")]}}-x64-ndp48.cab `
     && rmdir /S /Q patch `
     `
     # ngen .NET Fx

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -23,12 +23,12 @@ RUN `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
             -UseBasicParsing `
-            -Uri {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER)]}} `
+            -Uri {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|4.8")]}} `
             -OutFile patch.msu; `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER)]}}-x64-ndp48.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|4.8")]}}-x64-ndp48.cab `
     && rmdir /S /Q patch `
     `
     # ngen .NET Fx

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -1,22 +1,38 @@
 {
     "variables": {
-      "kb|ltsc2016|3.5-4.7.2":"kb5016622",
-      "lcu|ltsc2016|3.5-4.7.2":"https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/secu/2022/08/windows10.0-kb5016622-x64_77ff4c1d896b008e41f7804648f64ae9bd467f4c.msu",
-      "kb|ltsc2019|3.5-4.7.2": "kb5015736",
-      "lcu|ltsc2019|3.5-4.7.2": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/06/windows10.0-kb5015736-x64_596d4a58f9c8a9e6f661a3100e3284e33fbca197.msu",
-      "kb|ltsc2022|3.5-4.7.2": "kb5016627",
-      "lcu|ltsc2022|3.5-4.7.2": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/secu/2022/08/windows10.0-kb5016627-x64_46b7a22c4135299fd98ca9775211cf86e1ef7108.msu",
+      "kb|ltsc2016|3.5":"kb5016622",
+      "lcu|ltsc2016|3.5":"https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/secu/2022/08/windows10.0-kb5016622-x64_77ff4c1d896b008e41f7804648f64ae9bd467f4c.msu",
+      "kb|ltsc2019|3.5": "kb5015736",
+      "lcu|ltsc2019|3.5": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/06/windows10.0-kb5015736-x64_596d4a58f9c8a9e6f661a3100e3284e33fbca197.msu",
+      "kb|ltsc2022|3.5": "kb5016627",
+      "lcu|ltsc2022|3.5": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/secu/2022/08/windows10.0-kb5016627-x64_46b7a22c4135299fd98ca9775211cf86e1ef7108.msu",
+
+      // All of these versions are patched by the same corresponding KB labeled as 3.5 above.
+      "kb|ltsc2019|4.7.2": "$(kb|ltsc2019|3.5)",
+      "lcu|ltsc2019|4.7.2": "$(lcu|ltsc2019|3.5)",
+      "kb|ltsc2016|4.7.2": "$(kb|ltsc2016|3.5)",
+      "lcu|ltsc2016|4.7.2": "$(lcu|ltsc2016|3.5)",
+      "kb|ltsc2016|4.7.1": "$(kb|ltsc2016|3.5)",
+      "lcu|ltsc2016|4.7.1": "$(lcu|ltsc2016|3.5)",
+      "kb|ltsc2016|4.7": "$(kb|ltsc2016|3.5)",
+      "lcu|ltsc2016|4.7": "$(lcu|ltsc2016|3.5)",
 
       "4.8-is-security-release": false,
       "4.8-is-security-release|2016": "$(4.8-is-security-release)",
       "4.8-is-security-release|ltsc2019": "$(4.8-is-security-release)",
       "4.8-is-security-release|ltsc2022": "$(4.8-is-security-release)",
-      "kb|ltsc2016": "kb5016373",
-      "lcu|ltsc2016": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/07/windows10.0-kb5016373-x64-ndp48_fd8b73694746c825d6429a6fe8a1409d1ce30314.msu",
-      "kb|ltsc2019": "kb5015731",
-      "lcu|ltsc2019": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/06/windows10.0-kb5015731-x64-ndp48_ade9864038087d2d8ccedf421bb45499685d6493.msu",
-      "kb|ltsc2022": "kb5015733",
-      "lcu|ltsc2022": "https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/updt/2022/06/windows10.0-kb5015733-x64-ndp48_8efae0094a144001533bc4cb8eb8e9a779e2534d.msu",
+      "kb|ltsc2016|4.8": "kb5016373",
+      "lcu|ltsc2016|4.8": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/07/windows10.0-kb5016373-x64-ndp48_fd8b73694746c825d6429a6fe8a1409d1ce30314.msu",
+      "kb|ltsc2019|4.8": "kb5015731",
+      "lcu|ltsc2019|4.8": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/06/windows10.0-kb5015731-x64-ndp48_ade9864038087d2d8ccedf421bb45499685d6493.msu",
+      "kb|ltsc2022|4.8": "kb5015733",
+      "lcu|ltsc2022|4.8": "https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/updt/2022/06/windows10.0-kb5015733-x64-ndp48_8efae0094a144001533bc4cb8eb8e9a779e2534d.msu",
+
+      // Defines the patch info for the default .NET Fx version installed in the OS
+      "kb|ltsc2022|default": "$(kb|ltsc2022|4.8)",
+      "lcu|ltsc2022|default": "$(lcu|ltsc2022|4.8)",
+      "kb|ltsc2019|default": "$(kb|ltsc2019|4.7.2)",
+      "lcu|ltsc2019|default": "$(lcu|ltsc2019|4.7.2)",
 
       "nuget|version": "6.2.1",
   


### PR DESCRIPTION
In an effort to simplify the Dockerfile templates and prepare for the addition of .NET Fx 4.8.1, these changes refactor the templates to avoid the need for `if..else` logic when referencing the KB patch info variables.

The naming of the variables was consistent and didn't directly correspond to available template variables, which caused the templates to be very specific to which variable they needed to reference.

These changes add more specificity to the variable names so that the templates can simply use the template `PRODUCT_VERSION` variable when needing to construct the variable name to reference.