### PR TITLE
Use Permissive network isolation policy to workaround images reaching out to nuget.org

### DIFF
--- a/eng/pipelines/dotnet-framework-samples.yml
+++ b/eng/pipelines/dotnet-framework-samples.yml
@@ -39,6 +39,10 @@ extends:
   parameters:
     reposToExcludeFromScanning:
     - VersionsRepo
+    # Use "Permissive" network policy because .NET Framework image builds
+    # reach out to nuget.org. Remove this parameter when the following issue is
+    # resolved: https://github.com/microsoft/dotnet-framework-docker/issues/1286
+    networkIsolationPolicy: Permissive
     stages:
     - template: /eng/docker-tools/templates/stages/dotnet/publish-config-${{ iif(contains(variables['Build.DefinitionName'], '-official'), 'prod', 'nonprod') }}.yml@self
       parameters:

--- a/eng/pipelines/dotnet-framework.yml
+++ b/eng/pipelines/dotnet-framework.yml
@@ -39,6 +39,10 @@ extends:
   parameters:
     reposToExcludeFromScanning:
     - VersionsRepo
+    # Use "Permissive" network policy because .NET Framework image builds
+    # reach out to nuget.org. Remove this parameter when the following issue is
+    # resolved: https://github.com/microsoft/dotnet-framework-docker/issues/1286
+    networkIsolationPolicy: Permissive
     stages:
     - template: /eng/docker-tools/templates/stages/dotnet/publish-config-${{ iif(contains(variables['Build.DefinitionName'], '-official'), 'prod', 'nonprod') }}.yml@self
       parameters:


### PR DESCRIPTION
This PR is a temporary workaround for issue #1286.