### PR TITLE
Add .NET Fx 4.8.1 Dockerfiles

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/vs-tools-release.md
+++ b/.github/ISSUE_TEMPLATE/releases/vs-tools-release.md
@@ -26,7 +26,7 @@ _There is overlap between the tasks here and those for a [Patch Tuesday release]
 1. - [ ] Wait for changes to be mirrored to internal [dotnet-framework-docker repo](https://dev.azure.com/dnceng/internal/_git/Microsoft-dotnet-framework-docker) (internal MSFT link)
 1. - [ ] Queue build of [dotnet-framework-docker pipeline](https://dev.azure.com/dnceng/internal/_build?definitionId=372) (internal MSFT link) with variables:
 
-          imageBuilder.pathArgs: --path 'src/*/3.5/*' --path 'src/*/4.8/*'
+          imageBuilder.pathArgs: --path 'src/*/3.5/*' --path 'src/*/4.8/*' --path 'src/*/4.8.1/*'
 
 1. - [ ] Confirm images have been ingested by MCR
 1. - [ ] Confirm READMEs have been updated in Docker Hub for [microsoft-dotnet-framework](https://hub.docker.com/_/microsoft-dotnet-framework)

--- a/.mcr/portal/README.aspnet.portal.md
+++ b/.mcr/portal/README.aspnet.portal.md
@@ -13,6 +13,8 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 ## Featured Tags
 
+* `4.8.1`
+  * `docker pull mcr.microsoft.com/dotnet/framework/aspnet:4.8.1`
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/aspnet:4.8`
 * `3.5`
@@ -52,7 +54,8 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
-4.8 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.8.1 | windowsservercore-ltsc2022 | 4.8.1
+4.8 | windowsservercore-ltsc2022, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
 4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
 4.7.1 | windowsservercore-ltsc2016 | 4.7.1
 4.7 | windowsservercore-ltsc2016 | 4.7

--- a/.mcr/portal/README.runtime.portal.md
+++ b/.mcr/portal/README.runtime.portal.md
@@ -6,6 +6,8 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 ## Featured Tags
 
+* `4.8.1`
+  * `docker pull mcr.microsoft.com/dotnet/framework/runtime:4.8.1`
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/runtime:4.8`
 * `3.5`
@@ -44,7 +46,8 @@ docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
-4.8 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.8.1 | windowsservercore-ltsc2022 | 4.8.1
+4.8 | windowsservercore-ltsc2022, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
 4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
 4.7.1 | windowsservercore-ltsc2016 | 4.7.1
 4.7 | windowsservercore-ltsc2016 | 4.7

--- a/.mcr/portal/README.sdk.portal.md
+++ b/.mcr/portal/README.sdk.portal.md
@@ -15,6 +15,8 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 ## Featured Tags
 
+* `4.8.1`
+  * `docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8.1`
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8`
 * `3.5`
@@ -50,7 +52,8 @@ The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framewor
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
-4.8 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8*
+4.8.1 | windowsservercore-ltsc2022 | 4.8.1*
+4.8 | windowsservercore-ltsc2022, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8*
 4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
 4.7.1 | windowsservercore-ltsc2016 | 4.7.1
 4.7 | windowsservercore-ltsc2016 | 4.7
@@ -58,7 +61,7 @@ Version Tag | OS Version | Supported .NET Versions
 3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
 3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
 
-\* The 4.8 SDK is also capable of building 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.
+\* The 4.8 and 4.8.1 SDKs are also capable of building 4.8.1, 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.
 
 ## Support
 

--- a/.mcr/portal/README.wcf.portal.md
+++ b/.mcr/portal/README.wcf.portal.md
@@ -6,6 +6,8 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 ## Featured Tags
 
+* `4.8.1`
+  * `docker pull mcr.microsoft.com/dotnet/framework/wcf:4.8.1`
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/wcf:4.8`
 
@@ -54,7 +56,8 @@ docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
-4.8 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.8.1 | windowsservercore-ltsc2022 | 4.8.1
+4.8 | windowsservercore-ltsc2022, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
 4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
 4.7.1 | windowsservercore-ltsc2016 | 4.7.1
 4.7 | windowsservercore-ltsc2016 | 4.7

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -1,5 +1,7 @@
 # Featured Tags
 
+* `4.8.1`
+  * `docker pull mcr.microsoft.com/dotnet/framework/aspnet:4.8.1`
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/aspnet:4.8`
 * `3.5`
@@ -37,7 +39,8 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
-4.8 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.8.1 | windowsservercore-ltsc2022 | 4.8.1
+4.8 | windowsservercore-ltsc2022, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
 4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
 4.7.1 | windowsservercore-ltsc2016 | 4.7.1
 4.7 | windowsservercore-ltsc2016 | 4.7
@@ -65,6 +68,7 @@ Version Tag | OS Version | Supported .NET Versions
 ## Windows Server Core 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+4.8.1-20220809-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/4.8.1/windowsservercore-ltsc2022/Dockerfile)
 4.8-20220809-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/4.8/windowsservercore-ltsc2022/Dockerfile)
 3.5-20220809-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/3.5/windowsservercore-ltsc2022/Dockerfile)
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -1,5 +1,7 @@
 # Featured Tags
 
+* `4.8.1`
+  * `docker pull mcr.microsoft.com/dotnet/framework/runtime:4.8.1`
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/runtime:4.8`
 * `3.5`
@@ -29,7 +31,8 @@ docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
-4.8 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.8.1 | windowsservercore-ltsc2022 | 4.8.1
+4.8 | windowsservercore-ltsc2022, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
 4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
 4.7.1 | windowsservercore-ltsc2016 | 4.7.1
 4.7 | windowsservercore-ltsc2016 | 4.7
@@ -57,6 +60,7 @@ Version Tag | OS Version | Supported .NET Versions
 ## Windows Server Core 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+4.8.1-20220809-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/4.8.1/windowsservercore-ltsc2022/Dockerfile)
 4.8-20220809-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/4.8/windowsservercore-ltsc2022/Dockerfile)
 3.5-20220809-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/3.5/windowsservercore-ltsc2022/Dockerfile)
 

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -1,5 +1,7 @@
 # Featured Tags
 
+* `4.8.1`
+  * `docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8.1`
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8`
 * `3.5`
@@ -35,7 +37,8 @@ The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framewor
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
-4.8 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8*
+4.8.1 | windowsservercore-ltsc2022 | 4.8.1*
+4.8 | windowsservercore-ltsc2022, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8*
 4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
 4.7.1 | windowsservercore-ltsc2016 | 4.7.1
 4.7 | windowsservercore-ltsc2016 | 4.7
@@ -43,7 +46,7 @@ Version Tag | OS Version | Supported .NET Versions
 3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
 3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
 
-\* The 4.8 SDK is also capable of building 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.
+\* The 4.8 and 4.8.1 SDKs are also capable of building 4.8.1, 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.
 
 # Related Repos
 
@@ -65,6 +68,7 @@ Version Tag | OS Version | Supported .NET Versions
 ## Windows Server Core 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+4.8.1-20220809-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile)
 4.8-20220809-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile)
 3.5-20220809-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile)
 

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -1,5 +1,7 @@
 # Featured Tags
 
+* `4.8.1`
+  * `docker pull mcr.microsoft.com/dotnet/framework/wcf:4.8.1`
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/wcf:4.8`
 
@@ -39,7 +41,8 @@ docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
-4.8 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
+4.8.1 | windowsservercore-ltsc2022 | 4.8.1
+4.8 | windowsservercore-ltsc2022, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8
 4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
 4.7.1 | windowsservercore-ltsc2016 | 4.7.1
 4.7 | windowsservercore-ltsc2016 | 4.7
@@ -65,6 +68,7 @@ Version Tag | OS Version | Supported .NET Versions
 ## Windows Server Core 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
+4.8.1-20220809-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.8.1/windowsservercore-ltsc2022/Dockerfile)
 4.8-20220809-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.8/windowsservercore-ltsc2022/Dockerfile)
 
 ## Windows Server Core 2019 amd64 Tags

--- a/eng/dockerfile-templates/runtime/Dockerfile
+++ b/eng/dockerfile-templates/runtime/Dockerfile
@@ -3,6 +3,7 @@
     set apply35Patch to (VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|", PRODUCT_VERSION)] != void && PRODUCT_VERSION = "3.5" && OS_VERSION_NUMBER != "ltsc2019") ^
     set applyPatch to VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|", PRODUCT_VERSION)] != void &&
         !(
+            PRODUCT_VERSION = "4.8.1" ||
             (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.7.2") ||
             (
                 (
@@ -17,12 +18,12 @@
 FROM mcr.microsoft.com/windows/servercore:{{OS_VERSION_NUMBER}}-amd64
 
 ENV {{
-if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8"
+if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8" || PRODUCT_VERSION = "4.8.1"
 :`
     # Enable detection of running in a container
     }}{{ if OS_VERSION_NUMBER != "ltsc2019"
 :DOTNET_RUNNING_IN_CONTAINER=true `
-    }}{{ if PRODUCT_VERSION = "4.8":COMPLUS_RUNNING_IN_CONTAINER=1 `
+    }}{{ if PRODUCT_VERSION = "4.8" || PRODUCT_VERSION = "4.8.1":COMPLUS_RUNNING_IN_CONTAINER=1 `
     }}COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
@@ -35,8 +36,8 @@ RUN `
     && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
     `
-^elif OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8"
-:    # Install .NET Fx 4.8
+^elif (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8") || PRODUCT_VERSION = "4.8.1"
+:    # Install .NET Fx {{PRODUCT_VERSION}}
     curl -fSLo dotnet-framework-installer.exe {{VARIABLES[cat(PRODUCT_VERSION, "|url")]}} `
     && .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
@@ -70,7 +71,7 @@ else
 :    # ngen .NET Fx
     {{if PRODUCT_VERSION != "4.7.2":&& }}%windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `^    else
 :    # Ngen top of assembly graph to optimize a set of frequently used assemblies
-    {{if PRODUCT_VERSION = "3.5" || (PRODUCT_VERSION = "4.8" && !is48SecurityRelease):&& }}%windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    {{if PRODUCT_VERSION = "3.5" || ((PRODUCT_VERSION = "4.8" && !is48SecurityRelease) || PRODUCT_VERSION = "4.8.1"):&& }}%windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
     # To optimize 32-bit assemblies, uncomment the next line
     # && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `}}
     && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `

--- a/eng/dockerfile-templates/runtime/Dockerfile
+++ b/eng/dockerfile-templates/runtime/Dockerfile
@@ -54,11 +54,11 @@ RUN `
     `
 }}{{if applyPatch
 :    # Apply latest patch
-    {{if PRODUCT_VERSION = "3.5" || (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8"):&& }}curl -fSLo patch.msu {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|", when(PRODUCT_VERSION = "3.5", "default", PRODUCT_VERSION))]}} `
+    {{if PRODUCT_VERSION = "3.5" || (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8") || (OS_VERSION_NUMBER = "ltsc2022" && PRODUCT_VERSION = "4.8.1"):&& }}curl -fSLo patch.msu {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|", when(PRODUCT_VERSION = "3.5", "default", PRODUCT_VERSION))]}} `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|", when(PRODUCT_VERSION = "3.5", "default", PRODUCT_VERSION))]}}-x64{{if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8":-ndp48}}.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|", when(PRODUCT_VERSION = "3.5", "default", PRODUCT_VERSION))]}}-x64{{if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8":-ndp48}}{{if PRODUCT_VERSION = "4.8.1":1}}.cab `
     && rmdir /S /Q patch `
     `
 }}{{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5"

--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -1,4 +1,6 @@
-# escape=`
+{{
+    set sdkVersion to when(PRODUCT_VERSION = "4.8.1", "4.8.1", "4.8")
+}}# escape=`
 
 ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
 FROM $REPO:{{PRODUCT_VERSION}}-{{VARIABLES[cat(PRODUCT_VERSION, "-", OS_VERSION_NUMBER, "-Runtime-DateStamp")]}}-{{OS_VERSION}}
@@ -15,18 +17,18 @@ ENV `
 {{if OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "3.5"
 :
 RUN `
-    # Install .NET 4.8 Fx
-    curl -fSLo dotnet-framework-installer.exe {{VARIABLES["4.8|url"]}} `
+    # Install .NET {{sdkVersion}} Fx
+    curl -fSLo dotnet-framework-installer.exe {{VARIABLES[cat(sdkVersion, "|url")]}} `
     && .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
     && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
     `
     # Apply latest patch
-    && curl -fSLo patch.msu {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|4.8")]}} `
+    && curl -fSLo patch.msu {{VARIABLES[cat("lcu|", OS_VERSION_NUMBER, "|", sdkVersion)]}} `
     && mkdir patch `
     && expand patch.msu patch -F:* `
     && del /F /Q patch.msu `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|4.8")]}}-x64-ndp48.cab `
+    && dism /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-{{VARIABLES[cat("kb|", OS_VERSION_NUMBER, "|", sdkVersion)]}}-x64-ndp48{{if PRODUCT_VERSION = "4.8.1":1}}.cab `
     && rmdir /S /Q patch `
     `
     # ngen .NET Fx
@@ -51,7 +53,7 @@ RUN `
     && start /w vs_BuildTools @^ `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" @^ `
         --add Microsoft.Component.ClickOnce.MSBuild @^ `
-        --add Microsoft.Net.Component.4.8.SDK @^ `
+        --add Microsoft.Net.Component.{{sdkVersion}}.SDK @^ `
         --add Microsoft.NetCore.Component.Runtime.3.1 @^ `
         --add Microsoft.NetCore.Component.Runtime.5.0 @^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 @^ `
@@ -68,8 +70,8 @@ RUN `
     && "%ProgramFiles%\dotnet\dotnet" help `
     `
     # Workaround for issues with 64-bit ngen
-    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\SecAnnotate.exe" `
-    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\WinMDExp.exe" `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX {{sdkVersion}} Tools\SecAnnotate.exe" `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX {{sdkVersion}} Tools\WinMDExp.exe" `
     `
     # ngen assemblies queued by VS installers
     && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
@@ -87,14 +89,14 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles}\NuGet\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\" `
-    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A\bin\NETFX {{sdkVersion}} Tools\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
 RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
-    @@('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    @@('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
     | %{ `
         Invoke-WebRequest `
             -UseBasicParsing `

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -121,7 +121,7 @@ RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    @@('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    @@('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
     | %{ `
         Invoke-WebRequest `
             -UseBasicParsing `

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -1,4 +1,5 @@
 $(McrTagsYmlRepo:aspnet)
+$(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:3.5-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2019)

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -1,4 +1,5 @@
 $(McrTagsYmlRepo:runtime)
+$(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:3.5-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2019)

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -1,4 +1,5 @@
 $(McrTagsYmlRepo:sdk)
+$(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:3.5-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2019)

--- a/eng/mcr-tags-metadata-templates/wcf-tags.yml
+++ b/eng/mcr-tags-metadata-templates/wcf-tags.yml
@@ -1,4 +1,5 @@
 $(McrTagsYmlRepo:wcf)
+$(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2019)
 $(McrTagsYmlTagGroup:4.7.2-windowsservercore-ltsc2019)

--- a/eng/readme-templates/FeaturedTags.md
+++ b/eng/readme-templates/FeaturedTags.md
@@ -12,7 +12,9 @@
   * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfservice`
 * `wcfclient`
   * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfclient`^else
-:* `4.8`
+:* `4.8.1`
+  * `docker pull mcr.microsoft.com/dotnet/framework/{{SHORT_REPO}}:4.8.1`
+* `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/{{SHORT_REPO}}:4.8`{{if SHORT_REPO != "wcf":
 * `3.5`
   * `docker pull mcr.microsoft.com/dotnet/framework/{{SHORT_REPO}}:3.5`}}}}

--- a/eng/readme-templates/Use.md
+++ b/eng/readme-templates/Use.md
@@ -14,7 +14,8 @@ if !IS_PRODUCT_FAMILY && SHORT_REPO != "samples":
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
-4.8 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8{{if SHORT_REPO = "sdk":*}}
+4.8.1 | windowsservercore-ltsc2022 | 4.8.1{{if SHORT_REPO = "sdk":*}}
+4.8 | windowsservercore-ltsc2022, windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.8{{if SHORT_REPO = "sdk":*}}
 4.7.2 | windowsservercore-ltsc2019, windowsservercore-ltsc2016 | 4.7.2
 4.7.1 | windowsservercore-ltsc2016 | 4.7.1
 4.7 | windowsservercore-ltsc2016 | 4.7
@@ -22,4 +23,4 @@ Version Tag | OS Version | Supported .NET Versions
 3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
 3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5}}{{if SHORT_REPO = "sdk":
 
-\* The 4.8 SDK is also capable of building 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.}}}}
+\* The 4.8 and 4.8.1 SDKs are also capable of building 4.8.1, 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.}}}}

--- a/manifest.datestamps.json
+++ b/manifest.datestamps.json
@@ -40,6 +40,10 @@
       "4.8-ltsc2022-Runtime-DateStamp": "$(RuntimeReleaseDateStamp)",
       "4.8-ltsc2022-Aspnet-DateStamp": "$(AspnetReleaseDateStamp)",
       "4.8-ltsc2022-Wcf-DateStamp": "$(WcfReleaseDateStamp)",
-      "4.8-ltsc2022-Sdk-DateStamp": "$(SdkReleaseDateStamp)"
+      "4.8-ltsc2022-Sdk-DateStamp": "$(SdkReleaseDateStamp)",
+      "4.8.1-ltsc2022-Runtime-DateStamp": "$(RuntimeReleaseDateStamp)",
+      "4.8.1-ltsc2022-Aspnet-DateStamp": "$(AspnetReleaseDateStamp)",
+      "4.8.1-ltsc2022-Wcf-DateStamp": "$(WcfReleaseDateStamp)",
+      "4.8.1-ltsc2022-Sdk-DateStamp": "$(SdkReleaseDateStamp)"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,24 @@
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/runtime-tags.yml",
       "images": [
         {
+          "productVersion": "4.8.1",
+          "sharedTags": {
+            "4.8.1": {}
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/runtime/4.8.1/windowsservercore-ltsc2022",
+              "dockerfileTemplate": "eng/dockerfile-templates/runtime/Dockerfile",
+              "os": "windows",
+              "osVersion": "windowsservercore-ltsc2022",
+              "tags": {
+                "4.8.1-$(4.8.1-ltsc2022-Runtime-DateStamp)-windowsservercore-ltsc2022": {},
+                "4.8.1-windowsservercore-ltsc2022": {}
+              }
+            }
+          ]
+        },
+        {
           "productVersion": "4.8",
           "sharedTags": {
             "4.8": {},
@@ -254,6 +272,27 @@
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/sdk-tags.yml",
       "images": [
         {
+          "productVersion": "4.8.1",
+          "sharedTags": {
+            "4.8.1": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/sdk/4.8.1/windowsservercore-ltsc2022",
+              "dockerfileTemplate": "eng/dockerfile-templates/sdk/Dockerfile",
+              "os": "windows",
+              "osVersion": "windowsservercore-ltsc2022",
+              "tags": {
+                "4.8.1-$(4.8.1-ltsc2022-Sdk-DateStamp)-windowsservercore-ltsc2022": {},
+                "4.8.1-windowsservercore-ltsc2022": {}
+              }
+            }
+          ]
+        },
+        {
           "productVersion": "4.8",
           "sharedTags": {
             "4.8": {},
@@ -368,6 +407,27 @@
       ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/aspnet-tags.yml",
       "images": [
+        {
+          "productVersion": "4.8.1",
+          "sharedTags": {
+            "4.8.1": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:runtime)"
+              },
+              "dockerfile": "src/aspnet/4.8.1/windowsservercore-ltsc2022",
+              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile",
+              "os": "windows",
+              "osVersion": "windowsservercore-ltsc2022",
+              "tags": {
+                "4.8.1-$(4.8.1-ltsc2022-Aspnet-DateStamp)-windowsservercore-ltsc2022": {},
+                "4.8.1-windowsservercore-ltsc2022": {}
+              }
+            }
+          ]
+        },
         {
           "productVersion": "4.8",
           "sharedTags": {
@@ -580,6 +640,27 @@
       ],
       "mcrTagsMetadataTemplate": "eng/mcr-tags-metadata-templates/wcf-tags.yml",
       "images": [
+        {
+          "productVersion": "4.8.1",
+          "sharedTags": {
+            "4.8.1": {}
+          },
+          "platforms": [
+            {
+              "buildArgs": {
+                "REPO": "$(Repo:aspnet)"
+              },
+              "dockerfile": "src/wcf/4.8.1/windowsservercore-ltsc2022",
+              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
+              "os": "windows",
+              "osVersion": "windowsservercore-ltsc2022",
+              "tags": {
+                "4.8.1-$(4.8.1-ltsc2022-Wcf-DateStamp)-windowsservercore-ltsc2022": {},
+                "4.8.1-windowsservercore-ltsc2022": {}
+              }
+            }
+          ]
+        },
         {
           "productVersion": "4.8",
           "sharedTags": {

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -27,6 +27,8 @@
       "lcu|ltsc2019|4.8": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/06/windows10.0-kb5015731-x64-ndp48_ade9864038087d2d8ccedf421bb45499685d6493.msu",
       "kb|ltsc2022|4.8": "kb5015733",
       "lcu|ltsc2022|4.8": "https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/updt/2022/06/windows10.0-kb5015733-x64-ndp48_8efae0094a144001533bc4cb8eb8e9a779e2534d.msu",
+      "kb|ltsc2022|4.8.1": "KB5017030",
+      "lcu|ltsc2022|4.8.1": "TBD",
 
       // Defines the patch info for the default .NET Fx version installed in the OS
       "kb|ltsc2022|default": "$(kb|ltsc2022|4.8)",
@@ -43,6 +45,7 @@
       "4.7|url": "https://download.visualstudio.microsoft.com/download/pr/2dfcc711-bb60-421a-a17b-76c63f8d1907/e5c0231bd5d51fffe65f8ed7516de46a/ndp47-kb3186497-x86-x64-allos-enu.exe",
       "4.7.1|url": "https://download.visualstudio.microsoft.com/download/pr/4312fa21-59b0-4451-9482-a1376f7f3ba4/9947fce13c11105b48cba170494e787f/ndp471-kb4033342-x86-x64-allos-enu.exe",
       "4.7.2|url": "https://download.visualstudio.microsoft.com/download/pr/1f5af042-d0e4-4002-9c59-9ba66bcf15f6/089f837de42708daacaae7c04b7494db/ndp472-kb4054530-x86-x64-allos-enu.exe",
-      "4.8|url": "https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe"
+      "4.8|url": "https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe",
+      "4.8.1|url": "https://download.visualstudio.microsoft.com/download/pr/6f083c7e-bd40-44d4-9e3f-ffba71ec8b09/3951fd5af6098f2c7e8ff5c331a0679c/ndp481-x86-x64-allos-enu.exe"
     }
   }

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -27,7 +27,7 @@
       "lcu|ltsc2019|4.8": "https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2022/06/windows10.0-kb5015731-x64-ndp48_ade9864038087d2d8ccedf421bb45499685d6493.msu",
       "kb|ltsc2022|4.8": "kb5015733",
       "lcu|ltsc2022|4.8": "https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/updt/2022/06/windows10.0-kb5015733-x64-ndp48_8efae0094a144001533bc4cb8eb8e9a779e2534d.msu",
-      "kb|ltsc2022|4.8.1": "KB5017030",
+      "kb|ltsc2022|4.8.1": "kb5017030",
       "lcu|ltsc2022|4.8.1": "TBD",
 
       // Defines the patch info for the default .NET Fx version installed in the OS

--- a/src/aspnet/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/aspnet/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -1,0 +1,36 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
+FROM $REPO:4.8.1-20220809-windowsservercore-ltsc2022
+
+RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /FeatureName:NetFx4Extended-ASPNET45 /FeatureName:IIS-ASPNET45 `
+    && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
+    && del /q "C:\inetpub\wwwroot\*" `
+    && for /D %p IN ("C:\inetpub\wwwroot\*") DO rmdir "%p" /s /q `
+    && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update
+
+# Install 2.9.0 Roslyn compilers
+RUN curl -fSLo microsoft.net.compilers.2.9.0.zip https://api.nuget.org/packages/microsoft.net.compilers.2.9.0.nupkg `
+    && mkdir C:\RoslynCompilers `
+    && tar -C C:\RoslynCompilers -zxf microsoft.net.compilers.2.9.0.zip `
+    && del microsoft.net.compilers.2.9.0.zip `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install C:\RoslynCompilers\tools\csc.exe /ExeConfig:C:\RoslynCompilers\tools\csc.exe `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install C:\RoslynCompilers\tools\vbc.exe /ExeConfig:C:\RoslynCompilers\tools\vbc.exe `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install C:\RoslynCompilers\tools\VBCSCompiler.exe /ExeConfig:C:\RoslynCompilers\tools\VBCSCompiler.exe
+
+# Install 3.6.0 Roslyn compilers
+RUN curl -fSLo microsoft.net.compilers.3.6.0.zip https://api.nuget.org/packages/microsoft.net.compilers.3.6.0.nupkg `
+    && mkdir C:\RoslynCompilers-3.6.0 `
+    && tar -C C:\RoslynCompilers-3.6.0 -zxf microsoft.net.compilers.3.6.0.zip `
+    && del microsoft.net.compilers.3.6.0.zip `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install C:\RoslynCompilers-3.6.0\tools\csc.exe /ExeConfig:C:\RoslynCompilers-3.6.0\tools\csc.exe `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install C:\RoslynCompilers-3.6.0\tools\vbc.exe /ExeConfig:C:\RoslynCompilers-3.6.0\tools\vbc.exe `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install C:\RoslynCompilers-3.6.0\tools\VBCSCompiler.exe /ExeConfig:C:\RoslynCompilers-3.6.0\tools\VBCSCompiler.exe
+
+ENV ROSLYN_COMPILER_LOCATION=C:\RoslynCompilers-3.6.0\tools
+
+EXPOSE 80
+
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc"]

--- a/src/runtime/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/runtime/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -1,0 +1,23 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-amd64
+
+ENV `
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true `
+    COMPLUS_RUNNING_IN_CONTAINER=1 `
+    COMPLUS_NGenProtectedProcess_FeatureEnabled=0
+
+RUN `
+    # Install .NET Fx 4.8.1
+    curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/6f083c7e-bd40-44d4-9e3f-ffba71ec8b09/3951fd5af6098f2c7e8ff5c331a0679c/ndp481-x86-x64-allos-enu.exe `
+    && .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    `
+    # Ngen top of assembly graph to optimize a set of frequently used assemblies
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    # To optimize 32-bit assemblies, uncomment the next line
+    # && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen install "Microsoft.PowerShell.Utility.Activities, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -120,7 +120,7 @@ RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
     | %{ `
         Invoke-WebRequest `
             -UseBasicParsing `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -90,7 +90,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
 RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
     | %{ `
         Invoke-WebRequest `
             -UseBasicParsing `

--- a/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -72,7 +72,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
 RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
     | %{ `
         Invoke-WebRequest `
             -UseBasicParsing `

--- a/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -1,0 +1,83 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/framework/runtime
+FROM $REPO:4.8.1-20220809-windowsservercore-ltsc2022
+
+ENV `
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false `
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true `
+    # NuGet version to install
+    NUGET_VERSION=6.2.1 `
+    # Install location of Roslyn
+    ROSLYN_COMPILER_LOCATION="C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\Roslyn"
+
+# Install NuGet CLI
+RUN mkdir "%ProgramFiles%\NuGet\latest" `
+    && curl -fSLo "%ProgramFiles%\NuGet\nuget.exe" https://dist.nuget.org/win-x86-commandline/v%NUGET_VERSION%/nuget.exe `
+    && mklink "%ProgramFiles%\NuGet\latest\nuget.exe" "%ProgramFiles%\NuGet\nuget.exe"
+
+# Install VS components
+RUN `
+    # Install VS Test Agent
+    curl -fSLo vs_TestAgent.exe https://aka.ms/vs/17/release/vs_TestAgent.exe `
+    && start /w vs_TestAgent --quiet --norestart --nocache --wait --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\TestAgent" `
+    && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
+    && del vs_TestAgent.exe `
+    `
+    # Install VS Build Tools
+    && curl -fSLo vs_BuildTools.exe https://aka.ms/vs/17/release/vs_BuildTools.exe `
+    && start /w vs_BuildTools ^ `
+        --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
+        --add Microsoft.Component.ClickOnce.MSBuild ^ `
+        --add Microsoft.Net.Component.4.8.1.SDK ^ `
+        --add Microsoft.NetCore.Component.Runtime.3.1 ^ `
+        --add Microsoft.NetCore.Component.Runtime.5.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
+        --add Microsoft.NetCore.Component.SDK ^ `
+        --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
+        --add Microsoft.VisualStudio.Component.WebDeploy ^ `
+        --add Microsoft.VisualStudio.Web.BuildTools.ComponentGroup ^ `
+        --add Microsoft.VisualStudio.Workload.MSBuildTools ^ `
+        --quiet --norestart --nocache --wait `
+    && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
+    && del vs_BuildTools.exe `
+    `
+    # Trigger dotnet first run experience by running arbitrary cmd
+    && "%ProgramFiles%\dotnet\dotnet" help `
+    `
+    # Workaround for issues with 64-bit ngen
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\SecAnnotate.exe" `
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "%ProgramFiles(x86)%\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\WinMDExp.exe" `
+    `
+    # ngen assemblies queued by VS installers
+    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    `
+    # Cleanup
+    && (for /D %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do rmdir /S /Q "%i") `
+    && (for %i in ("%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\*") do if not "%~nxi" == "vswhere.exe" del "%~i") `
+    && powershell Remove-Item -Force -Recurse "%TEMP%\*" `
+    && rmdir /S /Q "%ProgramData%\Package Cache"
+
+# Set PATH in one layer to keep image size down.
+RUN powershell setx /M PATH $(${Env:PATH} `
+    + \";${Env:ProgramFiles}\NuGet\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\TestAgent\Common7\IDE\CommonExtensions\Microsoft\TestWindow\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8.1 Tools\" `
+    + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
+
+# Install Targeting Packs
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
+    | %{ `
+        Invoke-WebRequest `
+            -UseBasicParsing `
+            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
+            -OutFile referenceassemblies.zip; `
+        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
+        Remove-Item -Force referenceassemblies.zip; `
+    }"

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -88,7 +88,7 @@ RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
     | %{ `
         Invoke-WebRequest `
             -UseBasicParsing `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -71,7 +71,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
 RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
     | %{ `
         Invoke-WebRequest `
             -UseBasicParsing `

--- a/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -72,7 +72,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
 RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') `
+    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
     | %{ `
         Invoke-WebRequest `
             -UseBasicParsing `

--- a/src/wcf/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/wcf/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -1,0 +1,11 @@
+# escape=`
+
+ARG REPO=mcr.microsoft.com/dotnet/framework/aspnet
+FROM $REPO:4.8.1-20220809-windowsservercore-ltsc2022
+
+# Install Windows components required for WCF service hosted on IIS
+RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:WCF-HTTP-Activation45 /FeatureName:WCF-TCP-Activation45 /FeatureName:IIS-WebSockets
+
+# Enable net.tcp protocol for default web site on IIS
+RUN %windir%\system32\inetsrv\appcmd set app "Default Web Site/" /enabledProtocols:"http,net.tcp"
+EXPOSE 808

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/AspnetImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/AspnetImageTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2019 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2022 },
+            new ImageDescriptor { Version = "4.8.1", OsVariant = OsVersion.WSC_LTSC2022 },
         };
 
         public AspnetImageTests(ITestOutputHelper outputHelper)

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeOnlyImageTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2019 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2022 },
+            new ImageDescriptor { Version = "4.8.1", OsVariant = OsVersion.WSC_LTSC2022 },
         };
 
         public RuntimeOnlyImageTests(ITestOutputHelper outputHelper)

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/RuntimeSdkImageTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
             new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = OsVersion.WSC_LTSC2019 },
             new RuntimeImageDescriptor { Version = "4.8", SdkVersion = "4.8", OsVariant = OsVersion.WSC_LTSC2022 },
+            new RuntimeImageDescriptor { Version = "4.8.1", SdkVersion = "4.8.1", OsVariant = OsVersion.WSC_LTSC2022 },
         };
 
         private readonly ImageTestHelper _imageTestHelper;

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -57,13 +57,9 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                 new Version("4.7"),
                 new Version("4.7.1"),
                 new Version("4.7.2"),
-                new Version("4.8")
+                new Version("4.8"),
+                new Version("4.8.1")
             };
-
-            if (imageDescriptor.Version == "4.8.1")
-            {
-                allFrameworkVersions.Add(new Version("4.8.1"));
-            }
 
             string baseBuildImage = ImageTestHelper.GetImage("sdk", imageDescriptor.Version, imageDescriptor.OsVariant);
             string appId = $"targetingpacks-{DateTime.Now.ToFileTime()}";

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2019 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2022 },
+            new ImageDescriptor { Version = "4.8.1", OsVariant = OsVersion.WSC_LTSC2022 },
         };
 
         public SdkOnlyImageTests(ITestOutputHelper outputHelper)
@@ -44,7 +45,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
         [MemberData(nameof(GetImageData))]
         public void VerifyTargetingPacks(ImageDescriptor imageDescriptor)
         {
-            Version[] allFrameworkVersions = new Version[]
+            List<Version> allFrameworkVersions = new()
             {
                 new Version("4.0"),
                 new Version("4.5"),
@@ -58,6 +59,11 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
                 new Version("4.7.2"),
                 new Version("4.8")
             };
+
+            if (imageDescriptor.Version == "4.8.1")
+            {
+                allFrameworkVersions.Add(new Version("4.8.1"));
+            }
 
             string baseBuildImage = ImageTestHelper.GetImage("sdk", imageDescriptor.Version, imageDescriptor.OsVariant);
             string appId = $"targetingpacks-{DateTime.Now.ToFileTime()}";

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/SdkOnlyImageTests.cs
@@ -69,15 +69,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             IEnumerable<Version> actualVersions = output.Split(Environment.NewLine)
                 .Select(name => new Version(name.Substring(1))); // Trim the first character (v4.0 => 4.0)
 
-            Version buildVersion = new Version(imageDescriptor.Version);
-
-            IEnumerable<Version> expectedVersions = allFrameworkVersions;
-            if (imageDescriptor.Version != "3.5")
-            {
-                expectedVersions = allFrameworkVersions.Where(version => version <= buildVersion);
-            }
-
-            Assert.Equal(expectedVersions, actualVersions);
+            Assert.Equal(allFrameworkVersions, actualVersions);
         }
 
         [SkippableTheory("4.6.2", "4.7", "4.7.1", "4.7.2")]

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/WcfImageTests.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/WcfImageTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Framework.Docker.Tests
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2016 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2019 },
             new ImageDescriptor { Version = "4.8", OsVariant = OsVersion.WSC_LTSC2022 },
+            new ImageDescriptor { Version = "4.8.1", OsVariant = OsVersion.WSC_LTSC2022 },
         };
 
         public WcfImageTests(ITestOutputHelper outputHelper)

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/aspnet-4.8.1/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/aspnet-4.8.1/Dockerfile
@@ -1,0 +1,7 @@
+ARG BASE_ASPNET_IMAGE
+
+FROM $BASE_ASPNET_IMAGE
+
+WORKDIR  "c:\inetpub\wwwroot"
+COPY ./web.config .
+COPY ./hello-world.aspx .

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/aspnet-4.8.1/hello-world.aspx
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/aspnet-4.8.1/hello-world.aspx
@@ -1,0 +1,24 @@
+<%@ Page Language="C#" AutoEventWireup="true"  %>
+
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head runat="server">
+    <title></title>
+</head>
+<body>
+    <form id="form1" runat="server">
+        <div>
+        </div>
+    </form>
+</body>
+</html>
+
+<script runat="server">
+
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        Response.Write("Hello World!");
+    }
+
+</script>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/aspnet-4.8.1/web.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/aspnet-4.8.1/web.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <system.web>
+    <httpRuntime targetFramework="4.8.1"/>
+  </system.web>
+</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8.1/App.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8.1/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
+    </startup>
+</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8.1/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8.1/Dockerfile
@@ -1,0 +1,7 @@
+ARG BASE_BUILD_IMAGE
+
+FROM $BASE_BUILD_IMAGE as builder
+
+WORKDIR /app
+COPY . ./
+RUN msbuild.exe clickonce-4.8.1.csproj /t:Publish /p:Configuration=Release /p:PublishDir="publish/"

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8.1/Program.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8.1/Program.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine("Hello Docker World from .NET 4.8.1!");
+    }
+}

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8.1/clickonce-4.8.1.csproj
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/clickonce-4.8.1/clickonce-4.8.1.csproj
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7020FB02-5067-41B2-9493-A57918B3BD42}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>clickonce-4.8.1</RootNamespace>
+    <AssemblyName>clickonce-4.8.1</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>1</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <PublishWizardCompleted>true</PublishWizardCompleted>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <GenerateManifests>true</GenerateManifests>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="Dockerfile" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/App.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
+    </startup>
+</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/Dockerfile
@@ -1,0 +1,16 @@
+ARG BASE_BUILD_IMAGE
+ARG BASE_RUNTIME_IMAGE
+
+
+FROM $BASE_BUILD_IMAGE as builder
+WORKDIR /app
+COPY . ./
+RUN nuget restore dotnetapp-4.8.1.sln
+RUN dotnet build -c Release
+
+
+FROM $BASE_RUNTIME_IMAGE
+WORKDIR /app
+COPY --from=builder /app/bin/Release/net481 .
+
+ENTRYPOINT ["dotnetapp-4.8.1.exe"]

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/Program.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/Program.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        bool getProcessorCount = args.Length > 0 && args[0] == "getProcessorCount";
+
+        if (getProcessorCount)
+        {
+            Console.WriteLine(Environment.ProcessorCount);
+        }
+        else
+        {
+            Console.WriteLine("Hello Docker World from .NET 4.8.1!");
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/dotnetapp-4.8.1.csproj
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/dotnetapp-4.8.1.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net481</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/dotnetapp-4.8.1.sln
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/dotnetapp-4.8.1/dotnetapp-4.8.1.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnetapp-4.8.1", "dotnetapp-4.8.1.csproj", "{20033517-2F7F-4B2F-952A-C9B17F6E2284}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{20033517-2F7F-4B2F-952A-C9B17F6E2284}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20033517-2F7F-4B2F-952A-C9B17F6E2284}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20033517-2F7F-4B2F-952A-C9B17F6E2284}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20033517-2F7F-4B2F-952A-C9B17F6E2284}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {307221C7-F18F-4685-9C3B-88EE9A058128}
+	EndGlobalSection
+EndGlobal

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_WCF_IMAGE
+
+FROM $BASE_WCF_IMAGE AS runtime
+
+WORKDIR /inetpub/wwwroot
+COPY web.config .
+COPY Service1.svc .
+
+WORKDIR /inetpub/wwwroot/App_Code
+COPY IService1.cs .
+COPY Service1.svc.cs .

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/IService1.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/IService1.cs
@@ -1,0 +1,11 @@
+﻿using System.ServiceModel;
+
+namespace WcfServiceWebApp
+{
+    [ServiceContract]
+    public interface IService1
+    {
+        [OperationContract]
+        string Hello(string name);
+    }
+}

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/Service1.svc
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/Service1.svc
@@ -1,0 +1,1 @@
+﻿<%@ ServiceHost Language="C#" Debug="true" Service="WcfServiceWebApp.Service1" CodeBehind="Service1.svc.cs" %>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/Service1.svc.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/Service1.svc.cs
@@ -1,0 +1,10 @@
+﻿namespace WcfServiceWebApp
+{
+    public class Service1 : IService1
+    {
+        public string Hello(string name)
+        {
+            return string.Format("Hello {0} from Container!", name);
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/Web.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/wcf-4.8.1/Web.config
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <appSettings>
+    <add key="aspnet:UseTaskFriendlySynchronizationContext" value="true"/>
+  </appSettings>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.8.1" />
+      </system.Web>
+  -->
+  <system.web>
+    <compilation debug="true" targetFramework="4.8.1"/>
+    <httpRuntime targetFramework="4.8.1"/>
+  </system.web>
+  <system.serviceModel>
+    <services>
+      <service name="WcfServiceWebApp.Service1">
+        <endpoint binding="basicHttpBinding" contract="WcfServiceWebApp.IService1"/>
+        <endpoint address="mex" binding="mexTcpBinding" contract="IMetadataExchange"/>
+      </service>
+    </services>
+    <behaviors>
+      <serviceBehaviors>
+        <behavior>
+          <!-- To avoid disclosing metadata information, set the values below to false before deployment -->
+          <serviceMetadata httpGetEnabled="true" httpsGetEnabled="true"/>
+          <!-- To receive exception details in faults for debugging purposes, set the value below to true.  Set to false before deployment to avoid disclosing exception information -->
+          <serviceDebug includeExceptionDetailInFaults="false"/>
+        </behavior>
+      </serviceBehaviors>
+    </behaviors>
+    <protocolMapping>
+      <add binding="basicHttpsBinding" scheme="https"/>
+    </protocolMapping>
+    <serviceHostingEnvironment aspNetCompatibilityEnabled="true" multipleSiteBindingsEnabled="true"/>
+  </system.serviceModel>
+  <system.webServer>
+    <modules runAllManagedModulesForAllRequests="true"/>
+    <!--
+        To browse web app root directory during debugging, set the value below to true.
+        Set to false before deployment to avoid disclosing web app folder information.
+      -->
+    <directoryBrowse enabled="true"/>
+  </system.webServer>
+</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Dockerfile
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Dockerfile
@@ -1,0 +1,10 @@
+ARG BASE_BUILD_IMAGE
+
+FROM $BASE_BUILD_IMAGE
+
+WORKDIR /app
+COPY . ./
+
+RUN nuget restore SimpleWebApplication.sln -SolutionDirectory .
+
+RUN msbuild SimpleWebApplication.sln /p:Configuration=Release

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Properties/AssemblyInfo.cs
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SimpleWebApplication")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SimpleWebApplication")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e02160b5-4466-4003-ba3e-c5c62e576c07")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/SimpleWebApplication.csproj
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/SimpleWebApplication.csproj
@@ -1,0 +1,124 @@
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project=".\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('.\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project=".\packages\Microsoft.Net.Compilers.2.6.1\build\Microsoft.Net.Compilers.props" Condition="Exists('.\packages\Microsoft.Net.Compilers.2.6.1\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{E02160B5-4466-4003-BA3E-C5C62E576C07}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SimpleWebApplication</RootNamespace>
+    <AssemblyName>SimpleWebApplication</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
+      <HintPath>.\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>57072</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:57072/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('.\packages\Microsoft.Net.Compilers.2.6.1\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.Net.Compilers.2.6.1\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('.\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '.\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/SimpleWebApplication.sln
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/SimpleWebApplication.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleWebApplication", "SimpleWebApplication.csproj", "{E02160B5-4466-4003-BA3E-C5C62E576C07}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x64.Build.0 = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Debug|x86.Build.0 = Debug|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x64.ActiveCfg = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x64.Build.0 = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x86.ActiveCfg = Release|Any CPU
+		{E02160B5-4466-4003-BA3E-C5C62E576C07}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {307221C7-F18F-4685-9C3B-88EE9A058128}
+	EndGlobalSection
+EndGlobal

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Web.Debug.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Web.Release.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Web.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/Web.config
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.8.1"/>
+    <httpRuntime targetFramework="4.8.1"/>
+  </system.web>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701"/>
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb"
+        type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+        warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+    </compilers>
+  </system.codedom>
+
+</configuration>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/packages.config
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/projects/webapp-4.8.1/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.8" targetFramework="net481" />
+  <package id="Microsoft.Net.Compilers" version="2.6.1" targetFramework="net481" developmentDependency="true" />
+</packages>


### PR DESCRIPTION
Adds .NET Fx 4.8.1 Dockerfiles. As far as support for Windows Server, 4.8.1 is only supported on Windows Server 2022 so that is the only version being included here.

This is marked as a draft PR right now because further changes will be needed. But it is ready to review. Right now 4.8.1 is configured to be installed by itself. But as part of the September servicing release, a 4.8.1 patch will be installed as well. That will require a template and Dockerfile change.

In addition to new 4.8.1 Dockerfiles, these changes also add the 4.8.1 reference assemblies to the other SDK versions. This allows, for example, a 4.8 SDK container to be used to build (but not run or test) a 4.8.1 project.

Fixes https://github.com/microsoft/dotnet-framework-docker/issues/981