### PR TITLE
Disable Dependabot updates in Azure DevOps

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,6 @@
+# Disable Dependabot updates in Azure DevOps since this repository is managed
+# on GitHub and mirrored to Azure DevOps.
+# https://eng.ms/docs/products/dependabot/configuration/disable-features
+version: 2
+enable-security-updates: false
+enable-campaigned-updates: false


### PR DESCRIPTION
This PR disables the Azure DevOps Dependabot. This repo is managed on GitHub and mirrored to Azure DevOps, so ADO Dependabot updates must be rejected in order to keep the branch in sync with GitHub.