### PR TITLE
Fix markdown syntax violations

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,10 +1,4 @@
 {
     "default": true,
     "MD013": false, // line length
-
-    // The following rules are disabled to allow the linter to be enabled.
-    // Follow-up work will be done to enable these rules and clean up the violations.
-    "MD022": false, // blanks-around-headings Headings should be surrounded by blank lines
-    "MD025": false, // single-title/single-h1 Multiple top-level headings in the same document
-    "MD034": false, // no-bare-urls Bare URL used
 }

--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -25,6 +25,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
 ## Container sample: Run an ASP.NET application
+
 You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-samples/), based on the [ASP.NET Docker sample].
 
 Type the following [Docker](https://www.docker.com/products/docker) command:

--- a/.portal-docs/docker-hub/README.aspnet.md
+++ b/.portal-docs/docker-hub/README.aspnet.md
@@ -53,6 +53,7 @@ Version Tag | OS Version | Supported .NET Versions
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/runtime](https://hub.docker.com/r/microsoft/dotnet-framework-runtime/): .NET Framework Runtime
 * [dotnet/framework/wcf](https://hub.docker.com/r/microsoft/dotnet-framework-wcf/): Windows Communication Foundation (WCF)
@@ -61,7 +62,6 @@ Version Tag | OS Version | Supported .NET Versions
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 # Full Tag Listing

--- a/.portal-docs/docker-hub/README.runtime.md
+++ b/.portal-docs/docker-hub/README.runtime.md
@@ -45,6 +45,7 @@ Version Tag | OS Version | Supported .NET Versions
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
 * [dotnet/framework/wcf](https://hub.docker.com/r/microsoft/dotnet-framework-wcf/): Windows Communication Foundation (WCF)
@@ -53,7 +54,6 @@ Version Tag | OS Version | Supported .NET Versions
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 # Full Tag Listing

--- a/.portal-docs/docker-hub/README.samples.md
+++ b/.portal-docs/docker-hub/README.samples.md
@@ -62,6 +62,7 @@ docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 mcr.microsoft
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://hub.docker.com/r/microsoft/dotnet-framework-runtime/): .NET Framework Runtime
@@ -70,7 +71,6 @@ docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 mcr.microsoft
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 # Full Tag Listing

--- a/.portal-docs/docker-hub/README.sdk.md
+++ b/.portal-docs/docker-hub/README.sdk.md
@@ -53,6 +53,7 @@ Version Tag | OS Version | Supported .NET Versions
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/aspnet](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://hub.docker.com/r/microsoft/dotnet-framework-runtime/): .NET Framework Runtime
 * [dotnet/framework/wcf](https://hub.docker.com/r/microsoft/dotnet-framework-wcf/): Windows Communication Foundation (WCF)
@@ -61,7 +62,6 @@ Version Tag | OS Version | Supported .NET Versions
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 # Full Tag Listing

--- a/.portal-docs/docker-hub/README.wcf.md
+++ b/.portal-docs/docker-hub/README.wcf.md
@@ -52,6 +52,7 @@ Version Tag | OS Version | Supported .NET Versions
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://hub.docker.com/r/microsoft/dotnet-framework-runtime/): .NET Framework Runtime
@@ -60,7 +61,6 @@ Version Tag | OS Version | Supported .NET Versions
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
 # Full Tag Listing

--- a/.portal-docs/docker-hub/README.wcf.md
+++ b/.portal-docs/docker-hub/README.wcf.md
@@ -16,6 +16,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
 ## Container sample: Run a WCF application
+
 You can quickly run a container with a pre-built [sample WCF Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-samples/), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -24,6 +24,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework/): .NET Framework
 * [dotnet/framework/sdk](https://mcr.microsoft.com/product/dotnet/framework/sdk/about/): .NET Framework SDK
 * [dotnet/framework/runtime](https://mcr.microsoft.com/product/dotnet/framework/runtime/about/): .NET Framework Runtime
 * [dotnet/framework/wcf](https://mcr.microsoft.com/product/dotnet/framework/wcf/about/): Windows Communication Foundation (WCF)
@@ -32,7 +33,6 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
-* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about/): .NET Samples
 
 ## Usage

--- a/.portal-docs/mar/README.aspnet.portal.md
+++ b/.portal-docs/mar/README.aspnet.portal.md
@@ -40,6 +40,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
 ### Container sample: Run an ASP.NET application
+
 You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://mcr.microsoft.com/product/dotnet/framework/samples/about/), based on the [ASP.NET Docker sample].
 
 Type the following [Docker](https://www.docker.com/products/docker) command:

--- a/.portal-docs/mar/README.runtime.portal.md
+++ b/.portal-docs/mar/README.runtime.portal.md
@@ -17,6 +17,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework/): .NET Framework
 * [dotnet/framework/sdk](https://mcr.microsoft.com/product/dotnet/framework/sdk/about/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://mcr.microsoft.com/product/dotnet/framework/aspnet/about/): ASP.NET Web Forms and MVC
 * [dotnet/framework/wcf](https://mcr.microsoft.com/product/dotnet/framework/wcf/about/): Windows Communication Foundation (WCF)
@@ -25,7 +26,6 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
-* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about/): .NET Samples
 
 ## Usage

--- a/.portal-docs/mar/README.samples.portal.md
+++ b/.portal-docs/mar/README.samples.portal.md
@@ -19,6 +19,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework/): .NET Framework
 * [dotnet/framework/sdk](https://mcr.microsoft.com/product/dotnet/framework/sdk/about/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://mcr.microsoft.com/product/dotnet/framework/aspnet/about/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://mcr.microsoft.com/product/dotnet/framework/runtime/about/): .NET Framework Runtime
@@ -27,7 +28,6 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
-* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about/): .NET Samples
 
 ## Usage

--- a/.portal-docs/mar/README.sdk.portal.md
+++ b/.portal-docs/mar/README.sdk.portal.md
@@ -26,6 +26,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework/): .NET Framework
 * [dotnet/framework/aspnet](https://mcr.microsoft.com/product/dotnet/framework/aspnet/about/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://mcr.microsoft.com/product/dotnet/framework/runtime/about/): .NET Framework Runtime
 * [dotnet/framework/wcf](https://mcr.microsoft.com/product/dotnet/framework/wcf/about/): Windows Communication Foundation (WCF)
@@ -34,7 +35,6 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
-* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about/): .NET Samples
 
 ## Usage

--- a/.portal-docs/mar/README.wcf.portal.md
+++ b/.portal-docs/mar/README.wcf.portal.md
@@ -31,6 +31,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
 ### Container sample: Run a WCF application
+
 You can quickly run a container with a pre-built [sample WCF Docker image](https://mcr.microsoft.com/product/dotnet/framework/samples/about/), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:

--- a/.portal-docs/mar/README.wcf.portal.md
+++ b/.portal-docs/mar/README.wcf.portal.md
@@ -15,6 +15,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 
 .NET Framework:
 
+* [dotnet/framework](https://mcr.microsoft.com/catalog?search=dotnet/framework/): .NET Framework
 * [dotnet/framework/sdk](https://mcr.microsoft.com/product/dotnet/framework/sdk/about/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://mcr.microsoft.com/product/dotnet/framework/aspnet/about/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://mcr.microsoft.com/product/dotnet/framework/runtime/about/): .NET Framework Runtime
@@ -23,7 +24,6 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 .NET:
 
 * [dotnet](https://mcr.microsoft.com/catalog?search=dotnet/): .NET
-* [dotnet-nightly](https://mcr.microsoft.com/catalog?search=dotnet/nightly/): .NET (Preview)
 * [dotnet/samples](https://mcr.microsoft.com/product/dotnet/samples/about/): .NET Samples
 
 ## Usage

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -1,4 +1,6 @@
-# Featured tags
+# ASP.NET Web Forms and MVC
+
+## Featured tags
 
 * `4.8.1`
   * `docker pull mcr.microsoft.com/dotnet/framework/aspnet:4.8.1`
@@ -7,7 +9,7 @@
 * `3.5`
   * `docker pull mcr.microsoft.com/dotnet/framework/aspnet:3.5`
 
-# About
+## About
 
 ASP.NET is a high productivity framework for building Web Applications using Web Forms, MVC, Web API and SignalR.
 
@@ -20,11 +22,11 @@ This image contains:
 
 Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# Usage
+## Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Container sample: Run an ASP.NET application
+### Container sample: Run an ASP.NET application
 You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-samples/), based on the [ASP.NET Docker sample].
 
 Type the following [Docker](https://www.docker.com/products/docker) command:
@@ -35,7 +37,7 @@ docker run --name aspnet_sample --rm -it -p 8000:80 mcr.microsoft.com/dotnet/fra
 
 After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).
 
-## Version Compatibility
+### Version Compatibility
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
@@ -49,10 +51,11 @@ Version Tag | OS Version | Supported .NET Versions
 3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
 3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
 
-# Related repositories
+## Related repositories
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/runtime](https://hub.docker.com/r/microsoft/dotnet-framework-runtime/): .NET Framework Runtime
 * [dotnet/framework/wcf](https://hub.docker.com/r/microsoft/dotnet-framework-wcf/): Windows Communication Foundation (WCF)
@@ -61,26 +64,28 @@ Version Tag | OS Version | Supported .NET Versions
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
-# Full Tag Listing
+## Full Tag Listing
 
-## Windows Server Core 2022 amd64 Tags
+### Windows Server Core 2022 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8.1-20240709-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/4.8.1/windowsservercore-ltsc2022/Dockerfile)
 4.8-20240709-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/4.8/windowsservercore-ltsc2022/Dockerfile)
 3.5-20240709-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/3.5/windowsservercore-ltsc2022/Dockerfile)
 
-## Windows Server Core 2019 amd64 Tags
+### Windows Server Core 2019 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8-20240709-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile)
 4.7.2-20240709-windowsservercore-ltsc2019, 4.7.2-windowsservercore-ltsc2019, 4.7.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile)
 3.5-20240709-windowsservercore-ltsc2019, 3.5-windowsservercore-ltsc2019, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/3.5/windowsservercore-ltsc2019/Dockerfile)
 
-## Windows Server Core 2016 amd64 Tags
+### Windows Server Core 2016 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8-20240709-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile)
@@ -89,30 +94,29 @@ Tag | Dockerfile
 4.7-20240709-windowsservercore-ltsc2016, 4.7-windowsservercore-ltsc2016, 4.7 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile)
 4.6.2-20240709-windowsservercore-ltsc2016, 4.6.2-windowsservercore-ltsc2016, 4.6.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile)
 3.5-20240709-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/aspnet/3.5/windowsservercore-ltsc2016/Dockerfile)
-
-You can retrieve a list of all available tags for dotnet/framework/aspnet at https://mcr.microsoft.com/v2/dotnet/framework/aspnet/tags/list.
 <!--End of generated tags-->
 
-*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/framework/aspnet/tags/list) for all supported and unsupported tags.*
 
-# Support
+## Support
 
-## Lifecycle
+### Lifecycle
 
 * [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
 * [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
 
-## Image Update Policy
+### Image Update Policy
 
 * We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:ltsc2019, windows/servercore:ltsc2022, etc.).
 * We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
 
-## Feedback
+### Feedback
 
 * [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
-# License
+## License
 
 * [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)
 * [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/r/microsoft/windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)

--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -27,6 +27,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
 ### Container sample: Run an ASP.NET application
+
 You can quickly run a container with a pre-built [sample ASP.NET Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-samples/), based on the [ASP.NET Docker sample].
 
 Type the following [Docker](https://www.docker.com/products/docker) command:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET Framework
 
-# Featured Repos
+## Featured Repos
 
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
@@ -18,7 +18,7 @@ You can use C#, F# and VB to write .NET Framework apps. C# is simple, powerful, 
 
 The .NET Framework was first released by Microsoft in 2001. The latest version is [.NET Framework 4.8](https://www.microsoft.com/net/framework).
 
-> https://docs.microsoft.com/dotnet/framework/
+> [.NET Framework Documentation](https://docs.microsoft.com/dotnet/framework/)
 
 Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# .NET Framework
+
 # Featured Repos
 
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
@@ -6,7 +8,7 @@
 * [dotnet/framework/wcf](https://hub.docker.com/r/microsoft/dotnet-framework-wcf/): Windows Communication Foundation (WCF)
 * [dotnet/framework/samples](https://hub.docker.com/r/microsoft/dotnet-framework-samples/): .NET Framework, ASP.NET and WCF Samples
 
-# About
+## About
 
 The [.NET Framework](https://www.microsoft.com/net/framework) is a general purpose development platform maintained by Microsoft. It is the most popular way to build client and server applications for Windows and Windows Server. It is included with Windows, Windows Server and Windows Server Core. It includes server technologies such as ASP.NET Web Forms, ASP.NET MVC and Windows Communication Foundation (WCF) applications, which you can run in Docker containers.
 
@@ -20,11 +22,11 @@ The .NET Framework was first released by Microsoft in 2001. The latest version i
 
 Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# Usage
+## Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Container sample: Run a simple application
+### Container sample: Run a simple application
 
 Type the following command to run a sample console application:
 
@@ -32,7 +34,7 @@ Type the following command to run a sample console application:
 docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ```
 
-## Container sample: Run a web application
+### Container sample: Run a web application
 
 Type the following command to run a sample web application:
 
@@ -42,30 +44,30 @@ docker run -it --rm -p 8000:80 --name aspnet_sample mcr.microsoft.com/dotnet/fra
 
 After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).
 
-# Related repositories
+## Related repositories
+
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
-# Support
+## Support
 
-## Lifecycle
+### Lifecycle
 
 * [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
 * [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
 
-## Image Update Policy
+### Image Update Policy
 
 * We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:ltsc2019, windows/servercore:ltsc2022, etc.).
 * We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
 
-## Feedback
+### Feedback
 
 * [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
-# License
+## License
 
 * [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)
 * [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/r/microsoft/windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ After the application starts, navigate to `http://localhost:8000` in your web br
 
 ## Related repositories
 
-
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -1,4 +1,6 @@
-# Featured tags
+# .NET Framework Runtime
+
+## Featured tags
 
 * `4.8.1`
   * `docker pull mcr.microsoft.com/dotnet/framework/runtime:4.8.1`
@@ -7,17 +9,17 @@
 * `3.5`
   * `docker pull mcr.microsoft.com/dotnet/framework/runtime:3.5`
 
-# About
+## About
 
 This image contains the .NET Framework runtimes and libraries and is optimized for running .NET Framework apps in production.
 
 Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# Usage
+## Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Container sample: Run a simple application
+### Container sample: Run a simple application
 
 You can quickly run a container with a pre-built [.NET Framework Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-samples/), based on the [.NET Framework console sample](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/README.md).
 
@@ -27,7 +29,7 @@ Type the following command to run a sample console application:
 docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ```
 
-## Version Compatibility
+### Version Compatibility
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
@@ -41,10 +43,11 @@ Version Tag | OS Version | Supported .NET Versions
 3.5 | windowsservercore-ltsc2019 | 4.7.2, 3.5, 3.0, 2.5
 3.5 | windowsservercore-ltsc2016 | 4.6.2, 3.5, 3.0, 2.5
 
-# Related repositories
+## Related repositories
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
 * [dotnet/framework/wcf](https://hub.docker.com/r/microsoft/dotnet-framework-wcf/): Windows Communication Foundation (WCF)
@@ -53,26 +56,28 @@ Version Tag | OS Version | Supported .NET Versions
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
-# Full Tag Listing
+## Full Tag Listing
 
-## Windows Server Core 2022 amd64 Tags
+### Windows Server Core 2022 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8.1-20240709-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/4.8.1/windowsservercore-ltsc2022/Dockerfile)
 4.8-20240709-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/4.8/windowsservercore-ltsc2022/Dockerfile)
 3.5-20240709-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/3.5/windowsservercore-ltsc2022/Dockerfile)
 
-## Windows Server Core 2019 amd64 Tags
+### Windows Server Core 2019 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8-20240709-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile)
 4.7.2-20240709-windowsservercore-ltsc2019, 4.7.2-windowsservercore-ltsc2019, 4.7.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/4.7.2/windowsservercore-ltsc2019/Dockerfile)
 3.5-20240709-windowsservercore-ltsc2019, 3.5-windowsservercore-ltsc2019, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile)
 
-## Windows Server Core 2016 amd64 Tags
+### Windows Server Core 2016 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8-20240709-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/4.8/windowsservercore-ltsc2016/Dockerfile)
@@ -81,30 +86,29 @@ Tag | Dockerfile
 4.7-20240709-windowsservercore-ltsc2016, 4.7-windowsservercore-ltsc2016, 4.7 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/4.7/windowsservercore-ltsc2016/Dockerfile)
 4.6.2-20240709-windowsservercore-ltsc2016, 4.6.2-windowsservercore-ltsc2016, 4.6.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/4.6.2/windowsservercore-ltsc2016/Dockerfile)
 3.5-20240709-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile)
-
-You can retrieve a list of all available tags for dotnet/framework/runtime at https://mcr.microsoft.com/v2/dotnet/framework/runtime/tags/list.
 <!--End of generated tags-->
 
-*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/framework/runtime/tags/list) for all supported and unsupported tags.*
 
-# Support
+## Support
 
-## Lifecycle
+### Lifecycle
 
 * [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
 * [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
 
-## Image Update Policy
+### Image Update Policy
 
 * We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:ltsc2019, windows/servercore:ltsc2022, etc.).
 * We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
 
-## Feedback
+### Feedback
 
 * [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
-# License
+## License
 
 * [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)
 * [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/r/microsoft/windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)

--- a/README.samples.md
+++ b/README.samples.md
@@ -1,4 +1,6 @@
-# Featured tags
+# .NET Framework, ASP.NET and WCF Samples
+
+## Featured tags
 
 * `dotnetapp`
   * `docker pull mcr.microsoft.com/dotnet/framework/samples:dotnetapp`
@@ -9,17 +11,17 @@
 * `wcfclient`
   * `docker pull mcr.microsoft.com/dotnet/framework/samples:wcfclient`
 
-# About
+## About
 
 These images contain sample .NET Framework, ASP.NET and WCF applications.
 
 Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# Usage
+## Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Container sample: Run a simple application
+### Container sample: Run a simple application
 
 Type the following command to run a sample console application with Docker:
 
@@ -27,7 +29,7 @@ Type the following command to run a sample console application with Docker:
 docker run --rm mcr.microsoft.com/dotnet/framework/samples:dotnetapp
 ```
 
-## Container sample: Run a web application
+### Container sample: Run a web application
 
 Type the following command to run a sample web application with Docker:
 
@@ -37,7 +39,7 @@ docker run -it --rm -p 8000:80 --name aspnet_sample mcr.microsoft.com/dotnet/fra
 
 After the application starts, navigate to `http://localhost:8000` in your web browser. You need to navigate to the application via IP address instead of `localhost` for earlier Windows versions, which is demonstrated in [View the ASP.NET app in a running container on Windows](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/README.md#view-the-aspnet-app-in-a-running-container-on-windows).
 
-## Container sample: Run WCF service and client applications
+### Container sample: Run WCF service and client applications
 
 Type the following command to run a sample WCF service application with Docker:
 
@@ -58,10 +60,11 @@ Type the following Docker command to start a WCF client container, set environme
 docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 mcr.microsoft.com/dotnet/framework/samples:wcfclient
 ```
 
-# Related repositories
+## Related repositories
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://hub.docker.com/r/microsoft/dotnet-framework-runtime/): .NET Framework Runtime
@@ -70,12 +73,12 @@ docker run --name wcfclient_sample --rm -it -e HOST=172.26.236.119 mcr.microsoft
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
-# Full Tag Listing
+## Full Tag Listing
 
-## Windows Server Core 2022 amd64 Tags
+### Windows Server Core 2022 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 dotnetapp-windowsservercore-ltsc2022, dotnetapp, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/Dockerfile)
@@ -83,7 +86,8 @@ aspnetapp-windowsservercore-ltsc2022, aspnetapp | [Dockerfile](https://github.co
 wcfservice-windowsservercore-ltsc2022, wcfservice | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/wcfapp/Dockerfile.web)
 wcfclient-windowsservercore-ltsc2022, wcfclient | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/wcfapp/Dockerfile.client)
 
-## Windows Server Core 2019 amd64 Tags
+### Windows Server Core 2019 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 dotnetapp-windowsservercore-ltsc2019, dotnetapp, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/Dockerfile)
@@ -91,37 +95,37 @@ aspnetapp-windowsservercore-ltsc2019, aspnetapp | [Dockerfile](https://github.co
 wcfservice-windowsservercore-ltsc2019, wcfservice | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/wcfapp/Dockerfile.web)
 wcfclient-windowsservercore-ltsc2019, wcfclient | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/wcfapp/Dockerfile.client)
 
-## Windows Server Core 2016 amd64 Tags
+### Windows Server Core 2016 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 dotnetapp-windowsservercore-ltsc2016, dotnetapp, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/dotnetapp/Dockerfile)
 aspnetapp-windowsservercore-ltsc2016, aspnetapp | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/aspnetapp/Dockerfile)
 wcfservice-windowsservercore-ltsc2016, wcfservice | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/wcfapp/Dockerfile.web)
 wcfclient-windowsservercore-ltsc2016, wcfclient | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/wcfapp/Dockerfile.client)
-
-You can retrieve a list of all available tags for dotnet/framework/samples at https://mcr.microsoft.com/v2/dotnet/framework/samples/tags/list.
 <!--End of generated tags-->
 
-*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/framework/samples/tags/list) for all supported and unsupported tags.*
 
-# Support
+## Support
 
-## Lifecycle
+### Lifecycle
 
 * [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
 * [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
 
-## Image Update Policy
+### Image Update Policy
 
 * We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:ltsc2019, windows/servercore:ltsc2022, etc.).
 * We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
 
-## Feedback
+### Feedback
 
 * [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
-# License
+## License
 
 * [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)
 * [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/r/microsoft/windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -1,4 +1,6 @@
-# Featured tags
+# .NET Framework SDK
+
+## Featured tags
 
 * `4.8.1`
   * `docker pull mcr.microsoft.com/dotnet/framework/sdk:4.8.1`
@@ -7,7 +9,7 @@
 * `3.5`
   * `docker pull mcr.microsoft.com/dotnet/framework/sdk:3.5`
 
-# About
+## About
 
 This image contains the .NET Framework SDK which is comprised of the following parts:
 
@@ -22,18 +24,18 @@ Use this image for your development process (developing, building and testing ap
 
 Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# Usage
+## Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Building .NET Framework Apps with Docker
+### Building .NET Framework Apps with Docker
 
 * [.NET Framework Console Docker Sample](dotnetapp/README.md) - This [sample](dotnetapp/Dockerfile) builds, tests, and runs the sample. It includes and builds multiple projects.
 * [ASP.NET Web Forms Docker Sample](aspnetapp/README.md) - This [sample](aspnetapp/Dockerfile) demonstrates using Docker with an ASP.NET Web Forms app.
 * [ASP.NET MVC Docker Sample](aspnetmvcapp/README.md) - This [sample](aspnetmvcapp/Dockerfile) demonstrates using Docker with an ASP.NET MVC app.
 * [WCF Docker Sample](wcfapp/README.md) - This [sample](wcfapp/) demonstrates using Docker with a WCF app.
 
-## Version Compatibility
+### Version Compatibility
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
@@ -49,10 +51,11 @@ Version Tag | OS Version | Supported .NET Versions
 
 \* The 4.8 and 4.8.1 SDKs are also capable of building 4.8.1, 4.8, 4.7.2, 4.7.1, 4.7, and 4.6.2 projects.
 
-# Related repositories
+## Related repositories
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/aspnet](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://hub.docker.com/r/microsoft/dotnet-framework-runtime/): .NET Framework Runtime
 * [dotnet/framework/wcf](https://hub.docker.com/r/microsoft/dotnet-framework-wcf/): Windows Communication Foundation (WCF)
@@ -61,53 +64,54 @@ Version Tag | OS Version | Supported .NET Versions
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
-# Full Tag Listing
+## Full Tag Listing
 
-## Windows Server Core 2022 amd64 Tags
+### Windows Server Core 2022 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8.1-20240709-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile)
 4.8-20240709-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile)
 3.5-20240709-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile)
 
-## Windows Server Core 2019 amd64 Tags
+### Windows Server Core 2019 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8-20240709-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile)
 3.5-20240709-windowsservercore-ltsc2019, 3.5-windowsservercore-ltsc2019, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile)
 
-## Windows Server Core 2016 amd64 Tags
+### Windows Server Core 2016 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8-20240709-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile)
 3.5-20240709-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile)
-
-You can retrieve a list of all available tags for dotnet/framework/sdk at https://mcr.microsoft.com/v2/dotnet/framework/sdk/tags/list.
 <!--End of generated tags-->
 
-*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/framework/sdk/tags/list) for all supported and unsupported tags.*
 
-# Support
+## Support
 
-## Lifecycle
+### Lifecycle
 
 * [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
 * [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
 
-## Image Update Policy
+### Image Update Policy
 
 * We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:ltsc2019, windows/servercore:ltsc2022, etc.).
 * We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
 
-## Feedback
+### Feedback
 
 * [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
-# License
+## License
 
 * [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)
 * [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/r/microsoft/windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -18,6 +18,7 @@ Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discuss
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
 ### Container sample: Run a WCF application
+
 You can quickly run a container with a pre-built [sample WCF Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-samples/), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -1,21 +1,23 @@
-# Featured tags
+# Windows Communication Foundation (WCF)
+
+## Featured tags
 
 * `4.8.1`
   * `docker pull mcr.microsoft.com/dotnet/framework/wcf:4.8.1`
 * `4.8`
   * `docker pull mcr.microsoft.com/dotnet/framework/wcf:4.8`
 
-# About
+## About
 
 The Windows Communication Foundation (WCF) is a framework for building service-oriented applications. Using WCF, you can send data as asynchronous messages from one service endpoint to another. A service endpoint can be part of a continuously available service hosted by IIS, or it can be a service hosted in an application.
 
 Watch [discussions](https://github.com/microsoft/dotnet-framework-docker/discussions/categories/announcements) for Docker-related .NET announcements.
 
-# Usage
+## Usage
 
 The [.NET Framework Docker samples](https://github.com/microsoft/dotnet-framework-docker/blob/main/samples/README.md) show various ways to use .NET Framework and Docker together.
 
-## Container sample: Run a WCF application
+### Container sample: Run a WCF application
 You can quickly run a container with a pre-built [sample WCF Docker image](https://hub.docker.com/r/microsoft/dotnet-framework-samples/), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:
@@ -37,7 +39,7 @@ Type the following Docker command to start a WCF client container, set environme
 docker run --name wcfclientsample --rm -it -e HOST=172.26.236.119 mcr.microsoft.com/dotnet/framework/samples:wcfclient
 ```
 
-## Version Compatibility
+### Version Compatibility
 
 Version Tag | OS Version | Supported .NET Versions
 -- | -- | --
@@ -48,10 +50,11 @@ Version Tag | OS Version | Supported .NET Versions
 4.7 | windowsservercore-ltsc2016 | 4.7
 4.6.2 | windowsservercore-ltsc2016 | 4.6.2
 
-# Related repositories
+## Related repositories
 
 .NET Framework:
 
+* [dotnet/framework](https://hub.docker.com/r/microsoft/dotnet-framework/): .NET Framework
 * [dotnet/framework/sdk](https://hub.docker.com/r/microsoft/dotnet-framework-sdk/): .NET Framework SDK
 * [dotnet/framework/aspnet](https://hub.docker.com/r/microsoft/dotnet-framework-aspnet/): ASP.NET Web Forms and MVC
 * [dotnet/framework/runtime](https://hub.docker.com/r/microsoft/dotnet-framework-runtime/): .NET Framework Runtime
@@ -60,24 +63,26 @@ Version Tag | OS Version | Supported .NET Versions
 .NET:
 
 * [dotnet](https://hub.docker.com/r/microsoft/dotnet/): .NET
-* [dotnet-nightly](https://hub.docker.com/r/microsoft/dotnet-nightly/): .NET (Preview)
 * [dotnet/samples](https://hub.docker.com/r/microsoft/dotnet-samples/): .NET Samples
 
-# Full Tag Listing
+## Full Tag Listing
 
-## Windows Server Core 2022 amd64 Tags
+### Windows Server Core 2022 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8.1-20240709-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.8.1/windowsservercore-ltsc2022/Dockerfile)
 4.8-20240709-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.8/windowsservercore-ltsc2022/Dockerfile)
 
-## Windows Server Core 2019 amd64 Tags
+### Windows Server Core 2019 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8-20240709-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.8/windowsservercore-ltsc2019/Dockerfile)
 4.7.2-20240709-windowsservercore-ltsc2019, 4.7.2-windowsservercore-ltsc2019, 4.7.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.7.2/windowsservercore-ltsc2019/Dockerfile)
 
-## Windows Server Core 2016 amd64 Tags
+### Windows Server Core 2016 amd64 Tags
+
 Tag | Dockerfile
 ---------| ---------------
 4.8-20240709-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.8/windowsservercore-ltsc2016/Dockerfile)
@@ -85,30 +90,29 @@ Tag | Dockerfile
 4.7.1-20240709-windowsservercore-ltsc2016, 4.7.1-windowsservercore-ltsc2016, 4.7.1 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.7.1/windowsservercore-ltsc2016/Dockerfile)
 4.7-20240709-windowsservercore-ltsc2016, 4.7-windowsservercore-ltsc2016, 4.7 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.7/windowsservercore-ltsc2016/Dockerfile)
 4.6.2-20240709-windowsservercore-ltsc2016, 4.6.2-windowsservercore-ltsc2016, 4.6.2 | [Dockerfile](https://github.com/microsoft/dotnet-framework-docker/blob/main/src/wcf/4.6.2/windowsservercore-ltsc2016/Dockerfile)
-
-You can retrieve a list of all available tags for dotnet/framework/wcf at https://mcr.microsoft.com/v2/dotnet/framework/wcf/tags/list.
 <!--End of generated tags-->
 
-*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+See the [full list of tags](https://mcr.microsoft.com/v2/dotnet/framework/wcf/tags/list) for all supported and unsupported tags.*
 
-# Support
+## Support
 
-## Lifecycle
+### Lifecycle
 
 * [.NET Framework Lifecycle FAQ](https://support.microsoft.com/help/17455/lifecycle-faq-net-framework)
 * [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md)
 
-## Image Update Policy
+### Image Update Policy
 
 * We update the supported .NET Framework images within 12 hours of any updates to their base images (e.g. windows/servercore:ltsc2019, windows/servercore:ltsc2022, etc.).
 * We publish .NET Framework images as part of releasing new versions of .NET Framework including major/minor and servicing.
 
-## Feedback
+### Feedback
 
 * [File an issue](https://github.com/microsoft/dotnet-framework-docker/issues/new/choose)
 * [Contact Microsoft Support](https://support.microsoft.com/contactus/)
 
-# License
+## License
 
 * [Microsoft Container Images Legal Notice](https://aka.ms/mcr/osslegalnotice): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)
 * [Microsoft Software Supplemental License for Windows Container Base Image](https://hub.docker.com/r/microsoft/windows-servercore/): applies to all [.NET Framework container images](https://hub.docker.com/r/microsoft/dotnet-framework/)

--- a/eng/common/templates/variables/docker-images.yml
+++ b/eng/common/templates/variables/docker-images.yml
@@ -1,5 +1,5 @@
 variables:
-  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2508988
+  imageNames.imageBuilderName: mcr.microsoft.com/dotnet-buildtools/image-builder:2511639
   imageNames.imageBuilder: $(imageNames.imageBuilderName)
   imageNames.imageBuilder.withrepo: imagebuilder-withrepo:$(Build.BuildId)-$(System.JobId)
   imageNames.testRunner: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner2.0-docker-testrunner

--- a/eng/readme-templates/About.product-family.md
+++ b/eng/readme-templates/About.product-family.md
@@ -6,4 +6,4 @@ You can use C#, F# and VB to write .NET Framework apps. C# is simple, powerful, 
 
 The .NET Framework was first released by Microsoft in 2001. The latest version is [.NET Framework 4.8](https://www.microsoft.com/net/framework).
 
-> https://docs.microsoft.com/dotnet/framework/
+> [.NET Framework Documentation](https://docs.microsoft.com/dotnet/framework/)

--- a/eng/readme-templates/DefaultLayout.md
+++ b/eng/readme-templates/DefaultLayout.md
@@ -1,8 +1,13 @@
 {{
   set commonArgs to [
-    "top-header": "#",
+    "top-header": ARGS["top-header"]
     "readme-host": ARGS["readme-host"]
-  ]
+  ] ^
+
+  set insertReposListTemplate(template) to:{{
+    return InsertTemplate("ReposProvider.md", union([ "template": template ], commonArgs))
+  }}
+
 }}{{if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
 ^else:# Featured Repos
 
@@ -16,11 +21,12 @@
 
 {{InsertTemplate("Use.md", commonArgs)}}
 
-{{InsertTemplate("RelatedRepos.md", commonArgs)}}
+{{insertReposListTemplate("RelatedRepos.md")}}
 {{if !IS_PRODUCT_FAMILY:
-# Full Tag Listing
+{{ARGS["top-header"]}} Full Tag Listing
 {{if ARGS["readme-host"] = "github":<!--End of generated tags-->
-*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/microsoft/dotnet-framework-docker/blob/main/documentation/supported-tags.md).*
+*Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).
+See the [full list of tags](https://mcr.microsoft.com/v2/{{REPO}}/tags/list) for all supported and unsupported tags.*
 ^elif ARGS["readme-host"] = "dockerhub":
 View the current tags at the [Microsoft Artifact Registry portal](https://mcr.microsoft.com/product/{{REPO}}/tags) or on [GitHub](https://github.com/microsoft/dotnet-framework-docker/blob/main/README.{{SHORT_REPO}}.md#full-tag-listing).
 }}}}

--- a/eng/readme-templates/DefaultLayout.md
+++ b/eng/readme-templates/DefaultLayout.md
@@ -9,7 +9,7 @@
   }}
 
 }}{{if !IS_PRODUCT_FAMILY:{{InsertTemplate("FeaturedTags.md", commonArgs)}}
-^else:# Featured Repos
+^else:{{ARGS["top-header"]}} Featured Repos
 
 * [dotnet/framework/sdk]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/framework/sdk" ])}}): .NET Framework SDK
 * [dotnet/framework/aspnet]({{InsertTemplate("Url.md", [ "readme-host": "github", "repo": "dotnet/framework/aspnet" ])}}): ASP.NET Web Forms and MVC

--- a/eng/readme-templates/GitHub.header.md
+++ b/eng/readme-templates/GitHub.header.md
@@ -1,0 +1,17 @@
+{{
+    _ ARGS:
+      product-repos: List of .NET product repos
+      product-family-repos: List of .NET product family repos
+      samples-repos: List of .NET samples repos ^
+
+    set repos to cat(ARGS["product-repos"], ARGS["samples-repos"]) ^
+
+    set isCurrentRepo(repo) to:{{
+        set repoNameParts to split(repo[0], "/") ^
+        set shortRepo to repoNameParts[len(repoNameParts) - 1] ^
+        return shortRepo = SHORT_REPO
+    }} ^
+
+    set currentRepo to when(IS_PRODUCT_FAMILY, ARGS["product-family-repos"], cat(filter(repos, isCurrentRepo)))
+
+}}# {{currentRepo[0][1]}}

--- a/eng/readme-templates/README.dockerhub.md
+++ b/eng/readme-templates/README.dockerhub.md
@@ -1,1 +1,1 @@
-{{InsertTemplate("DefaultLayout.md", ["readme-host": "dockerhub"])}}
+{{InsertTemplate("DefaultLayout.md", ["top-header": "#", "readme-host": "dockerhub"])}}

--- a/eng/readme-templates/README.github.md
+++ b/eng/readme-templates/README.github.md
@@ -1,1 +1,3 @@
-{{InsertTemplate("DefaultLayout.md", ["readme-host": "github"])}}
+{{InsertTemplate("ReposProvider.md", ["template": "GitHub.header.md"])}}
+
+{{InsertTemplate("DefaultLayout.md", ["top-header": "##", "readme-host": "github"])}}

--- a/eng/readme-templates/README.mcr.md
+++ b/eng/readme-templates/README.mcr.md
@@ -4,7 +4,7 @@
 
 {{InsertTemplate("FeaturedTags.md", commonArgs)}}
 
-{{InsertTemplate("RelatedRepos.md", commonArgs)}}
+{{InsertTemplate("ReposProvider.md", union([ "template": "RelatedRepos.md" ], commonArgs))}}
 
 {{InsertTemplate("Use.md", commonArgs)}}
 

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -1,24 +1,42 @@
 {{
     _ ARGS:
       top-header: The string to use as the top-level header.
-      readme-host: Moniker of the site that will host the readme
+      readme-host: Moniker of the site that will host the readmes
+      product-repos: List of .NET product repos
+      product-family-repos: List of .NET product family repos
+      samples-repos: List of .NET samples repos
+      dotnet-repos: List of .NET Framework repos ^
+
+    set repos to ARGS["product-repos"] ^
+    set productFamilyRepos to ARGS["product-family-repos"] ^
+    set samplesRepos to ARGS["samples-repos"] ^
+    set dotnetRepos to ARGS["dotnet-repos"] ^
+
+    _ Common functions to help with repo rendering ^
+
+    set isCurrentRepo(repo) to:{{
+        set repoNameParts to split(repo[0], "/") ^
+        set shortRepo to repoNameParts[len(repoNameParts) - 1] ^
+        return shortRepo = SHORT_REPO
+    }} ^
+
+    set isNotCurrentRepo(repo) to:{{
+        return not(isCurrentRepo(repo))
+    }} ^
+
+    _ Create final set of repos to display ^
+
+    set currentRepo to cat(filter(repos, isCurrentRepo)) ^
+
+    set repos to cat(productFamilyRepos, repos, samplesRepos) ^
+
+    _ Exclude this repo from its own readme ^
+    set repos to filter(repos, isNotCurrentRepo)
+
 }}{{ARGS["top-header"]}} Related repositories
 {{if !IS_PRODUCT_FAMILY:
 .NET Framework:
+{{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": repos ])}}
 
-{{if SHORT_REPO != "sdk"
-    :* [dotnet/framework/sdk]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/sdk" ])}}): .NET Framework SDK
-}}{{if SHORT_REPO != "aspnet"
-    :* [dotnet/framework/aspnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/aspnet" ])}}): ASP.NET Web Forms and MVC
-}}{{if SHORT_REPO != "runtime"
-    :* [dotnet/framework/runtime]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/runtime" ])}}): .NET Framework Runtime
-}}{{if SHORT_REPO != "wcf"
-    :* [dotnet/framework/wcf]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/wcf" ])}}): Windows Communication Foundation (WCF)
-}}{{if SHORT_REPO != "samples"
-    :* [dotnet/framework/samples]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/samples" ])}}): .NET Framework, ASP.NET and WCF Samples
-}}
-.NET:
-}}
-* [dotnet]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet", "is-product-family": "true" ])}}): .NET
-* [dotnet-nightly]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/nightly", "is-product-family": "true" ])}}): .NET (Preview)
-* [dotnet/samples]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/samples" ])}}): .NET Samples
+.NET:}}
+{{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": dotnetRepos ])}}

--- a/eng/readme-templates/RelatedRepos.md
+++ b/eng/readme-templates/RelatedRepos.md
@@ -38,5 +38,5 @@
 .NET Framework:
 {{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": repos ])}}
 
-.NET:}}
-{{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": dotnetRepos ])}}
+.NET:
+}}{{InsertTemplate("RepoList.md", [ "readme-host": ARGS["readme-host"], "repos": dotnetRepos ])}}

--- a/eng/readme-templates/RepoList.md
+++ b/eng/readme-templates/RepoList.md
@@ -1,0 +1,15 @@
+{{
+    _ ARGS:
+      readme-host: Moniker of the site that will host the readme
+      repos: List of repos to render, in the format [repoName, displayName, isProductFamilyRepo] ^
+
+    set getRepoBulletPoint(repo) to:{{
+        set repoName to repo[0] ^
+        set displayName to repo[1] ^
+        set isProductFamilyRepo to repo[2] ^
+        set url to InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": repoName, "is-product-family": isProductFamilyRepo ]) ^
+        return join(["* [", repoName, "](", url, "): ", displayName])
+    }}
+
+}}{{ARGS["top-header"]}}{{for r in ARGS["repos"]:
+{{getRepoBulletPoint(r)}}}}

--- a/eng/readme-templates/ReposProvider.md
+++ b/eng/readme-templates/ReposProvider.md
@@ -1,0 +1,33 @@
+{{
+    _ Wrapper template for providing the list of repos to other templates.
+
+    _ ARGS:
+      top-header: The string to use as the top-level header.
+      readme-host: Moniker of the site that will host the readme
+      template: Template to pass the repo lists to ^
+
+    set productRepos to [
+        ["dotnet/framework/sdk", ".NET Framework SDK"],
+        ["dotnet/framework/aspnet", "ASP.NET Web Forms and MVC"],
+        ["dotnet/framework/runtime", ".NET Framework Runtime"],
+        ["dotnet/framework/wcf", "Windows Communication Foundation (WCF)"]
+    ] ^
+    set productFamilyRepos to [
+        ["dotnet/framework", ".NET Framework", 1]
+    ] ^
+    set samplesRepos to [
+        ["dotnet/framework/samples", ".NET Framework, ASP.NET and WCF Samples"]
+    ] ^
+    set dotnetRepos to [
+        ["dotnet", ".NET", 1],
+        ["dotnet/samples", ".NET Samples"]
+    ]
+
+}}{{InsertTemplate(ARGS["template"], [
+    "top-header": ARGS["top-header"],
+    "readme-host": ARGS["readme-host"],
+    "product-repos": productRepos,
+    "product-family-repos": productFamilyRepos,
+    "samples-repos": samplesRepos,
+    "dotnet-repos": dotnetRepos
+])}}

--- a/eng/readme-templates/Use.aspnet.md
+++ b/eng/readme-templates/Use.aspnet.md
@@ -3,6 +3,7 @@
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run an ASP.NET application
+
 You can quickly run a container with a pre-built [sample ASP.NET Docker image]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/samples" ])}}), based on the [ASP.NET Docker sample].
 
 Type the following [Docker](https://www.docker.com/products/docker) command:

--- a/eng/readme-templates/Use.wcf.md
+++ b/eng/readme-templates/Use.wcf.md
@@ -3,6 +3,7 @@
       top-header: The string to use as the top-level header.
       readme-host: Moniker of the site that will host the readme
 }}{{ARGS["top-header"]}}# Container sample: Run a WCF application
+
 You can quickly run a container with a pre-built [sample WCF Docker image]({{InsertTemplate("Url.md", [ "readme-host": ARGS["readme-host"], "repo": "dotnet/framework/samples" ])}}), based on the WCF Docker sample.
 
 Type the following [Docker](https://www.docker.com/products/docker) command to start a WCF service container:


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet-docker/issues/5316

This PR is the last part of a series of changes to address various markdown syntax violations.

1. I ported the ReposProvider readme template infra from dotnet-docker to eliminate duplication that would otherwise exist with these changes.
2. I discovered we were referencing a dead link to a dotnet-nightly product family repo that doesn't exist.  I removed the dotnet-nightly related repos section of the readmes
3. To be consistent with dotnet-docker I added the product family to the related repos section of the readmes.