### PR TITLE
Update eng/common with latest and update to .NET 7.0

### DIFF
--- a/eng/common/Install-DotNetSdk.ps1
+++ b/eng/common/Install-DotNetSdk.ps1
@@ -40,7 +40,7 @@ if (!(Test-Path $DotnetInstallScriptPath)) {
     & "$PSScriptRoot/Invoke-WithRetry.ps1" "Invoke-WebRequest 'https://dot.net/v1/$DotnetInstallScript' -OutFile $DotnetInstallScriptPath"
 }
 
-$DotnetChannel = "6.0"
+$DotnetChannel = "7.0"
 
 $InstallFailed = $false
 if ($IsRunningOnUnix) {

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2079421
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2086859
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-buster-slim-docker-testrunner-974165

--- a/eng/update-dependencies/Microsoft.DotNet.Framework.UpdateDependencies.csproj
+++ b/eng/update-dependencies/Microsoft.DotNet.Framework.UpdateDependencies.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.DotNet.Framework.UpdateDependencies</RootNamespace>

--- a/tests/Microsoft.DotNet.Framework.Docker.Tests/Microsoft.DotNet.Framework.Docker.Tests.csproj
+++ b/tests/Microsoft.DotNet.Framework.Docker.Tests/Microsoft.DotNet.Framework.Docker.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes changes from https://github.com/microsoft/dotnet-framework-docker/pull/1040 as well as updates to .NET 7.0 to fix the test project failure in that PR. I don't have permissions to push to dotnet-docker-bot's branch so I'm opening this as a separate PR.