### PR TITLE
Updates for VS 17.5 release

### DIFF
--- a/README.sdk.md
+++ b/README.sdk.md
@@ -69,21 +69,21 @@ Version Tag | OS Version | Supported .NET Versions
 ## Windows Server Core 2022 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8.1-20230214-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile)
-4.8-20230214-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile)
-3.5-20230214-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile)
+4.8.1-20230221-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile)
+4.8-20230221-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile)
+3.5-20230221-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile)
 
 ## Windows Server Core 2019 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20230214-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile)
-3.5-20230214-windowsservercore-ltsc2019, 3.5-windowsservercore-ltsc2019, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile)
+4.8-20230221-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile)
+3.5-20230221-windowsservercore-ltsc2019, 3.5-windowsservercore-ltsc2019, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile)
 
 ## Windows Server Core 2016 amd64 Tags
 Tag | Dockerfile
 ---------| ---------------
-4.8-20230214-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile)
-3.5-20230214-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile)
+4.8-20230221-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile)
+3.5-20230221-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile)
 
 You can retrieve a list of all available tags for dotnet/framework/sdk at https://mcr.microsoft.com/v2/dotnet/framework/sdk/tags/list.
 <!--End of generated tags-->

--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -108,3 +108,4 @@ if OS_VERSION_NUMBER = "ltsc2019"
 :
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]}}
+

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -131,3 +131,4 @@ RUN powershell " `
     }"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+

--- a/manifest.datestamps.json
+++ b/manifest.datestamps.json
@@ -3,7 +3,7 @@
       "RuntimeReleaseDateStamp": "20230214",
       "AspnetReleaseDateStamp": "20230214",
       "WcfReleaseDateStamp": "20230214",
-      "SdkReleaseDateStamp": "20230214",
+      "SdkReleaseDateStamp": "20230221",
       
       "3.5-ltsc2016-Runtime-DateStamp": "$(RuntimeReleaseDateStamp)",
       "3.5-ltsc2016-Aspnet-DateStamp": "$(AspnetReleaseDateStamp)",

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -36,7 +36,7 @@
 
       "nuget|version": "6.4.0",
   
-      "vs|version": "17.4",
+      "vs|version": "17.5",
       "vs|testAgentUrl": "https://aka.ms/vs/17/release/vs_TestAgent.exe",
       "vs|buildToolsUrl": "https://aka.ms/vs/17/release/vs_BuildTools.exe",
 

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -130,3 +130,4 @@ RUN powershell " `
     }"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -100,3 +100,4 @@ RUN powershell " `
     }"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+

--- a/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -80,3 +80,4 @@ RUN powershell " `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
     }"
+

--- a/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -80,3 +80,4 @@ RUN powershell " `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
     }"
+

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -98,3 +98,4 @@ RUN powershell " `
     }"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -81,3 +81,4 @@ RUN powershell " `
     }"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+

--- a/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -80,3 +80,4 @@ RUN powershell " `
         Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
         Remove-Item -Force referenceassemblies.zip; `
     }"
+


### PR DESCRIPTION
Non-functional whitespace was intentionally added to the SDK Dockerfiles to cause them to have a new git commit. This is to workaround the pipeline image caching logic. For this release we want to reuse all existing images except for the SDK, without rebuilding them. So we want caching to be enabled but we need to cause the SDK Dockerfiles to be rebuilt. This is done by having them be associated with a new git commit, causing a cache miss and rebuilding the Dockerfiles.

Related to https://github.com/dotnet/release/issues/473