### PR TITLE
Pin 1ES Pipeline Templates version

### DIFF
--- a/eng/docker-tools/templates/1es.yml
+++ b/eng/docker-tools/templates/1es.yml
@@ -54,7 +54,7 @@ resources:
   - repository: 1ESPipelineTemplates
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+    ref: refs/tags/release-3.12.2026-05-30-1
 
 extends:
   template: /eng/docker-tools/templates/task-prefix-decorator.yml@self


### PR DESCRIPTION
Pins the active 1ES Pipeline Templates reference to `release-3.12.2026-05-30-1` to unblock Windows Server 2016 image builds.

Related to dotnet/release#2338.