### PR TITLE
Remove eol 7.0 runtime and add missing 8.0 runtime

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -55,7 +55,6 @@ RUN `
         --add Microsoft.Component.ClickOnce.MSBuild @^ `
         --add Microsoft.Net.Component.{{sdkVersion}}.SDK @^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 @^ `
-        --add Microsoft.NetCore.Component.Runtime.7.0 @^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 @^ `
         --add Microsoft.NetCore.Component.SDK @^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools @^ `

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -78,7 +78,7 @@ RUN `
         --add Microsoft.Component.ClickOnce.MSBuild @^ `
         --add Microsoft.Net.Component.4.8.SDK @^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 @^ `
-        --add Microsoft.NetCore.Component.Runtime.7.0 @^ `
+        --add Microsoft.NetCore.Component.Runtime.8.0 @^ `
         --add Microsoft.NetCore.Component.SDK @^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools @^ `
         --add Microsoft.VisualStudio.Component.WebDeploy @^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -77,7 +77,7 @@ RUN `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
-        --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -50,7 +50,6 @@ RUN `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
-        --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -33,7 +33,6 @@ RUN `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
-        --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `

--- a/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -33,7 +33,6 @@ RUN `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.1.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
-        --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -45,7 +45,7 @@ RUN `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
-        --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -31,7 +31,6 @@ RUN `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
-        --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -33,7 +33,6 @@ RUN `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
-        --add Microsoft.NetCore.Component.Runtime.7.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker/issues/5336.

When making these changes I discovered the ltsc2016 sdk images were missing the 8.0 runtime so I added it.