### PR TITLE
Move dotnet-framework-docker pipelines to 1ES Pipeline templates

### DIFF
--- a/eng/common/templates/jobs/build-images.yml
+++ b/eng/common/templates/jobs/build-images.yml
@@ -26,6 +26,8 @@ jobs:
     imageBuilderDockerRunExtraOptions: $(build.imageBuilderDockerRunExtraOptions)
     versionsRepoPath: versions
     sbomDirectory: $(Build.ArtifactStagingDirectory)/sbom
+    imageInfoHostDir: $(Build.ArtifactStagingDirectory)/imageInfo
+    imageInfoContainerDir: $(artifactsPath)/imageInfo
     ${{ if eq(parameters.noCache, false) }}:
       versionsBasePath: $(versionsRepoPath)/
       pipelineDisabledCache: false
@@ -75,9 +77,11 @@ jobs:
       }
       echo "##vso[task.setvariable variable=baseContainerRepoPath]$baseContainerRepoPath"
     displayName: Set Base Container Repo Path
-  - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
+  - template: /eng/common/templates/jobs/${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}@self
+    parameters:
+      cleanupDocker: true
   - ${{ parameters.customInitSteps }}
-  - template: ../steps/set-image-info-path-var.yml
+  - template: /eng/common/templates/steps/set-image-info-path-var.yml@self
     parameters:
       publicSourceBranch: $(publicSourceBranch)
   - powershell: echo "##vso[task.setvariable variable=imageBuilderBuildArgs]"
@@ -90,7 +94,8 @@ jobs:
       # to escape the single quotes that are in the string which would need to be done outside the context of PowerShell. Since
       # all we need is for that value to be in a PowerShell variable, we can get that by the fact that AzDO automatically creates
       # the environment variable for us.
-      $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS $(imageBuilder.queueArgs) --image-info-output-path $(artifactsPath)/$(legName)-image-info.json"
+      New-Item -Path $(imageInfoHostDir) -ItemType Directory -Force
+      $imageBuilderBuildArgs = "$env:IMAGEBUILDERBUILDARGS $(imageBuilder.queueArgs) --image-info-output-path $(imageInfoContainerDir)/$(legName)-image-info.json"
       if ($env:SYSTEM_TEAMPROJECT -eq "${{ parameters.internalProjectName }}" -and $env:BUILD_REASON -ne "PullRequest") {
         $imageBuilderBuildArgs = "$imageBuilderBuildArgs --registry-override $(acr.server) --repo-prefix $(stagingRepoPrefix) --source-repo-prefix $(mirrorRepoPrefix) --push --registry-creds ""$(acr.server)=$(acr.userName);$(acr.password)"""
       }
@@ -121,9 +126,13 @@ jobs:
       $(imageBuilderBuildArgs)
     name: BuildImages
     displayName: Build Images
-  - publish: $(Build.ArtifactStagingDirectory)/$(legName)-image-info.json
-    artifact: $(legName)-image-info-$(System.JobAttempt)
-    displayName: Publish Image Info File Artifact
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(imageInfoHostDir)
+      artifactName: $(legName)-image-info-$(System.JobAttempt)
+      displayName: Publish Image Info File Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
   - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
       # Define the task here to load it into the agent so that we can invoke the tool manually
       # TODO: Revert the build-specific pinned version when https://github.com/dotnet/docker-tools/issues/1152 is fixed
@@ -135,14 +144,19 @@ jobs:
     - powershell: |
         $images = "$(BuildImages.builtImages)"
         if (-not $images) { return 0 }
+
         # There can be leftover versions of the task left on the agent if it's not fresh. So find the latest version.
         $taskDir = $(Get-ChildItem -Recurse -Directory -Filter "ManifestGeneratorTask*" -Path '$(Agent.WorkFolder)')[-1].FullName
-        $manifestToolDllPath = $(Get-ChildItem -Recurse -File -Filter "Microsoft.ManifestTool.dll" -Path $taskDir).FullName
+
+        # There may be multiple version directories within the task directory. Use the latest.
+        $taskVersionDir = $(Get-ChildItem -Directory $taskDir | Sort-Object)[-1].FullName
+
+        $manifestToolDllPath = $(Get-ChildItem -Recurse -File -Filter "Microsoft.ManifestTool.dll" -Path $taskVersionDir).FullName
 
         # Check whether the manifest task installed its own version of .NET.
         # To be more robust, we'll handle varying implementations that it's had.
         # First check for a dotnet folder in the task location
-        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "dotnet-*" -Path $taskDir).FullName
+        $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "dotnet-*" -Path $taskVersionDir).FullName
         if (-not $dotnetDir) {
           # If it's not there, check in the agent tools location
           $dotnetDir = $(Get-ChildItem -Recurse -Directory -Filter "*dotnet-*" -Path "$(Agent.ToolsDirectory)").FullName
@@ -172,17 +186,20 @@ jobs:
             -PackageVersion '$(Build.BuildNumber)' `
             -ManifestDirPath $sbomChildDir `
             -DockerImagesToScan $_ `
-            -Verbosity Information 
+            -Verbosity Information
         }
       displayName: Generate SBOMs
       condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-    - template: ${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}
+    - template: /eng/common/templates/jobs/${{ format('../steps/test-images-{0}-client.yml', parameters.dockerClientOS) }}@self
       parameters:
         condition: ne(variables.testScriptPath, '')
-  - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}
   - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-    - publish: $(sbomDirectory)
-      artifact: $(legName)-sboms
-      displayName: Publish SBOM
-      condition: and(succeeded(), ne(variables['BuildImages.builtImages'], ''))
+    - template: /eng/common/templates/steps/publish-artifact.yml@self
+      parameters:
+        path: $(sbomDirectory)
+        artifactName: $(legName)-sboms
+        displayName: Publish SBOM
+        internalProjectName: ${{ parameters.internalProjectName }}
+        publicProjectName: ${{ parameters.publicProjectName }}
+        condition: ne(variables['BuildImages.builtImages'], '')

--- a/eng/common/templates/jobs/copy-base-images.yml
+++ b/eng/common/templates/jobs/copy-base-images.yml
@@ -4,16 +4,15 @@ parameters:
   additionalOptions: null
   publicProjectName: null
   customInitSteps: []
-  
+
 jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
   steps:
-  - template: ../steps/init-docker-linux.yml
+  - template: /eng/common/templates/steps/init-docker-linux.yml@self
   - ${{ parameters.customInitSteps }}
-  - template: ../steps/copy-base-images.yml
+  - template: /eng/common/templates/steps/copy-base-images.yml@self
     parameters:
       additionalOptions: ${{ parameters.additionalOptions }}
       publicProjectName: ${{ parameters.publicProjectName }}
       continueOnError: true
-  - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/jobs/generate-matrix.yml
+++ b/eng/common/templates/jobs/generate-matrix.yml
@@ -10,13 +10,13 @@ jobs:
 - job: ${{ parameters.name }}
   pool: ${{ parameters.pool }}
   steps:
-  - template: ../steps/retain-build.yml
-  - template: ../steps/init-docker-linux.yml
-  - template: ../steps/validate-branch.yml
+  - template: /eng/common/templates/steps/retain-build.yml@self
+  - template: /eng/common/templates/steps/init-docker-linux.yml@self
+  - template: /eng/common/templates/steps/validate-branch.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}
   - ${{ if eq(parameters.isTestStage, true) }}:
-    - template: ../steps/download-build-artifact.yml
+    - template: /eng/common/templates/steps/download-build-artifact.yml@self
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: image-info
@@ -38,4 +38,3 @@ jobs:
       $(additionalGenerateBuildMatrixOptions)
     displayName: Generate ${{ parameters.matrixType }} Matrix
     name: matrix
-  - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/jobs/post-build.yml
+++ b/eng/common/templates/jobs/post-build.yml
@@ -1,37 +1,42 @@
 parameters:
   pool: {}
+  internalProjectName: null
+  publicProjectName: null
 
 jobs:
 - job: Build
   pool: ${{ parameters.pool }}
   variables:
     imageInfosSubDir: "/image-infos"
-    sbomSubDir: "/sbom"
+    imageInfosHostDir: "$(Build.ArtifactStagingDirectory)$(imageInfosSubDir)"
+    imageInfosContainerDir: "$(artifactsPath)$(imageInfosSubDir)"
+    imageInfosOutputSubDir: "/output"
+    sbomOutputDir: "$(Build.ArtifactStagingDirectory)/sbom"
   steps:
-  - template: ../steps/init-docker-linux.yml
-  - template: ../steps/download-build-artifact.yml
+  - template: /eng/common/templates/steps/init-docker-linux.yml@self
+  - template: /eng/common/templates/steps/download-build-artifact.yml@self
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
   - powershell: |
       # Move all image-info artifacts to their own directory
-      New-Item -ItemType Directory -Path $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)
+      New-Item -ItemType Directory -Path $(imageInfosHostDir)
       Get-ChildItem -Directory -Filter "*-image-info-*" $(Build.ArtifactStagingDirectory) |
-        Move-Item -Verbose -Destination $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)
+        Move-Item -Verbose -Destination $(imageInfosHostDir)
     displayName: Collect Image Info Files
   - powershell: |
       # Move the contents of all the SBOM artifact directories to a single location
-      New-Item -ItemType Directory -Path $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+      New-Item -ItemType Directory -Path $(sbomOutputDir)
       Get-ChildItem -Directory -Filter "*-sboms" $(Build.ArtifactStagingDirectory) |
         ForEach-Object {
-          Get-ChildItem $_ -Directory | Move-Item -Verbose -Destination $(Build.ArtifactStagingDirectory)$(sbomSubDir)
+          Get-ChildItem $_ -Directory | Move-Item -Force -Verbose -Destination $(sbomOutputDir)
         }
     displayName: Consolidate SBOMs to Single Directory
   - powershell: |
       # Deletes the artifacts from all the unsuccessful jobs
-      Get-ChildItem $(Build.ArtifactStagingDirectory)$(imageInfosSubDir) -Directory |
+      Get-ChildItem $(imageInfosHostDir) -Directory |
           ForEach-Object {
               [pscustomobject]@{
-                  # Parse the artifact name to separate the base of the name from the job attempt number 
+                  # Parse the artifact name to separate the base of the name from the job attempt number
                   BaseName = $_.Name.Substring(0, $_.Name.LastIndexOf('-'));
                   JobAttempt = $_.Name.Substring($_.Name.LastIndexOf('-') + 1)
                   FullName = $_.FullName
@@ -46,16 +51,25 @@ jobs:
                   Remove-Item -Recurse -Force
           }
     displayName: Prune Publish Artifacts
-  - script: >
-      $(runImageBuilderCmd) mergeImageInfo
-      --manifest $(manifest)
-      $(artifactsPath)$(imageInfosSubDir)
-      $(artifactsPath)$(imageInfosSubDir)/image-info.json
-      $(manifestVariables)
+  - powershell: |
+      New-Item -ItemType Directory -Path $(imageInfosHostDir)$(imageInfosOutputSubDir) -Force
+      $(runImageBuilderCmd) mergeImageInfo `
+        --manifest $(manifest) `
+        $(imageInfosContainerDir) `
+        $(imageInfosContainerDir)$(imageInfosOutputSubDir)/image-info.json `
+        $(manifestVariables)
     displayName: Merge Image Info Files
-  - publish: $(Build.ArtifactStagingDirectory)$(sbomSubDir)
-    artifact: sboms
-    displayName: Publish SBOM Artifact
-  - publish: $(Build.ArtifactStagingDirectory)$(imageInfosSubDir)/image-info.json
-    artifact: image-info
-    displayName: Publish Image Info File Artifact
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(sbomOutputDir)
+      artifactName: sboms
+      displayName: Publish SBOM Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(imageInfosHostDir)$(imageInfosOutputSubDir)
+      artifactName: image-info
+      displayName: Publish Image Info File Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}

--- a/eng/common/templates/jobs/publish.yml
+++ b/eng/common/templates/jobs/publish.yml
@@ -21,36 +21,48 @@ jobs:
       value: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
     ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
       value: $[ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') ]
+  - name: imageInfoHostDir
+    value: $(Build.ArtifactStagingDirectory)/imageInfo
+  - name: imageInfoContainerDir
+    value: $(artifactsPath)/imageInfo
+  - name: sourceBuildIdOutputDir
+    value: $(Build.ArtifactStagingDirectory)/sourceBuildId
   - ${{ parameters.customPublishVariables }}
   steps:
-  - template: ../steps/retain-build.yml
-  - template: ../steps/init-docker-linux.yml
+  - template: /eng/common/templates/steps/retain-build.yml@self
+  - template: /eng/common/templates/steps/init-docker-linux.yml@self
   - pwsh: |
       $azdoOrgName = Split-Path -Leaf $Env:SYSTEM_COLLECTIONURI
       echo "##vso[task.setvariable variable=azdoOrgName]$azdoOrgName"
     displayName: Set Publish Variables
   - ${{ parameters.customInitSteps }}
-  - template: ../steps/validate-branch.yml
+  - template: /eng/common/templates/steps/validate-branch.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}
-  - template: ../steps/download-build-artifact.yml
+  - template: /eng/common/templates/steps/download-build-artifact.yml@self
     parameters:
-      targetPath: $(Build.ArtifactStagingDirectory)
+      targetPath: $(imageInfoHostDir)
       artifactName: image-info
-  - template: ../steps/set-image-info-path-var.yml
+  - template: /eng/common/templates/steps/set-image-info-path-var.yml@self
     parameters:
       publicSourceBranch: $(publicSourceBranch)
-  - template: ../steps/set-dry-run.yml
-  - script: echo $(sourceBuildId) > $(Build.ArtifactStagingDirectory)/source-build-id.txt
+  - template: /eng/common/templates/steps/set-dry-run.yml@self
+  - powershell: |
+      New-Item -ItemType Directory -Path $(sourceBuildIdOutputDir)
+      Set-Content -Path $(sourceBuildIdOutputDir)/source-build-id.txt -Value $(sourceBuildId)
     displayName: Write Source Build ID to File
-  - publish: $(Build.ArtifactStagingDirectory)/source-build-id.txt
-    artifact: source-build-id
-    displayName: Publish Source Build ID Artifact
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(sourceBuildIdOutputDir)
+      artifactName: source-build-id
+      displayName: Publish Source Build ID Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
   - script: echo "##vso[task.setvariable variable=imageQueueTime]$(date --rfc-2822)"
     displayName: Set Publish Variables
   - script: >
       $(runImageBuilderCmd) trimUnchangedPlatforms
-      '$(artifactsPath)/image-info.json'
+      '$(imageInfoContainerDir)/image-info.json'
     displayName: Trim Unchanged Images
   - script: >
       $(runImageBuilderCmd) copyAcrImages
@@ -63,14 +75,14 @@ jobs:
       --os-type '*'
       --architecture '*'
       --repo-prefix '$(publishRepoPrefix)'
-      --image-info '$(artifactsPath)/image-info.json'
+      --image-info '$(imageInfoContainerDir)/image-info.json'
       $(dryRunArg)
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Copy Images
   - script: >
       $(runImageBuilderCmd) publishManifest
-      '$(artifactsPath)/image-info.json'
+      '$(imageInfoContainerDir)/image-info.json'
       --repo-prefix '$(publishRepoPrefix)'
       --registry-creds '$(acr.server)=$(acr.userName);$(acr.password)'
       --os-type '*'
@@ -79,22 +91,26 @@ jobs:
       $(imageBuilder.pathArgs)
       $(imageBuilder.commonCmdArgs)
     displayName: Publish Manifest
-  - publish: $(Build.ArtifactStagingDirectory)/image-info.json
-    artifact: image-info-final-$(System.JobAttempt)
-    displayName: Publish Image Info File Artifact
-  - template: ../steps/wait-for-mcr-image-ingestion.yml
+  - template: /eng/common/templates/steps/publish-artifact.yml@self
+    parameters:
+      path: $(imageInfoHostDir)
+      artifactName: image-info-final-$(System.JobAttempt)
+      displayName: Publish Image Info File Artifact
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
+  - template: /eng/common/templates/steps/wait-for-mcr-image-ingestion.yml@self
     parameters:
       imageInfoPath: '$(artifactsPath)/image-info.json'
       minQueueTime: $(imageQueueTime)
       dryRunArg: $(dryRunArg)
       condition: succeeded()
-  - template: ../steps/publish-readmes.yml
+  - template: /eng/common/templates/steps/publish-readmes.yml@self
     parameters:
       dryRunArg: $(dryRunArg)
       condition: and(succeeded(), eq(variables['publishReadme'], 'true'))
   - script: >
       $(runImageBuilderCmd) publishImageInfo
-      '$(artifactsPath)/image-info.json'
+      '$(imageInfoContainerDir)/image-info.json'
       '$(gitHubVersionsRepoInfo.userName)'
       '$(gitHubVersionsRepoInfo.email)'
       '$(gitHubVersionsRepoInfo.accessToken)'
@@ -108,7 +124,7 @@ jobs:
     displayName: Publish Image Info
   - script: >
       $(runImageBuilderCmd) ingestKustoImageInfo
-      '$(artifactsPath)/image-info.json'
+      '$(imageInfoContainerDir)/image-info.json'
       '$(kusto.cluster)'
       '$(kusto.database)'
       '$(kusto.imageTable)'
@@ -126,7 +142,7 @@ jobs:
       $(runImageBuilderCmd) postPublishNotification
       '$(publishNotificationRepoName)'
       '$(branchName)'
-      '$(artifactsPath)/image-info.json'
+      '$(imageInfoContainerDir)/image-info.json'
       $(Build.BuildId)
       '$(System.AccessToken)'
       '$(azdoOrgName)'
@@ -146,4 +162,3 @@ jobs:
       $(imageBuilder.commonCmdArgs)
     displayName: Post Publish Notification
     condition: and(always(), eq(variables['publishNotificationsEnabled'], 'true'))
-  - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/jobs/test-images-linux-client.yml
+++ b/eng/common/templates/jobs/test-images-linux-client.yml
@@ -19,7 +19,7 @@ jobs:
   pool: ${{ parameters.pool }}
   timeoutInMinutes: ${{ parameters.testJobTimeout }}
   steps:
-  - template: ../steps/test-images-linux-client.yml
+  - template: /eng/common/templates/steps/test-images-linux-client.yml@self
     parameters:
       preBuildValidation: ${{ parameters.preBuildValidation }}
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/jobs/test-images-windows-client.yml
+++ b/eng/common/templates/jobs/test-images-windows-client.yml
@@ -15,7 +15,7 @@ jobs:
     matrix: $[ ${{ parameters.matrix }} ]
   timeoutInMinutes: ${{ parameters.testJobTimeout }}
   steps:
-  - template: ../steps/test-images-windows-client.yml
+  - template: /eng/common/templates/steps/test-images-windows-client.yml@self
     parameters:
       internalProjectName: ${{ parameters.internalProjectName }}
       customInitSteps: ${{ parameters.customInitSteps }}

--- a/eng/common/templates/jobs/wait-for-ingestion.yml
+++ b/eng/common/templates/jobs/wait-for-ingestion.yml
@@ -24,4 +24,3 @@ jobs:
     parameters:
       commitDigest: $(readmeCommitDigest)
       condition: and(succeeded(), ne(variables['readmeCommitDigest'], ''))
-  - template: ../steps/cleanup-docker-linux.yml

--- a/eng/common/templates/stages/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/build-test-publish-repo.yml
@@ -46,7 +46,7 @@ stages:
 - stage: Build
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
-  - template: ../jobs/test-images-linux-client.yml
+  - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
     parameters:
       name: PreBuildValidation
       pool: ${{ parameters.linuxAmd64Pool }}
@@ -64,14 +64,14 @@ stages:
             echo "##vso[task.setvariable variable=osVersions]"
             echo "##vso[task.setvariable variable=architecture]"
           displayName: Initialize Test Variables
-  - template: ../jobs/copy-base-images.yml
+  - template: /eng/common/templates/jobs/copy-base-images.yml@self
     parameters:
       name: CopyBaseImages
       pool: ${{ parameters.linuxAmd64Pool }}
       additionalOptions: "--manifest '$(manifest)' $(imageBuilder.pathArgs) $(manifestVariables)"
       publicProjectName: ${{ parameters.publicProjectName }}
       customInitSteps: ${{ parameters.customCopyBaseImagesInitSteps}}
-  - template: ../jobs/generate-matrix.yml
+  - template: /eng/common/templates/jobs/generate-matrix.yml@self
     parameters:
       matrixType: ${{ parameters.buildMatrixType }}
       name: GenerateBuildMatrix
@@ -80,7 +80,7 @@ stages:
       internalProjectName: ${{ parameters.internalProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Linux_amd64
       pool: ${{ parameters.linuxAmd64Pool }}
@@ -93,7 +93,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Linux_arm64
       pool: ${{ parameters.linuxArm64Pool }}
@@ -106,7 +106,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Linux_arm32
       pool: ${{ parameters.linuxArm32Pool }}
@@ -119,7 +119,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Windows1809_amd64
       pool: ${{ parameters.windows1809Pool }}
@@ -132,7 +132,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: Windows2022_amd64
       pool: ${{ parameters.windows2022Pool }}
@@ -145,7 +145,7 @@ stages:
       publicProjectName: ${{ parameters.publicProjectName }}
       internalVersionsRepoRef: ${{ parameters.internalVersionsRepoRef }}
       publicVersionsRepoRef: ${{ parameters.publicVersionsRepoRef }}
-  - template: ../jobs/build-images.yml
+  - template: /eng/common/templates/jobs/build-images.yml@self
     parameters:
       name: WindowsLtsc2016_amd64
       pool: ${{ parameters.windows2016Pool }}
@@ -166,9 +166,11 @@ stages:
   dependsOn: Build
   condition: and(succeeded(), contains(variables['stages'], 'build'))
   jobs:
-  - template: ../jobs/post-build.yml
+  - template: /eng/common/templates/jobs/post-build.yml@self
     parameters:
       pool: ${{ parameters.linuxAmd64Pool }}
+      internalProjectName: ${{ parameters.internalProjectName }}
+      publicProjectName: ${{ parameters.publicProjectName }}
 
 ################################################################################
 # Test Images
@@ -187,7 +189,7 @@ stages:
               contains(variables['stages'], 'build')),
             not(contains(variables['stages'], 'build')))))"
     jobs:
-    - template: ../jobs/generate-matrix.yml
+    - template: /eng/common/templates/jobs/generate-matrix.yml@self
       parameters:
         matrixType: ${{ parameters.testMatrixType }}
         name: GenerateTestMatrix
@@ -196,8 +198,7 @@ stages:
         isTestStage: true
         internalProjectName: ${{ parameters.internalProjectName }}
         publicProjectName: ${{ parameters.publicProjectName }}
-
-    - template: ../jobs/test-images-linux-client.yml
+    - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
       parameters:
         name: Linux_amd64
         pool: ${{ parameters.linuxAmd64Pool }}
@@ -205,7 +206,7 @@ stages:
         testJobTimeout: ${{ parameters.linuxAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-linux-client.yml
+    - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
       parameters:
         name: Linux_arm64
         pool: ${{ parameters.linuxArm64Pool }}
@@ -213,7 +214,7 @@ stages:
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-linux-client.yml
+    - template: /eng/common/templates/jobs/test-images-linux-client.yml@self
       parameters:
         name: Linux_arm32
         pool: ${{ parameters.linuxArm32Pool }}
@@ -221,7 +222,7 @@ stages:
         testJobTimeout: ${{ parameters.linuxArmTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-windows-client.yml
+    - template: /eng/common/templates/jobs/test-images-windows-client.yml@self
       parameters:
         name: Windows1809_amd64
         pool: ${{ parameters.windows1809Pool }}
@@ -229,7 +230,7 @@ stages:
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-windows-client.yml
+    - template: /eng/common/templates/jobs/test-images-windows-client.yml@self
       parameters:
         name: Windows2022_amd64
         pool: ${{ parameters.windows2022Pool }}
@@ -237,7 +238,7 @@ stages:
         testJobTimeout: ${{ parameters.windowsAmdTestJobTimeout }}
         internalProjectName: ${{ parameters.internalProjectName }}
         customInitSteps: ${{ parameters.customTestInitSteps }}
-    - template: ../jobs/test-images-windows-client.yml
+    - template: /eng/common/templates/jobs/test-images-windows-client.yml@self
       parameters:
         name: WindowsLtsc2016_amd64
         pool: ${{ parameters.windows2016Pool }}
@@ -284,7 +285,7 @@ stages:
               contains(variables['stages'], 'build'),
               contains(variables['stages'], 'test'))))))"
   jobs:
-  - template: ../jobs/publish.yml
+  - template: /eng/common/templates/jobs/publish.yml@self
     parameters:
       pool: ${{ parameters.linuxAmd64Pool }}
       internalProjectName: ${{ parameters.internalProjectName }}

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -100,19 +100,15 @@ stages:
         image: Server2016-NESDockerBuilds-PT
 
     # Windows Server 2019 (1809)
-    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-      windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-      windows1809Pool:
-        name: NetCore1ESPool-Internal
-        image: 1es-windows-2019
-        os: windows
+    windows1809Pool:
+      os: windows
+      name: Docker-1809-${{ variables['System.TeamProject'] }}
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        image: Server2019-1809-NESDockerBuilds-1ESPT
 
     # Windows Server 2022
-    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
-      windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
-    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
-      windows2022Pool:
-        name: NetCore1ESPool-Internal
-        image: 1es-windows-2022
-        os: windows
+    windows2022Pool:
+      os: windows
+      name: Docker-2022-${{ variables['System.TeamProject'] }}
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        image: Server2022-NESDockerBuilds-1ESPT

--- a/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
+++ b/eng/common/templates/stages/dotnet/build-test-publish-repo.yml
@@ -19,7 +19,7 @@ parameters:
   testMatrixType: platformVersionedOs
 
 stages:
-- template: ../build-test-publish-repo.yml
+- template: /eng/common/templates/stages/build-test-publish-repo.yml@self
   parameters:
     noCache: ${{ parameters.noCache }}
     internalProjectName: ${{ parameters.internalProjectName }}
@@ -56,11 +56,12 @@ stages:
 
     internalVersionsRepoRef: InternalVersionsRepo
     publicVersionsRepoRef: PublicVersionsRepo
-    
+
     ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
       customPublishVariables:
       - group: DotNet-AllOrgs-Darc-Pats
 
+    # Linux AMD64
     linuxAmd64Pool:
       ${{ if ne(parameters.linuxAmd64Pool, '') }}:
         ${{ parameters.linuxAmd64Pool }}
@@ -68,18 +69,50 @@ stages:
         vmImage: $(defaultLinuxAmd64PoolImage)
       ${{ elseif eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-    
+        image: 1es-ubuntu-2204
+        os: linux
+
+    # Linux Arm64
     linuxArm64Pool:
+      os: linux
+      hostArchitecture: Arm64
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         name: Docker-Linux-Arm-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        image: Mariner-2-Docker-ARM64
         name: Docker-Linux-Arm-Internal
+
+    # Linux Arm32
     linuxArm32Pool:
+      os: linux
+      hostArchitecture: Arm64
       ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
         name: Docker-Linux-Arm-Public
       ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        image: Mariner-2-Docker-ARM64
         name: Docker-Linux-Arm-Internal
-    windows2016Pool: Docker-2016-${{ variables['System.TeamProject'] }}
-    windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
-    windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+
+    # Windows Server 2016
+    windows2016Pool:
+      os: windows
+      name: Docker-2016-${{ variables['System.TeamProject'] }}
+      ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+        image: Server2016-NESDockerBuilds-PT
+
+    # Windows Server 2019 (1809)
+    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+      windows1809Pool: Docker-1809-${{ variables['System.TeamProject'] }}
+    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+      windows1809Pool:
+        name: NetCore1ESPool-Internal
+        image: 1es-windows-2019
+        os: windows
+
+    # Windows Server 2022
+    ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+      windows2022Pool: Docker-2022-${{ variables['System.TeamProject'] }}
+    ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+      windows2022Pool:
+        name: NetCore1ESPool-Internal
+        image: 1es-windows-2022
+        os: windows

--- a/eng/common/templates/steps/copy-base-images.yml
+++ b/eng/common/templates/steps/copy-base-images.yml
@@ -2,10 +2,10 @@ parameters:
   additionalOptions: null
   publicProjectName: null
   continueOnError: false
-  
+
 steps:
 - ${{ if or(eq(variables['System.TeamProject'], parameters.publicProjectName), eq(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: ../steps/set-dry-run.yml
+  - template: /eng/common/templates/steps/set-dry-run.yml@self
 - script: >
     $(runImageBuilderCmd)
     copyBaseImages

--- a/eng/common/templates/steps/init-docker-linux.yml
+++ b/eng/common/templates/steps/init-docker-linux.yml
@@ -1,11 +1,11 @@
 parameters:
   setupImageBuilder: true
   setupTestRunner: false
-  cleanupDocker: true
+  cleanupDocker: false
   condition: true
 
 steps:
-- template: init-common.yml
+- template: /eng/common/templates/steps/init-common.yml@self
   parameters:
     condition: ${{ parameters.condition }}
 - script: echo "##vso[task.setvariable variable=artifactsPath]/artifacts"
@@ -16,7 +16,7 @@ steps:
   # Cleanup Docker Resources
   ################################################################################
 - ${{ if eq(parameters.cleanupDocker, 'true') }}:
-  - template: cleanup-docker-linux.yml
+  - template: /eng/common/templates/steps/cleanup-docker-linux.yml@self
     parameters:
       condition: ${{ parameters.condition }}
 

--- a/eng/common/templates/steps/init-docker-windows.yml
+++ b/eng/common/templates/steps/init-docker-windows.yml
@@ -3,7 +3,7 @@ parameters:
   condition: true
 
 steps:
-- template: init-common.yml
+- template: /eng/common/templates/steps/init-common.yml@self
   parameters:
     condition: ${{ parameters.condition }}
 - powershell: echo "##vso[task.setvariable variable=artifactsPath]$(Build.ArtifactStagingDirectory)"
@@ -13,7 +13,7 @@ steps:
   ################################################################################
   # Cleanup Docker Resources
   ################################################################################
-- template: cleanup-docker-windows.yml
+- template: /eng/common/templates/steps/cleanup-docker-windows.yml@self
   parameters:
     condition: ${{ parameters.condition }}
 

--- a/eng/common/templates/steps/publish-artifact.yml
+++ b/eng/common/templates/steps/publish-artifact.yml
@@ -1,0 +1,28 @@
+parameters:
+- name: path
+  type: string
+- name: artifactName
+  type: string
+- name: displayName
+  type: string
+- name: internalProjectName
+  type: string
+- name: publicProjectName
+  type: string
+- name: condition
+  type: string
+  default: 'true'
+
+steps:
+- ${{ if eq(variables['System.TeamProject'], parameters.internalProjectName) }}:
+  - task: 1ES.PublishPipelineArtifact@1
+    inputs:
+      path: ${{ parameters.path }}
+      artifact: ${{ parameters.artifactName }}
+    displayName: ${{ parameters.displayName }}
+    condition: and(succeeded(), ${{ parameters.condition }})
+- ${{ if eq(variables['System.TeamProject'], parameters.publicProjectName) }}:
+  - publish: ${{ parameters.path }}
+    artifact: ${{ parameters.artifactName }}
+    displayName: ${{ parameters.displayName }}
+    condition: and(succeeded(), ${{ parameters.condition }})

--- a/eng/common/templates/steps/publish-readmes.yml
+++ b/eng/common/templates/steps/publish-readmes.yml
@@ -22,7 +22,7 @@ steps:
   name: PublishReadmes
   displayName: Publish Readmes
   condition: ${{ parameters.condition }}
-- template: wait-for-mcr-doc-ingestion.yml
+- template: /eng/common/templates/steps/wait-for-mcr-doc-ingestion.yml@self
   parameters:
     commitDigest: $(PublishReadmes.readmeCommitDigest)
     condition: and(${{ parameters.condition }}, ne(variables['PublishReadmes.readmeCommitDigest'], ''))

--- a/eng/common/templates/steps/set-dry-run.yml
+++ b/eng/common/templates/steps/set-dry-run.yml
@@ -1,12 +1,11 @@
 steps:
 - powershell: |
-      # Use dry-run option for certain publish operations if this is not a production build
-      $dryRunArg=""
-      if (-not "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)") `
-          -or "$(System.TeamProject)" -eq "$(publicProjectName)")
-      {
-        $dryRunArg=" --dry-run"
-      }
-      
-      echo "##vso[task.setvariable variable=dryRunArg]$dryRunArg"
+    # Use dry-run option for certain publish operations if this is not a production build
+    $dryRunArg=""
+    if (-not "$(officialRepoPrefixes)".Split(',').Contains("$(publishRepoPrefix)") `
+        -or "$(System.TeamProject)" -eq "$(publicProjectName)")
+    {
+      $dryRunArg=" --dry-run"
+    }
+    echo "##vso[task.setvariable variable=dryRunArg]$dryRunArg"
   displayName: Set dry-run arg for non-prod

--- a/eng/common/templates/steps/test-images-linux-client.yml
+++ b/eng/common/templates/steps/test-images-linux-client.yml
@@ -5,11 +5,13 @@ parameters:
   customInitSteps: []
 
 steps:
-- template: init-docker-linux.yml
+- template: /eng/common/templates/steps/init-docker-linux.yml@self
   parameters:
     setupImageBuilder: false
     setupTestRunner: true
-    cleanupDocker: ${{ and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}
+    # Clean only up when we're running an internal build, not a PR, and not doing pre-build validation.
+    # i.e. when we're building something important.
+    cleanupDocker: ${{ and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.preBuildValidation, 'false')) }}
     condition: ${{ parameters.condition }}
 - ${{ parameters.customInitSteps }}
 - script: |
@@ -47,12 +49,12 @@ steps:
     displayName: Docker login
     condition: and(succeeded(), ${{ parameters.condition }})
   - ${{ if eq(parameters.preBuildValidation, 'false') }}:
-    - template: ../steps/download-build-artifact.yml
+    - template: /eng/common/templates/steps/download-build-artifact.yml@self
       parameters:
         targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: image-info
         condition: ${{ parameters.condition }}
-- template: parse-test-arg-arrays.yml
+- template: /eng/common/templates/steps/parse-test-arg-arrays.yml@self
 - powershell: >
     $(test.init);
     docker exec
@@ -71,16 +73,21 @@ steps:
     displayName: Docker logout
     condition: and(always(), ${{ parameters.condition }})
     continueOnError: true
-- script: >
-    docker cp
-    $(testRunner.container):/repo/$(testResultsDirectory)
-    $(Common.TestResultsDirectory)/.
+- powershell: |
+    $hasTestResults = Test-Path $(Common.TestResultsDirectory)/$(testResultsDirectory)
+    echo "##vso[task.setvariable variable=hasTestResults]$hasTestResults"
+    if ($hasTestResults) {
+      docker cp $(testRunner.container):/repo/$(testResultsDirectory) $(Common.TestResultsDirectory)/.
+    }
+    else {
+      echo "There were no test outputs in $(Common.TestResultsDirectory)/$(testResultsDirectory). Skipping test result publishing."
+    }
   displayName: Copy Test Results
   condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
 - task: PublishTestResults@2
   displayName: Publish Test Results
-  condition: and(always(), ${{ parameters.condition }})
+  condition: and(always(), ${{ parameters.condition }}, eq(variables['hasTestResults'], 'True'))
   continueOnError: true
   inputs:
     testRunner: vSTest
@@ -96,7 +103,3 @@ steps:
   displayName: Cleanup TestRunner Container
   condition: and(always(), ${{ parameters.condition }})
   continueOnError: true
-- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: cleanup-docker-linux.yml
-    parameters:
-      condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/test-images-windows-client.yml
+++ b/eng/common/templates/steps/test-images-windows-client.yml
@@ -5,8 +5,9 @@ parameters:
 
 steps:
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: init-docker-windows.yml
+  - template: /eng/common/templates/steps/init-docker-windows.yml@self
     parameters:
+      cleanupDocker: true
       setupImageBuilder: false
       condition: ${{ parameters.condition }}
   - powershell: >
@@ -18,7 +19,7 @@ steps:
 - powershell: |
     if ("${{ variables['System.TeamProject'] }}" -eq "${{ parameters.internalProjectName }}" -and "${{ variables['Build.Reason'] }}" -ne "PullRequest") {
       $optionalTestArgs="$optionalTestArgs -PullImages -Registry $env:ACR_SERVER -RepoPrefix $env:STAGINGREPOPREFIX -ImageInfoPath $(artifactsPath)/image-info.json"
-    } 
+    }
     if ($env:REPOTESTARGS) {
       $optionalTestArgs += " $env:REPOTESTARGS"
     }
@@ -29,12 +30,12 @@ steps:
   displayName: Cleanup Old Test Results
   condition: and(succeeded(), ${{ parameters.condition }})
 - ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: ../steps/download-build-artifact.yml
+  - template: /eng/common/templates/steps/download-build-artifact.yml@self
     parameters:
       targetPath: $(Build.ArtifactStagingDirectory)
       artifactName: image-info
       condition: ${{ parameters.condition }}
-- template: parse-test-arg-arrays.yml
+- template: /eng/common/templates/steps/parse-test-arg-arrays.yml@self
 - powershell: >
     $(test.init);
     $(testScriptPath)
@@ -58,7 +59,3 @@ steps:
     mergeTestResults: true
     publishRunAttachments: true
     testRunTitle: $(productVersion) $(osVersionsDisplayName) amd64
-- ${{ if and(eq(variables['System.TeamProject'], parameters.internalProjectName), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: cleanup-docker-windows.yml
-    parameters:
-      condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/validate-image-sizes.yml
+++ b/eng/common/templates/steps/validate-image-sizes.yml
@@ -2,13 +2,15 @@ parameters:
   dockerClientOS: null
   architecture: "*"
   validationMode: "all"
-  
+
 steps:
   - template: ${{ format('../steps/init-docker-{0}.yml', parameters.dockerClientOS) }}
+    parameters:
+      # Get some disk space back, pipeline run time is not a concern here
+      cleanupDocker: true
   - powershell: >
       ./tests/performance/Validate-ImageSize.ps1
       -ImageBuilderCustomArgs "--architecture '${{ parameters.architecture }}'"
       -ValidationMode:${{ parameters.validationMode }}
       -PullImages
     displayName: Run Image Size Tests
-  - template: ${{ format('../steps/cleanup-docker-{0}.yml', parameters.dockerClientOS) }}

--- a/eng/common/templates/variables/common.yml
+++ b/eng/common/templates/variables/common.yml
@@ -1,6 +1,6 @@
 variables:
-- template: docker-images.yml
-- template: common-paths.yml
+- template: /eng/common/templates/variables/docker-images.yml@self
+- template: /eng/common/templates/variables/common-paths.yml@self
 - name: stagingRepoPrefix
   value: build-staging/$(sourceBuildId)/
 - name: publishReadme
@@ -9,8 +9,10 @@ variables:
   value: true
 - name: ingestKustoImageInfo
   value: true
+  # CG is disabled by default because projects are built within Dockerfiles and CG step do not scan artifacts
+  # that are built within Dockerfiles. A separate CG pipeline exists for this reason.
 - name: skipComponentGovernanceDetection
-  value: true
+  value: false
 - name: build.imageBuilderDockerRunExtraOptions
   value: ""
 - name: imageBuilderDockerRunExtraOptions

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2388008
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2405989
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner

--- a/eng/common/templates/variables/dotnet/build-test-publish.yml
+++ b/eng/common/templates/variables/dotnet/build-test-publish.yml
@@ -1,7 +1,7 @@
 # Common variables for building/testing/publishing in the .NET team's pipelines
 
 variables:
-- template: common.yml
+- template: /eng/common/templates/variables/dotnet/common.yml@self
 
 - name: commonVersionsImageInfoPath
   value: build-info/docker

--- a/eng/common/templates/variables/dotnet/common.yml
+++ b/eng/common/templates/variables/dotnet/common.yml
@@ -1,5 +1,5 @@
 variables:
-- template: ../common.yml
+- template: /eng/common/templates/variables/common.yml@self
 - name: publicProjectName
   value: public
 - name: internalProjectName

--- a/eng/pipelines/dotnet-framework-samples.yml
+++ b/eng/pipelines/dotnet-framework-samples.yml
@@ -3,22 +3,37 @@ pr: none
 
 resources:
   repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    ref: refs/tags/release
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
   - repository: InternalVersionsRepo
     type: github
     endpoint: dotnet
     name: dotnet/versions
 
 variables:
-- template: variables/common.yml
+- template: /eng/pipelines/variables/common.yml@self
 - name: manifest
   value: manifest.samples.json
 - name: imageInfoVariant
   value: "-samples"
 
-stages:
-- template: ../common/templates/stages/dotnet/build-test-publish-repo.yml
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    internalProjectName: ${{ variables.internalProjectName }}
-    publicProjectName: ${{ variables.publicProjectName }}
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build
+    sdl:
+      sourceRepositoriesToScan:
+        include:
+        - repository: InternalVersionsRepo
+    pool:
+      name: NetCore1ESPool-Internal
+      image: 1es-windows-2022
+      os: windows
+    stages:
+    - template: /eng/common/templates/stages/dotnet/build-test-publish-repo.yml@self
+      parameters:
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          buildMatrixCustomBuildLegGroupArgs: --custom-build-leg-group pr-build

--- a/eng/pipelines/dotnet-framework.yml
+++ b/eng/pipelines/dotnet-framework.yml
@@ -3,22 +3,37 @@ pr: none
 
 resources:
   repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    ref: refs/tags/release
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
   - repository: InternalVersionsRepo
     type: github
     endpoint: dotnet
     name: dotnet/versions
 
 variables:
-- template: variables/common.yml
+- template: /eng/pipelines/variables/common.yml@self
 - name: manifest
   value: manifest.json
 - name: mcrImageIngestionTimeout
   value: "00:30:00"
 
-stages:
-- template: ../common/templates/stages/dotnet/build-test-publish-repo.yml
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    internalProjectName: ${{ variables.internalProjectName }}
-    publicProjectName: ${{ variables.publicProjectName }}
-    windowsAmdBuildJobTimeout: 240
-    windowsAmdTestJobTimeout: 90
+    sdl:
+      sourceRepositoriesToScan:
+        include:
+        - repository: InternalVersionsRepo
+    pool:
+      name: NetCore1ESPool-Internal
+      image: 1es-windows-2022
+      os: windows
+    stages:
+    - template: /eng/common/templates/stages/dotnet/build-test-publish-repo.yml@self
+      parameters:
+        internalProjectName: ${{ variables.internalProjectName }}
+        publicProjectName: ${{ variables.publicProjectName }}
+        windowsAmdBuildJobTimeout: 240
+        windowsAmdTestJobTimeout: 90


### PR DESCRIPTION
This PR contains changes from https://github.com/microsoft/dotnet-framework-docker/pull/1112

Part of https://github.com/dotnet/dotnet-docker-internal/issues/4475

Server 2016 images have pipeline templates support now. This is a draft PR since validation is still running but I am fairly confident in the changes. I will submit a follow-up PR to docker-tools for the eng/common changes once validation is successful.

2016 test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2409603&view=results
2019 & 2022 test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2409701&view=results

Samples test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2409869&view=results