### PR TITLE
Update ServiceMonitor URL to GitHub Releases download

### DIFF
--- a/manifest.versions.json
+++ b/manifest.versions.json
@@ -43,7 +43,7 @@
       "nuget|version": "6.13.2",
 
       "servicemonitor|version": "2.0.1.10",
-      "servicemonitor|url": "https://dotnetbinaries.blob.core.windows.net/servicemonitor/$(servicemonitor|version)/ServiceMonitor.exe",
+      "servicemonitor|url": "https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v$(servicemonitor|version)/ServiceMonitor.exe",
 
       "vs|version": "17.13",
       "vs|testAgentUrl": "https://aka.ms/vs/17/release/vs_TestAgent.exe",

--- a/src/aspnet/3.5/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-ltsc2016/Dockerfile
@@ -10,7 +10,7 @@ RUN powershell -Command `
         Add-WindowsFeature Web-Asp-Net; `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
+        Invoke-WebRequest -Uri https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
     && %windir%\Microsoft.NET\Framework64\v2.0.50727\ngen update `
     && %windir%\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/src/aspnet/3.5/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-ltsc2019/Dockerfile
@@ -9,7 +9,7 @@ RUN powershell -Command `
         Add-WindowsFeature Web-Server; `
         Add-WindowsFeature Web-Asp-Net; `
         Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-        Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
+        Invoke-WebRequest -Uri https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
     && %windir%\Microsoft.NET\Framework64\v2.0.50727\ngen update `
     && %windir%\Microsoft.NET\Framework\v2.0.50727\ngen update

--- a/src/aspnet/3.5/windowsservercore-ltsc2022/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-ltsc2022/Dockerfile
@@ -7,7 +7,7 @@ RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /Fea
     && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
     && del /q "C:\inetpub\wwwroot\*" `
     && for /D %p IN ("C:\inetpub\wwwroot\*") DO rmdir "%p" /s /q `
-    && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
+    && curl -fSLo ServiceMonitor.exe https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
     && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/aspnet/3.5/windowsservercore-ltsc2025/Dockerfile
+++ b/src/aspnet/3.5/windowsservercore-ltsc2025/Dockerfile
@@ -7,7 +7,7 @@ RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /Fea
     && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
     && del /q "C:\inetpub\wwwroot\*" `
     && for /D %p IN ("C:\inetpub\wwwroot\*") DO rmdir "%p" /s /q `
-    && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
+    && curl -fSLo ServiceMonitor.exe https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe `
     && %windir%\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /managedRuntimeVersion:v2.0 `
     && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile
@@ -10,7 +10,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    Invoke-WebRequest -Uri https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
     &$Env:windir\Microsoft.NET\Framework64\v4.0.30319\ngen update; `
     &$Env:windir\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/src/aspnet/4.7.1/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7.1/windowsservercore-ltsc2016/Dockerfile
@@ -10,7 +10,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    Invoke-WebRequest -Uri https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
     &$Env:windir\Microsoft.NET\Framework64\v4.0.30319\ngen update; `
     &$Env:windir\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/src/aspnet/4.7.2/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7.2/windowsservercore-ltsc2016/Dockerfile
@@ -10,7 +10,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    Invoke-WebRequest -Uri https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
     &$Env:windir\Microsoft.NET\Framework64\v4.0.30319\ngen update; `
     &$Env:windir\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    Invoke-WebRequest -Uri https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
     &$Env:windir\Microsoft.NET\Framework64\v4.0.30319\ngen update; `
     &$Env:windir\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile
@@ -10,7 +10,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    Invoke-WebRequest -Uri https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
     &$Env:windir\Microsoft.NET\Framework64\v4.0.30319\ngen update; `
     &$Env:windir\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/src/aspnet/4.8.1/windowsservercore-ltsc2022/Dockerfile
+++ b/src/aspnet/4.8.1/windowsservercore-ltsc2022/Dockerfile
@@ -7,7 +7,7 @@ RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /Fea
     && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
     && del /q "C:\inetpub\wwwroot\*" `
     && for /D %p IN ("C:\inetpub\wwwroot\*") DO rmdir "%p" /s /q `
-    && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
+    && curl -fSLo ServiceMonitor.exe https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe `
     && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/src/aspnet/4.8.1/windowsservercore-ltsc2025/Dockerfile
+++ b/src/aspnet/4.8.1/windowsservercore-ltsc2025/Dockerfile
@@ -7,7 +7,7 @@ RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /Fea
     && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
     && del /q "C:\inetpub\wwwroot\*" `
     && for /D %p IN ("C:\inetpub\wwwroot\*") DO rmdir "%p" /s /q `
-    && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
+    && curl -fSLo ServiceMonitor.exe https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe `
     && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile
@@ -10,7 +10,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    Invoke-WebRequest -Uri https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
     &$Env:windir\Microsoft.NET\Framework64\v4.0.30319\ngen update; `
     &$Env:windir\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature Web-Server; `
     Add-WindowsFeature NET-Framework-45-ASPNET; `
     Add-WindowsFeature Web-Asp-Net45; `
     Remove-Item -Recurse C:\inetpub\wwwroot\*; `
-    Invoke-WebRequest -Uri https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
+    Invoke-WebRequest -Uri https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe -OutFile C:\ServiceMonitor.exe; `
     &$Env:windir\Microsoft.NET\Framework64\v4.0.30319\ngen update; `
     &$Env:windir\Microsoft.NET\Framework\v4.0.30319\ngen update
 

--- a/src/aspnet/4.8/windowsservercore-ltsc2022/Dockerfile
+++ b/src/aspnet/4.8/windowsservercore-ltsc2022/Dockerfile
@@ -7,7 +7,7 @@ RUN dism /Online /Quiet /Enable-Feature /All /FeatureName:IIS-WebServerRole /Fea
     && dism /Online /Quiet /Disable-Feature /FeatureName:IIS-WebServerManagementTools `
     && del /q "C:\inetpub\wwwroot\*" `
     && for /D %p IN ("C:\inetpub\wwwroot\*") DO rmdir "%p" /s /q `
-    && curl -fSLo ServiceMonitor.exe https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.10/ServiceMonitor.exe `
+    && curl -fSLo ServiceMonitor.exe https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe `
     && %windir%\Microsoft.NET\Framework64\v4.0.30319\ngen update `
     && %windir%\Microsoft.NET\Framework\v4.0.30319\ngen update
 


### PR DESCRIPTION
ServiceMonitor.exe has been re-uploaded to the microsoft/IIS.ServiceMonitor GitHub release: https://github.com/microsoft/IIS.ServiceMonitor/releases/tag/v2.0.1.10.