### PR TITLE
Remove .NET 6 SDK from Windows Server 2016 SDK images

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -48,22 +48,7 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_TestAgent.exe `
     `
-    # Install VS Build Tools
-    && curl -fSLo vs_BuildTools.exe {{VARIABLES["vs|buildToolsUrl"]}} `
-    && start /w vs_BuildTools @^ `
-        --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" @^ `
-        --add Microsoft.Component.ClickOnce.MSBuild @^ `
-        --add Microsoft.Net.Component.{{sdkVersion}}.SDK @^ `
-        --add Microsoft.NetCore.Component.Runtime.8.0 @^ `
-        --add Microsoft.NetCore.Component.Runtime.9.0 @^ `
-        --add Microsoft.NetCore.Component.SDK @^ `
-        --add Microsoft.VisualStudio.Component.NuGet.BuildTools @^ `
-        --add Microsoft.VisualStudio.Component.WebDeploy @^ `
-        --add Microsoft.VisualStudio.Web.BuildTools.ComponentGroup @^ `
-        --add Microsoft.VisualStudio.Workload.MSBuildTools @^ `
-        --quiet --norestart --nocache --wait `
-    && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
-    && del vs_BuildTools.exe `
+    {{InsertTemplate("Dockerfile.install-vs-buildtools", [], "    ")}}
     `
     # Trigger dotnet first run experience by running arbitrary cmd
     && "%ProgramFiles%\dotnet\dotnet" help `

--- a/eng/dockerfile-templates/sdk/Dockerfile.install-vs-buildtools
+++ b/eng/dockerfile-templates/sdk/Dockerfile.install-vs-buildtools
@@ -1,0 +1,32 @@
+{{
+
+    _ ARGS:
+        usePowerShell: whether to use PowerShell to download and remove files ^
+
+    set sdkVersion to when(PRODUCT_VERSION = "4.8.1", "4.8.1", "4.8")
+
+}}# Install VS Build Tools{{
+if ARGS.usePowerShell:
+&& powershell -Command `
+    $ProgressPreference = 'SilentlyContinue'; `
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
+    Invoke-WebRequest `
+        -UseBasicParsing `
+        -Uri {{VARIABLES["vs|buildToolsUrl"]}} `
+        -OutFile vs_BuildTools.exe `^
+else:
+&& curl -fSLo vs_BuildTools.exe {{VARIABLES["vs|buildToolsUrl"]}} `}}
+&& start /w vs_BuildTools @^ `
+    --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" @^ `
+    --add Microsoft.Component.ClickOnce.MSBuild @^ `
+    --add Microsoft.Net.Component.{{sdkVersion}}.SDK @^ `
+    --add Microsoft.NetCore.Component.Runtime.8.0 @^ `
+    --add Microsoft.NetCore.Component.Runtime.9.0 @^ `
+    --add Microsoft.NetCore.Component.SDK @^ `
+    --add Microsoft.VisualStudio.Component.NuGet.BuildTools @^ `
+    --add Microsoft.VisualStudio.Component.WebDeploy @^ `
+    --add Microsoft.VisualStudio.Web.BuildTools.ComponentGroup @^ `
+    --add Microsoft.VisualStudio.Workload.MSBuildTools @^ `
+    --quiet --norestart --nocache --wait `
+&& powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
+&& del vs_BuildTools.exe `

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -65,29 +65,7 @@ RUN `
     && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
     && del vs_TestAgent.exe `
     `
-    # Install VS Build Tools
-    && powershell -Command `
-        $ProgressPreference = 'SilentlyContinue'; `
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri {{VARIABLES["vs|buildToolsUrl"]}} `
-            -OutFile vs_BuildTools.exe `
-    && start /w vs_BuildTools @^ `
-        --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" @^ `
-        --add Microsoft.Component.ClickOnce.MSBuild @^ `
-        --add Microsoft.Net.Component.4.8.SDK @^ `
-        --add Microsoft.NetCore.Component.Runtime.6.0 @^ `
-        --add Microsoft.NetCore.Component.Runtime.8.0 @^ `
-        --add Microsoft.NetCore.Component.Runtime.9.0 @^ `
-        --add Microsoft.NetCore.Component.SDK @^ `
-        --add Microsoft.VisualStudio.Component.NuGet.BuildTools @^ `
-        --add Microsoft.VisualStudio.Component.WebDeploy @^ `
-        --add Microsoft.VisualStudio.Web.BuildTools.ComponentGroup @^ `
-        --add Microsoft.VisualStudio.Workload.MSBuildTools @^ `
-        --quiet --norestart --nocache --wait `
-    && powershell -Command "if ($err = dir $Env:TEMP -Filter dd_setup_*_errors.log | where Length -gt 0 | Get-Content) { throw $err }" `
-    && del vs_BuildTools.exe `
+    {{InsertTemplate("Dockerfile.install-vs-buildtools", [ "usePowerShell": "true" ], "    ")}}
     `
     # Trigger dotnet first run experience by running arbitrary cmd
     && "%ProgramFiles%\dotnet\dotnet" help `

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -76,7 +76,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -44,7 +44,6 @@ RUN `
         --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" ^ `
         --add Microsoft.Component.ClickOnce.MSBuild ^ `
         --add Microsoft.Net.Component.4.8.SDK ^ `
-        --add Microsoft.NetCore.Component.Runtime.6.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.8.0 ^ `
         --add Microsoft.NetCore.Component.Runtime.9.0 ^ `
         --add Microsoft.NetCore.Component.SDK ^ `


### PR DESCRIPTION
These were left out from https://github.com/microsoft/dotnet-framework-docker/pull/1196.

This change was already announced in https://github.com/microsoft/dotnet-framework-docker/discussions/1203.

I took the opportunity to factor out the VS buildtools installation to another template so that this is less likely to happen in the future.