### PR TITLE
Remove .NET Core 3.1 from SDK Dockerfiles

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -54,7 +54,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" @^ `
         --add Microsoft.Component.ClickOnce.MSBuild @^ `
         --add Microsoft.Net.Component.{{sdkVersion}}.SDK @^ `
-        --add Microsoft.NetCore.Component.Runtime.3.1 @^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 @^ `
         --add Microsoft.NetCore.Component.Runtime.7.0 @^ `
         --add Microsoft.NetCore.Component.SDK @^ `

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -77,7 +77,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" @^ `
         --add Microsoft.Component.ClickOnce.MSBuild @^ `
         --add Microsoft.Net.Component.4.8.SDK @^ `
-        --add Microsoft.NetCore.Component.Runtime.3.1 @^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 @^ `
         --add Microsoft.NetCore.Component.Runtime.7.0 @^ `
         --add Microsoft.NetCore.Component.SDK @^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -76,7 +76,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.3.1 ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -49,7 +49,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.3.1 ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -32,7 +32,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.3.1 ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -32,7 +32,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.1.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.3.1 ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -44,7 +44,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.3.1 ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -30,7 +30,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.3.1 ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -32,7 +32,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.3.1 ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `


### PR DESCRIPTION
.NET Core 3.1 is EOL as of Dec. 13, 2022 so it is being removed from the SDK Dockerfiles.

Fixes #994