### PR TITLE
Add Markdown linter GH action

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/markdownlint-problem-matcher.json
+++ b/.github/ISSUE_TEMPLATE/workflows/markdownlint-problem-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "markdownlint",
+            "pattern": [
+                {
+                    "regexp": "^([^:]*):(\\d+):?(\\d+)?\\s([\\w-\\/]*)\\s(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "code": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/ISSUE_TEMPLATE/workflows/markdownlint.yml
+++ b/.github/ISSUE_TEMPLATE/workflows/markdownlint.yml
@@ -1,0 +1,29 @@
+name: markdownlint
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "**/.markdownlint.json"
+      - ".github/workflows/markdownlint.yml"
+      - ".github/workflows/markdownlint-problem-matcher.json"
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Run Markdownlint
+      run: |
+        echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
+        npm i -g markdownlint-cli
+        markdownlint "**/*.md" -i "eng/readme-templates/*" -i "eng/common/*"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,16 @@
+{
+    "default": true,
+    "MD013": false, // line length
+
+    // The following rules are disabled to allow the linter to be enabled.
+    // Follow-up work will be done to enable these rules and clean up the violations.
+    "MD009": false, // no-trailing-spaces Trailing spaces
+    "MD022": false, // blanks-around-headings Headings should be surrounded by blank lines
+    "MD025": false, // single-title/single-h1 Multiple top-level headings in the same document
+    "MD031": false, // blanks-around-fences Fenced code blocks should be surrounded by blank lines
+    "MD034": false, // no-bare-urls Bare URL used
+    "MD040": false, // fenced-code-language Fenced code blocks should have a language specified
+    "MD041": false, // first-line-heading/first-line-h1 First line in a file should be a top-level heading
+    "MD047": false, // single-trailing-newline Files should end with a single newline character
+    "MD056": false, // table-column-count Table column count
+}


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker/issues/5316

This initial set of changes just adds the linter action but disables numerous rules. Once enabled I will open follow-up PRs to address the syntax violations.

The linter action was copied from [dotnet/runtime](https://github.com/dotnet/runtime/blob/main/.github/workflows/markdownlint.yml).