### PR TITLE
Use Windows Update and Features on Demand to install .NET Framework 3.5

### DIFF
--- a/eng/dockerfile-templates/runtime/Dockerfile
+++ b/eng/dockerfile-templates/runtime/Dockerfile
@@ -19,8 +19,6 @@
             )
         ) ^
 
-    set installNet35UsingWU to OS_VERSION_NUMBER = "ltsc2025" ^
-
     set winver to when(
         OS_VERSION_NUMBER = "ltsc2019" || OS_VERSION_NUMBER = "ltsc2022",
         "windows10.0",
@@ -40,18 +38,8 @@ if OS_VERSION_NUMBER != "ltsc2019" || PRODUCT_VERSION = "4.8" || PRODUCT_VERSION
     }}COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
-{{if PRODUCT_VERSION = "3.5" && installNet35UsingWU
-:    # Install .NET Fx 3.5
-    dism /Online /Add-Capability /CapabilityName:NetFx3 `
-    `
-^elif PRODUCT_VERSION = "3.5"
-:    # Install .NET Fx 3.5
-    curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-{{OS_VERSION_NUMBER}}.zip `
-    && tar -zxf microsoft-windows-netfx3.zip `
-    && del /F /Q microsoft-windows-netfx3.zip `
-    && dism /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+{{if PRODUCT_VERSION = "3.5"
+:    {{InsertTemplate("Dockerfile.install-netfx3", [], "    ")}} `
     `
 ^elif (OS_VERSION_NUMBER = "ltsc2019" && PRODUCT_VERSION = "4.8") || (OS_VERSION_NUMBER != "ltsc2025" && PRODUCT_VERSION = "4.8.1")
 :    # Install .NET Fx {{PRODUCT_VERSION}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.install-netfx3
+++ b/eng/dockerfile-templates/runtime/Dockerfile.install-netfx3
@@ -1,0 +1,24 @@
+{{
+
+    _ Features on Demand (FoDs) are supported on Windows Server 2022 and later.
+        Using DISM /add-package to add FODs is deprecated.
+        It is best practice to add all FODs with DISM /Add-Capability. ^
+    _ https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/features-on-demand-v2--capabilities#overview ^
+
+    set useCapability to
+        OS_VERSION_NUMBER != "ltsc2016" &&
+        OS_VERSION_NUMBER != "ltsc2019" ^
+
+    set enableWindowsUpdate to !useCapability ^
+    set dismArgs to when(useCapability,
+        "/Add-Capability /CapabilityName:NetFx3",
+        "/Enable-Feature /FeatureName:NetFx3 /All")
+
+}}{{
+if enableWindowsUpdate:# Enable Windows Update service
+sc config wuauserv start= auto `
+}}# Install .NET Fx 3.5
+{{if enableWindowsUpdate:&& }}dism /Online {{dismArgs}}{{
+if enableWindowsUpdate: `
+# Disable Windows Update service
+&& sc config wuauserv start= disabled}}

--- a/eng/dockerfile-templates/runtime/Dockerfile.ltsc2016
+++ b/eng/dockerfile-templates/runtime/Dockerfile.ltsc2016
@@ -5,29 +5,23 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
-{{if PRODUCT_VERSION != "4.6.2"
+{{
+if PRODUCT_VERSION != "4.6.2":{{
+if PRODUCT_VERSION = "3.5"
+:    {{InsertTemplate("Dockerfile.install-netfx3", [], "    ")}} `
+^else
 :    # Install .NET Fx {{PRODUCT_VERSION}}
     powershell -Command `
-{{if PRODUCT_VERSION = "3.5"
-:        $ErrorActionPreference = 'Stop'; `
-}}        $ProgressPreference = 'SilentlyContinue'; `
+        $ProgressPreference = 'SilentlyContinue'; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
         Invoke-WebRequest `
             -UseBasicParsing `
-{{if PRODUCT_VERSION = "3.5"
-:            -Uri https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-ltsc2016.zip `
-            -OutFile microsoft-windows-netfx3.zip; `
-        Expand-Archive microsoft-windows-netfx3.zip; `
-    && del microsoft-windows-netfx3.zip `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package.cab `
-    && rmdir /S /Q microsoft-windows-netfx3 `
-^else
-:            -Uri {{VARIABLES[cat(PRODUCT_VERSION, "|url")]}} `
+            -Uri {{VARIABLES[cat(PRODUCT_VERSION, "|url")]}} `
             -OutFile dotnet-framework-installer.exe `
     && start /w .\dotnet-framework-installer.exe /q `
     && del .\dotnet-framework-installer.exe `
-}}    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
-    `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+}}    `
     # Apply latest patch
     && powershell -Command `
         $ProgressPreference = 'SilentlyContinue'; `

--- a/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -5,20 +5,12 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016-amd64
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
+    # Enable Windows Update service
+    sc config wuauserv start= auto `
     # Install .NET Fx 3.5
-    powershell -Command `
-        $ErrorActionPreference = 'Stop'; `
-        $ProgressPreference = 'SilentlyContinue'; `
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-        Invoke-WebRequest `
-            -UseBasicParsing `
-            -Uri https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-ltsc2016.zip `
-            -OutFile microsoft-windows-netfx3.zip; `
-        Expand-Archive microsoft-windows-netfx3.zip; `
-    && del microsoft-windows-netfx3.zip `
-    && dism /Online /Quiet /Add-Package /PackagePath:C:\microsoft-windows-netfx3\microsoft-windows-netfx3-ondemand-package.cab `
-    && rmdir /S /Q microsoft-windows-netfx3 `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    && dism /Online /Enable-Feature /FeatureName:NetFx3 /All `
+    # Disable Windows Update service
+    && sc config wuauserv start= disabled `
     `
     # Apply latest patch
     && powershell -Command `

--- a/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -5,13 +5,12 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
 ENV COMPLUS_NGenProtectedProcess_FeatureEnabled=0
 
 RUN `
+    # Enable Windows Update service
+    sc config wuauserv start= auto `
     # Install .NET Fx 3.5
-    curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-ltsc2019.zip `
-    && tar -zxf microsoft-windows-netfx3.zip `
-    && del /F /Q microsoft-windows-netfx3.zip `
-    && dism /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    && dism /Online /Enable-Feature /FeatureName:NetFx3 /All `
+    # Disable Windows Update service
+    && sc config wuauserv start= disabled `
     `
     # Apply latest patch
     && curl -fSLo patch.msu https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/secu/2024/12/windows10.0-kb5049608-x64_1a94518425035b7c11ccd554c89ae09752db511c.msu `

--- a/src/runtime/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/runtime/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -9,12 +9,7 @@ ENV `
 
 RUN `
     # Install .NET Fx 3.5
-    curl -fSLo microsoft-windows-netfx3.zip https://dotnetbinaries.blob.core.windows.net/dockerassets/microsoft-windows-netfx3-ltsc2022.zip `
-    && tar -zxf microsoft-windows-netfx3.zip `
-    && del /F /Q microsoft-windows-netfx3.zip `
-    && dism /Online /Quiet /Add-Package /PackagePath:.\microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && del microsoft-windows-netfx3-ondemand-package~31bf3856ad364e35~amd64~~.cab `
-    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\* `
+    dism /Online /Add-Capability /CapabilityName:NetFx3 `
     `
     # Apply latest 3.5 patch
     && curl -fSLo patch.msu https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/secu/2024/12/windows10.0-kb5049617-x64-ndp48_5adfae2ccbb4743d93898ff35010c77daa8f130f.msu `


### PR DESCRIPTION
* Added a new template to handle .NET Framework 3.5 installation
* On Server 2022+, use [Features on Demand](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/features-on-demand-v2--capabilities?view=windows-11#overview) to install `NetFX3`.
* On earlier versions, use Windows update to install `NetFX3`.

To-do:

* [ ] Check if these changes have any impact to image size
  * [ ] 2016 - 
  * [ ] 2019 - 
  * [ ] 2022 - 
  * [ ] 2025 - 