### PR TITLE
Fix warnings in template generation scripts on Windows

### DIFF
--- a/eng/common/Invoke-ImageBuilder.ps1
+++ b/eng/common/Invoke-ImageBuilder.ps1
@@ -8,7 +8,7 @@ Executes ImageBuilder with the specified args.
 The args to pass to ImageBuilder.
 
 .PARAMETER ReuseImageBuilderImage
-Indicates that a previously built ImageBuilder image is presumed to exist locally and that 
+Indicates that a previously built ImageBuilder image is presumed to exist locally and that
 it should be used for this execution of the script.  This allows some optimization when
 multiple calls are being made to this script that don't require a fresh image (i.e. the
 repo contents in the image don't need to be or should not be updated with each call to
@@ -74,6 +74,7 @@ try {
     }
     else {
         # On Windows, ImageBuilder is run locally due to limitations with running Docker client within a container.
+        # Remove when https://github.com/dotnet/docker-tools/issues/159 is resolved
         $imageBuilderFolder = ".Microsoft.DotNet.ImageBuilder"
         $imageBuilderCmd = [System.IO.Path]::Combine($imageBuilderFolder, "Microsoft.DotNet.ImageBuilder.exe")
         if (-not (Test-Path -Path "$imageBuilderCmd" -PathType Leaf)) {
@@ -99,6 +100,6 @@ finally {
     if ($containerCreated) {
         Exec "docker container rm -f $imageBuilderContainerName"
     }
-    
+
     popd
 }

--- a/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
+++ b/eng/dockerfile-templates/Get-GeneratedDockerfiles.ps1
@@ -3,9 +3,7 @@ param(
     [switch]$Validate
 )
 
-if (!$IsWindows) {
-    $IsWindows = $PSVersionTable.PSEdition -eq "Desktop"
-}
+$dockerOs = docker version -f "{{ .Server.Os }}"
 
 $imageBuilderArgs = "generateDockerfiles --optional-templates"
 if ($Validate) {
@@ -21,7 +19,9 @@ $onDockerfilesGeneratedLinux = {
     }
 }
 
-if ($IsWindows) {
+# On Windows, ImageBuilder is run locally due to limitations with running Docker client within a container.
+# Remove when https://github.com/dotnet/docker-tools/issues/159 is resolved
+if ($dockerOs -eq "windows") {
     & $PSScriptRoot/../common/Invoke-ImageBuilder.ps1 `
         -ImageBuilderArgs $imageBuilderArgs
 } else {

--- a/eng/readme-templates/Get-GeneratedReadmes.ps1
+++ b/eng/readme-templates/Get-GeneratedReadmes.ps1
@@ -5,9 +5,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-if (!$IsWindows) {
-    $IsWindows = $PSVersionTable.PSEdition -eq "Desktop"
-}
+$dockerOs = docker version -f "{{ .Server.Os }}"
 
 if ($Validate) {
     $customImageBuilderArgs = " --validate"
@@ -50,7 +48,9 @@ function Invoke-GenerateReadme {
 
     $imageBuilderArgs = "generateReadmes --manifest $Manifest --source-branch 'main'$customImageBuilderArgs 'https://github.com/microsoft/dotnet-framework-docker'"
 
-    if ($IsWindows) {
+    # On Windows, ImageBuilder is run locally due to limitations with running Docker client within a container.
+    # Remove when https://github.com/dotnet/docker-tools/issues/159 is resolved
+    if ($dockerOs -eq "windows") {
         & $PSScriptRoot/../common/Invoke-ImageBuilder.ps1 `
             -ImageBuilderArgs $imageBuilderArgs
     } else {


### PR DESCRIPTION
When running the current scripts on Windows, the script tries to copy files from a container that doesn't exist because Invoke-ImageBuilder.ps1 does not create a container on Windows. As a result it throws some warnings/errors and the command "fails" even though it does what you want:

```pwsh
PS> pwsh .\eng\readme-templates\Get-GeneratedReadmes.ps1
...
Executing: 'docker cp ImageBuilder-20250228105133:/repo/README.aspnet.md C:\...\dotnet-framework-docker/'
Error response from daemon: No such container: ImageBuilder-20250228105133
PS> $?
False
```

This PR skips the copy on Windows. I made sure it works on all three of Windows PowerShell, PowerShell Core on Windows, and PowerShell Core on Linux.