### PR TITLE
Remove .NET 6 from SDK images

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -54,7 +54,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" @^ `
         --add Microsoft.Component.ClickOnce.MSBuild @^ `
         --add Microsoft.Net.Component.{{sdkVersion}}.SDK @^ `
-        --add Microsoft.NetCore.Component.Runtime.6.0 @^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 @^ `
         --add Microsoft.NetCore.Component.Runtime.9.0 @^ `
         --add Microsoft.NetCore.Component.SDK @^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -49,7 +49,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -32,7 +32,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -32,7 +32,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.1.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -30,7 +30,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -32,7 +32,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `


### PR DESCRIPTION
See https://github.com/dotnet/dotnet-docker/issues/6051#issuecomment-2474763943