### PR TITLE
Move ServiceMonitor download URL into versions file

### DIFF
--- a/eng/dockerfile-templates/aspnet/Dockerfile
+++ b/eng/dockerfile-templates/aspnet/Dockerfile
@@ -7,7 +7,7 @@ RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole {{if
     && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
     && del /q "C:\inetpub\wwwroot\*" `
     && for /D %p IN ("C:\inetpub\wwwroot\*") DO rmdir "%p" /s /q `
-    && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
+    && curl -fSLo ServiceMonitor.exe {{VARIABLES["servicemonitor|url"]}} `
 {{if PRODUCT_VERSION = "3.5"
 :    && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
 }}    && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `

--- a/eng/dockerfile-templates/aspnet/Dockerfile.3.5.pre20H2
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.3.5.pre20H2
@@ -11,7 +11,7 @@ RUN powershell -Command `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
 {{if OS_VERSION_NUMBER = "ltsc2016"
 :        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-}}        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
+}}        Invoke-WebRequest -Uri {{VARIABLES["servicemonitor|url"]}} -OutFile C:\ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
 {{if OS_VERSION_NUMBER = "ltsc2016" || OS_VERSION_NUMBER = "ltsc2019"
 :    && %windir%\Microsoft.NET\Framework64\v2.0.50727\ngen update `

--- a/eng/dockerfile-templates/aspnet/Dockerfile.pre20H2
+++ b/eng/dockerfile-templates/aspnet/Dockerfile.pre20H2
@@ -11,7 +11,7 @@ RUN Add-WindowsFeature Web-Server; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
 {{if OS_VERSION_NUMBER = "ltsc2016"
 :    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-}}    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+}}    Invoke-WebRequest -Uri {{VARIABLES["servicemonitor|url"]}} -OutFile C:\ServiceMonitor.exe; `
     &$Env:windir\Microsoft.NET\Framework64\v4.0.30319\ngen update; `
     &$Env:windir\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -42,6 +42,9 @@
 
       "nuget|version": "6.12.2",
 
+      "servicemonitor|version": "2.0.1.10",
+      "servicemonitor|url": "https://dotnetbinaries.blob.core.windows.net/servicemonitor/$(servicemonitor|version)/ServiceMonitor.exe",
+
       "vs|version": "17.13",
       "vs|testAgentUrl": "https://aka.ms/vs/17/release/vs_TestAgent.exe",
       "vs|buildToolsUrl": "https://aka.ms/vs/17/release/vs_BuildTools.exe",


### PR DESCRIPTION
This PR centralizes the ServiceMonitor.exe download URL used in multiple templates. Related: #1221 