### PR TITLE
Revert pipeline repo endpoint name for internal pipelines

### DIFF
--- a/eng/pipelines/dotnet-framework-samples.yml
+++ b/eng/pipelines/dotnet-framework-samples.yml
@@ -5,7 +5,7 @@ resources:
   repositories:
   - repository: InternalVersionsRepo
     type: github
-    endpoint: public
+    endpoint: dotnet
     name: dotnet/versions
 
 variables:

--- a/eng/pipelines/dotnet-framework.yml
+++ b/eng/pipelines/dotnet-framework.yml
@@ -5,7 +5,7 @@ resources:
   repositories:
   - repository: InternalVersionsRepo
     type: github
-    endpoint: public
+    endpoint: dotnet
     name: dotnet/versions
 
 variables:


### PR DESCRIPTION
The changes in https://github.com/microsoft/dotnet-framework-docker/pull/1001 ended up renaming the GitHub repo endpoint name for internal pipelines when it should instead have only applied them to the public pipelines. I've reverted the change for the affected internal pipelines.