### PR TITLE
Re-enable prebuild validation step

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -13,12 +13,9 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  # Temporarily disable prebuild validation. Revert as part of https://github.com/microsoft/dotnet-framework-docker/issues/1075
-  # condition: and(${{ parameters.matrix }}, not(canceled()), in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
-  condition: and(${{ parameters.matrix }}, not(canceled()))
+  condition: and(${{ parameters.matrix }}, not(canceled()), in(dependencies.PreBuildValidation.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   dependsOn:
-  # Temporarily disable prebuild validation. Revert as part of https://github.com/microsoft/dotnet-framework-docker/issues/1075
-  # - PreBuildValidation
+  - PreBuildValidation
   - CopyBaseImages
   - GenerateBuildMatrix
   pool: ${{ parameters.pool }}

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -46,25 +46,24 @@ stages:
 - stage: Build
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
-  # Temporarily disable prebuild validation. Revert as part of https://github.com/microsoft/dotnet-framework-docker/issues/1075
-  # - template: ../jobs/test-images-linux-client.yml
-  #   parameters:
-  #     name: PreBuildValidation
-  #     pool: ${{ parameters.linuxAmd64Pool }}
-  #     testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
-  #     preBuildValidation: true
-  #     internalProjectName: ${{ parameters.internalProjectName }}
-  #     customInitSteps:
-  #       - ${{ parameters.customTestInitSteps }}
-  #       # These variables are normally set by the matrix. Since this test job is not generated
-  #       # by a matrix, we need to set them manually. They can be set to empty values since their
-  #       # values aren't actually used for the pre-build tests.
-  #       - powershell: |
-  #           echo "##vso[task.setvariable variable=productVersion]"
-  #           echo "##vso[task.setvariable variable=imageBuilderPaths]"
-  #           echo "##vso[task.setvariable variable=osVersions]"
-  #           echo "##vso[task.setvariable variable=architecture]"
-  #         displayName: Initialize Test Variables
+  - template: ../jobs/test-images-linux-client.yml
+    parameters:
+      name: PreBuildValidation
+      pool: ${{ parameters.linuxAmd64Pool }}
+      testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
+      preBuildValidation: true
+      internalProjectName: ${{ parameters.internalProjectName }}
+      customInitSteps:
+        - ${{ parameters.customTestInitSteps }}
+        # These variables are normally set by the matrix. Since this test job is not generated
+        # by a matrix, we need to set them manually. They can be set to empty values since their
+        # values aren't actually used for the pre-build tests.
+        - powershell: |
+            echo "##vso[task.setvariable variable=productVersion]"
+            echo "##vso[task.setvariable variable=imageBuilderPaths]"
+            echo "##vso[task.setvariable variable=osVersions]"
+            echo "##vso[task.setvariable variable=architecture]"
+          displayName: Initialize Test Variables
   - template: ../jobs/copy-base-images.yml
     parameters:
       name: CopyBaseImages


### PR DESCRIPTION
Now that the Dockerfiles are in sync with the templates from https://github.com/microsoft/dotnet-framework-docker/pull/1080, we can re-enable the prebuild validation step that was disabled by https://github.com/microsoft/dotnet-framework-docker/pull/1074.

Fixes https://github.com/microsoft/dotnet-framework-docker/issues/1075