### PR TITLE
Temporarily disable Server 2025 image publishing

### DIFF
--- a/README.aspnet.md
+++ b/README.aspnet.md
@@ -69,13 +69,6 @@ Version Tag | OS Version | Supported .NET Versions
 
 ## Full Tag Listing
 
-### Windows Server Core 2025 amd64 Tags
-
-Tag | Dockerfile
----------| ---------------
-4.8.1-20250211-windowsservercore-ltsc2025, 4.8.1-windowsservercore-ltsc2025, 4.8.1 | [Dockerfile](src/aspnet/4.8.1/windowsservercore-ltsc2025/Dockerfile)
-3.5-20250211-windowsservercore-ltsc2025, 3.5-windowsservercore-ltsc2025, 3.5 | [Dockerfile](src/aspnet/3.5/windowsservercore-ltsc2025/Dockerfile)
-
 ### Windows Server Core 2022 amd64 Tags
 
 Tag | Dockerfile

--- a/README.runtime.md
+++ b/README.runtime.md
@@ -60,13 +60,6 @@ Version Tag | OS Version | Supported .NET Versions
 
 ## Full Tag Listing
 
-### Windows Server Core 2025 amd64 Tags
-
-Tag | Dockerfile
----------| ---------------
-4.8.1-20250211-windowsservercore-ltsc2025, 4.8.1-windowsservercore-ltsc2025, 4.8.1 | [Dockerfile](src/runtime/4.8.1/windowsservercore-ltsc2025/Dockerfile)
-3.5-20250211-windowsservercore-ltsc2025, 3.5-windowsservercore-ltsc2025, 3.5 | [Dockerfile](src/runtime/3.5/windowsservercore-ltsc2025/Dockerfile)
-
 ### Windows Server Core 2022 amd64 Tags
 
 Tag | Dockerfile

--- a/README.sdk.md
+++ b/README.sdk.md
@@ -68,13 +68,6 @@ Version Tag | OS Version | Supported .NET Versions
 
 ## Full Tag Listing
 
-### Windows Server Core 2025 amd64 Tags
-
-Tag | Dockerfile
----------| ---------------
-4.8.1-20250211-windowsservercore-ltsc2025, 4.8.1-windowsservercore-ltsc2025, 4.8.1 | [Dockerfile](src/sdk/4.8.1/windowsservercore-ltsc2025/Dockerfile)
-3.5-20250211-windowsservercore-ltsc2025, 3.5-windowsservercore-ltsc2025, 3.5 | [Dockerfile](src/sdk/3.5/windowsservercore-ltsc2025/Dockerfile)
-
 ### Windows Server Core 2022 amd64 Tags
 
 Tag | Dockerfile

--- a/README.wcf.md
+++ b/README.wcf.md
@@ -68,12 +68,6 @@ Version Tag | OS Version | Supported .NET Versions
 
 ## Full Tag Listing
 
-### Windows Server Core 2025 amd64 Tags
-
-Tag | Dockerfile
----------| ---------------
-4.8.1-20250211-windowsservercore-ltsc2025, 4.8.1-windowsservercore-ltsc2025, 4.8.1 | [Dockerfile](src/wcf/4.8.1/windowsservercore-ltsc2025/Dockerfile)
-
 ### Windows Server Core 2022 amd64 Tags
 
 Tag | Dockerfile

--- a/eng/mcr-tags-metadata-templates/aspnet-tags.yml
+++ b/eng/mcr-tags-metadata-templates/aspnet-tags.yml
@@ -1,6 +1,4 @@
 $(McrTagsYmlRepo:aspnet)
-$(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2025)
-$(McrTagsYmlTagGroup:3.5-windowsservercore-ltsc2025)
 $(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:3.5-windowsservercore-ltsc2022)

--- a/eng/mcr-tags-metadata-templates/runtime-tags.yml
+++ b/eng/mcr-tags-metadata-templates/runtime-tags.yml
@@ -1,6 +1,4 @@
 $(McrTagsYmlRepo:runtime)
-$(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2025)
-$(McrTagsYmlTagGroup:3.5-windowsservercore-ltsc2025)
 $(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:3.5-windowsservercore-ltsc2022)

--- a/eng/mcr-tags-metadata-templates/sdk-tags.yml
+++ b/eng/mcr-tags-metadata-templates/sdk-tags.yml
@@ -1,6 +1,4 @@
 $(McrTagsYmlRepo:sdk)
-$(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2025)
-$(McrTagsYmlTagGroup:3.5-windowsservercore-ltsc2025)
 $(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:3.5-windowsservercore-ltsc2022)

--- a/eng/mcr-tags-metadata-templates/wcf-tags.yml
+++ b/eng/mcr-tags-metadata-templates/wcf-tags.yml
@@ -1,5 +1,4 @@
 $(McrTagsYmlRepo:wcf)
-$(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2025)
 $(McrTagsYmlTagGroup:4.8.1-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2022)
 $(McrTagsYmlTagGroup:4.8-windowsservercore-ltsc2019)

--- a/manifest.json
+++ b/manifest.json
@@ -43,16 +43,6 @@
                 "4.8.1-$(4.8.1-ltsc2022-Runtime-DateStamp)-windowsservercore-ltsc2022": {},
                 "4.8.1-windowsservercore-ltsc2022": {}
               }
-            },
-            {
-              "dockerfile": "src/runtime/4.8.1/windowsservercore-ltsc2025",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime/Dockerfile",
-              "os": "windows",
-              "osVersion": "windowsservercore-ltsc2025",
-              "tags": {
-                "4.8.1-$(4.8.1-ltsc2025-Runtime-DateStamp)-windowsservercore-ltsc2025": {},
-                "4.8.1-windowsservercore-ltsc2025": {}
-              }
             }
           ]
         },
@@ -265,16 +255,6 @@
                 "3.5-$(3.5-ltsc2022-Runtime-DateStamp)-windowsservercore-ltsc2022": {},
                 "3.5-windowsservercore-ltsc2022": {}
               }
-            },
-            {
-              "dockerfile": "src/runtime/3.5/windowsservercore-ltsc2025",
-              "dockerfileTemplate": "eng/dockerfile-templates/runtime/Dockerfile",
-              "os": "windows",
-              "osVersion": "windowsservercore-ltsc2025",
-              "tags": {
-                "3.5-$(3.5-ltsc2025-Runtime-DateStamp)-windowsservercore-ltsc2025": {},
-                "3.5-windowsservercore-ltsc2025": {}
-              }
             }
           ]
         }
@@ -316,19 +296,6 @@
               "tags": {
                 "4.8.1-$(4.8.1-ltsc2022-Sdk-DateStamp)-windowsservercore-ltsc2022": {},
                 "4.8.1-windowsservercore-ltsc2022": {}
-              }
-            },
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:runtime)"
-              },
-              "dockerfile": "src/sdk/4.8.1/windowsservercore-ltsc2025",
-              "dockerfileTemplate": "eng/dockerfile-templates/sdk/Dockerfile",
-              "os": "windows",
-              "osVersion": "windowsservercore-ltsc2025",
-              "tags": {
-                "4.8.1-$(4.8.1-ltsc2025-Sdk-DateStamp)-windowsservercore-ltsc2025": {},
-                "4.8.1-windowsservercore-ltsc2025": {}
               }
             }
           ]
@@ -428,19 +395,6 @@
                 "3.5-$(3.5-ltsc2022-Sdk-DateStamp)-windowsservercore-ltsc2022": {},
                 "3.5-windowsservercore-ltsc2022": {}
               }
-            },
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:runtime)"
-              },
-              "dockerfile": "src/sdk/3.5/windowsservercore-ltsc2025",
-              "dockerfileTemplate": "eng/dockerfile-templates/sdk/Dockerfile",
-              "os": "windows",
-              "osVersion": "windowsservercore-ltsc2025",
-              "tags": {
-                "3.5-$(3.5-ltsc2025-Sdk-DateStamp)-windowsservercore-ltsc2025": {},
-                "3.5-windowsservercore-ltsc2025": {}
-              }
             }
           ]
         }
@@ -482,19 +436,6 @@
               "tags": {
                 "4.8.1-$(4.8.1-ltsc2022-Aspnet-DateStamp)-windowsservercore-ltsc2022": {},
                 "4.8.1-windowsservercore-ltsc2022": {}
-              }
-            },
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:runtime)"
-              },
-              "dockerfile": "src/aspnet/4.8.1/windowsservercore-ltsc2025",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile",
-              "os": "windows",
-              "osVersion": "windowsservercore-ltsc2025",
-              "tags": {
-                "4.8.1-$(4.8.1-ltsc2025-Aspnet-DateStamp)-windowsservercore-ltsc2025": {},
-                "4.8.1-windowsservercore-ltsc2025": {}
               }
             }
           ]
@@ -691,19 +632,6 @@
                 "3.5-$(3.5-ltsc2022-Aspnet-DateStamp)-windowsservercore-ltsc2022": {},
                 "3.5-windowsservercore-ltsc2022": {}
               }
-            },
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:runtime)"
-              },
-              "dockerfile": "src/aspnet/3.5/windowsservercore-ltsc2025",
-              "dockerfileTemplate": "eng/dockerfile-templates/aspnet/Dockerfile",
-              "os": "windows",
-              "osVersion": "windowsservercore-ltsc2025",
-              "tags": {
-                "3.5-$(3.5-ltsc2025-Aspnet-DateStamp)-windowsservercore-ltsc2025": {},
-                "3.5-windowsservercore-ltsc2025": {}
-              }
             }
           ]
         }
@@ -745,19 +673,6 @@
               "tags": {
                 "4.8.1-$(4.8.1-ltsc2022-Wcf-DateStamp)-windowsservercore-ltsc2022": {},
                 "4.8.1-windowsservercore-ltsc2022": {}
-              }
-            },
-            {
-              "buildArgs": {
-                "REPO": "$(Repo:aspnet)"
-              },
-              "dockerfile": "src/wcf/4.8.1/windowsservercore-ltsc2025",
-              "dockerfileTemplate": "eng/dockerfile-templates/wcf/Dockerfile",
-              "os": "windows",
-              "osVersion": "windowsservercore-ltsc2025",
-              "tags": {
-                "4.8.1-$(4.8.1-ltsc2025-Wcf-DateStamp)-windowsservercore-ltsc2025": {},
-                "4.8.1-windowsservercore-ltsc2025": {}
               }
             }
           ]


### PR DESCRIPTION
There was an issue publishing the Server 2025 images. I will work out the issues and then re-add them later.