### PR TITLE
Use combined reference assembly/targeting pack zip file

### DIFF
--- a/eng/dockerfile-templates/sdk/Dockerfile
+++ b/eng/dockerfile-templates/sdk/Dockerfile
@@ -91,19 +91,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A\bin\NETFX {{sdkVersion}} Tools\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
-# Install Targeting Packs
-RUN powershell " `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    @@('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"{{
+{{InsertTemplate("Dockerfile.install-reference-assemblies")}}{{
 if OS_VERSION_NUMBER = "ltsc2019"
 :
 

--- a/eng/dockerfile-templates/sdk/Dockerfile.install-reference-assemblies
+++ b/eng/dockerfile-templates/sdk/Dockerfile.install-reference-assemblies
@@ -1,0 +1,32 @@
+{{
+
+    _ ARGS:
+        usePowerShell: whether to use PowerShell ^
+
+    set version to "v0" ^
+
+    set url to cat(
+        "https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-",
+        version,
+        "/referenceassemblies.",
+        version,
+        ".zip"
+    )
+
+}}# Install Targeting Packs{{
+if ARGS.usePowerShell:
+RUN powershell " `
+    $ErrorActionPreference = 'Stop'; `
+    $ProgressPreference = 'SilentlyContinue'; `
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
+    Invoke-WebRequest `
+        -UseBasicParsing `
+        -Uri {{url}} `
+        -OutFile referenceassemblies.zip; `
+    Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
+    Remove-Item -Force referenceassemblies.zip"^
+else:
+RUN curl -fSLo referenceassemblies.zip {{url}} `
+    && mkdir "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && tar -xzf referenceassemblies.zip -C "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && del referenceassemblies.zip}}

--- a/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/sdk/Dockerfile.ltsc2016
@@ -116,19 +116,6 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\" `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
-# Install Targeting Packs
-RUN powershell " `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    @@('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+{{InsertTemplate("Dockerfile.install-reference-assemblies", [ "usePowerShell": "true" ])}}
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -120,14 +120,11 @@ RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+    Invoke-WebRequest `
+        -UseBasicParsing `
+        -Uri https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-v0/referenceassemblies.v0.zip `
+        -OutFile referenceassemblies.zip; `
+    Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
+    Remove-Item -Force referenceassemblies.zip"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -86,17 +86,9 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN powershell " `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+RUN curl -fSLo referenceassemblies.zip https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-v0/referenceassemblies.v0.zip `
+    && mkdir "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && tar -xzf referenceassemblies.zip -C "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && del referenceassemblies.zip
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -68,15 +68,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN powershell " `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+RUN curl -fSLo referenceassemblies.zip https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-v0/referenceassemblies.v0.zip `
+    && mkdir "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && tar -xzf referenceassemblies.zip -C "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && del referenceassemblies.zip

--- a/src/sdk/3.5/windowsservercore-ltsc2025/Dockerfile
+++ b/src/sdk/3.5/windowsservercore-ltsc2025/Dockerfile
@@ -68,15 +68,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN powershell " `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+RUN curl -fSLo referenceassemblies.zip https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-v0/referenceassemblies.v0.zip `
+    && mkdir "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && tar -xzf referenceassemblies.zip -C "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && del referenceassemblies.zip

--- a/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -68,15 +68,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN powershell " `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+RUN curl -fSLo referenceassemblies.zip https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-v0/referenceassemblies.v0.zip `
+    && mkdir "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && tar -xzf referenceassemblies.zip -C "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && del referenceassemblies.zip

--- a/src/sdk/4.8.1/windowsservercore-ltsc2025/Dockerfile
+++ b/src/sdk/4.8.1/windowsservercore-ltsc2025/Dockerfile
@@ -68,15 +68,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN powershell " `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+RUN curl -fSLo referenceassemblies.zip https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-v0/referenceassemblies.v0.zip `
+    && mkdir "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && tar -xzf referenceassemblies.zip -C "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && del referenceassemblies.zip

--- a/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -88,14 +88,11 @@ RUN powershell " `
     $ErrorActionPreference = 'Stop'; `
     $ProgressPreference = 'SilentlyContinue'; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+    Invoke-WebRequest `
+        -UseBasicParsing `
+        -Uri https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-v0/referenceassemblies.v0.zip `
+        -OutFile referenceassemblies.zip; `
+    Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
+    Remove-Item -Force referenceassemblies.zip"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -67,17 +67,9 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN powershell " `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+RUN curl -fSLo referenceassemblies.zip https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-v0/referenceassemblies.v0.zip `
+    && mkdir "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && tar -xzf referenceassemblies.zip -C "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && del referenceassemblies.zip
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/sdk/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -68,15 +68,7 @@ RUN powershell setx /M PATH $(${Env:PATH} `
     + \";${Env:ProgramFiles(x86)}\Microsoft SDKs\ClickOnce\SignTool\")
 
 # Install Targeting Packs
-RUN powershell " `
-    $ErrorActionPreference = 'Stop'; `
-    $ProgressPreference = 'SilentlyContinue'; `
-    @('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8', '4.8.1') `
-    | %{ `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip `
-            -OutFile referenceassemblies.zip; `
-        Expand-Archive referenceassemblies.zip -DestinationPath \"${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\"; `
-        Remove-Item -Force referenceassemblies.zip; `
-    }"
+RUN curl -fSLo referenceassemblies.zip https://github.com/lbussell/dotnet-framework-docker/releases/download/referenceassemblies-v0/referenceassemblies.v0.zip `
+    && mkdir "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && tar -xzf referenceassemblies.zip -C "%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework" `
+    && del referenceassemblies.zip


### PR DESCRIPTION
Fixes #1135 

This PR is marked as draft because we still need to publish the reference assembly zip to our storage account.

Here's the PowerShell script that I used to generate the new reference assembly zip:

<details>

```pwsh
$blobs = @(
    "v4.0.zip",
    "v4.5.2.zip",
    "v4.6.2.zip",
    # v4.7.1 is not used and conflicts with 4.7.2's files
    # "v4.7.1.zip",
    "v4.7.2.zip",
    "v4.8.1.zip",
    "v4.8.zip"
)

foreach ($blobname in $blobs) {
    $url = "https://dotnetbinaries.blob.core.windows.net/referenceassemblies/$blobname"
    $output = "./$blobname"
    Invoke-WebRequest -Uri $url -OutFile $output
}

foreach ($blobname in $blobs) {
    Expand-Archive -path "./$blobname" -DestinationPath "./temp" -Force
}

Compress-Archive -Path "./temp/*" -DestinationPath "./referenceassemblies.v0.zip"
```

</details>