### PR TITLE
Add .NET 9 to SDK images

### DIFF
--- a/README.sdk.md
+++ b/README.sdk.md
@@ -72,23 +72,23 @@ Version Tag | OS Version | Supported .NET Versions
 
 Tag | Dockerfile
 ---------| ---------------
-4.8.1-20241008-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile)
-4.8-20241008-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile)
-3.5-20241008-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile)
+4.8.1-20241112-windowsservercore-ltsc2022, 4.8.1-windowsservercore-ltsc2022, 4.8.1 | [Dockerfile](src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile)
+4.8-20241112-windowsservercore-ltsc2022, 4.8-windowsservercore-ltsc2022, 4.8, latest | [Dockerfile](src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile)
+3.5-20241112-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, 3.5 | [Dockerfile](src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile)
 
 ### Windows Server Core 2019 amd64 Tags
 
 Tag | Dockerfile
 ---------| ---------------
-4.8-20241008-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile)
-3.5-20241008-windowsservercore-ltsc2019, 3.5-windowsservercore-ltsc2019, 3.5 | [Dockerfile](src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile)
+4.8-20241112-windowsservercore-ltsc2019, 4.8-windowsservercore-ltsc2019, 4.8, latest | [Dockerfile](src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile)
+3.5-20241112-windowsservercore-ltsc2019, 3.5-windowsservercore-ltsc2019, 3.5 | [Dockerfile](src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile)
 
 ### Windows Server Core 2016 amd64 Tags
 
 Tag | Dockerfile
 ---------| ---------------
-4.8-20241008-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile)
-3.5-20241008-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile)
+4.8-20241112-windowsservercore-ltsc2016, 4.8-windowsservercore-ltsc2016, 4.8, latest | [Dockerfile](src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile)
+3.5-20241112-windowsservercore-ltsc2016, 3.5-windowsservercore-ltsc2016, 3.5 | [Dockerfile](src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile)
 <!--End of generated tags-->
 
 *Tags not listed in the table above are not supported. See the [Supported Tags Policy](https://github.com/dotnet/dotnet-docker/blob/main/documentation/supported-tags.md).

--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -56,6 +56,7 @@ RUN `
         --add Microsoft.Net.Component.{{sdkVersion}}.SDK @^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 @^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 @^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 @^ `
         --add Microsoft.NetCore.Component.SDK @^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools @^ `
         --add Microsoft.VisualStudio.Component.WebDeploy @^ `

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -79,6 +79,7 @@ RUN `
         --add Microsoft.Net.Component.4.8.SDK @^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 @^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 @^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 @^ `
         --add Microsoft.NetCore.Component.SDK @^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools @^ `
         --add Microsoft.VisualStudio.Component.WebDeploy @^ `

--- a/manifest.datestamps.json
+++ b/manifest.datestamps.json
@@ -1,10 +1,11 @@
 {
     "variables": {
-      "CurrentReleaseDateStamp": "20241008",
+      "CurrentReleaseDateStamp": "20241112",
+      "PreviousReleaseDateStamp": "20241008",
 
-      "RuntimeReleaseDateStamp": "$(CurrentReleaseDateStamp)",
-      "AspnetReleaseDateStamp": "$(CurrentReleaseDateStamp)",
-      "WcfReleaseDateStamp": "$(CurrentReleaseDateStamp)",
+      "RuntimeReleaseDateStamp": "$(PreviousReleaseDateStamp)",
+      "AspnetReleaseDateStamp": "$(PreviousReleaseDateStamp)",
+      "WcfReleaseDateStamp": "$(PreviousReleaseDateStamp)",
       "SdkReleaseDateStamp": "$(CurrentReleaseDateStamp)",
 
       "3.5-ltsc2016-Runtime-DateStamp": "$(RuntimeReleaseDateStamp)",

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -78,6 +78,7 @@ RUN `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -51,6 +51,7 @@ RUN `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -34,6 +34,7 @@ RUN `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `

--- a/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -34,6 +34,7 @@ RUN `
         --add Microsoft.Net.Component.4.8.1.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -46,6 +46,7 @@ RUN `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -32,6 +32,7 @@ RUN `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -34,6 +34,7 @@ RUN `
         --add Microsoft.Net.Component.4.8.SDK ^ `
         --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
+        --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `
         --add Microsoft.VisualStudio.Component.NuGet.BuildTools ^ `
         --add Microsoft.VisualStudio.Component.WebDeploy ^ `


### PR DESCRIPTION
Fixes #1180. This should not be merged until .NET 9 is officially released.